### PR TITLE
Add SDK-related docker Makefile targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rigetti/quicklisp
 
+ARG build_target
+
 # install build dependencies
 COPY Makefile /src/quilc/Makefile
 WORKDIR /src/quilc
@@ -12,6 +14,6 @@ RUN git clone https://github.com/rigetti/rpcq.git
 # build the quilc app
 ADD . /src/quilc
 WORKDIR /src/quilc
-RUN git clean -fdx && make
+RUN git clean -fdx && make ${build_target}
 
 ENTRYPOINT ["./quilc"]

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,21 @@ quilc-unsafe: system-index.txt
 		--compress-core \
 		--entry quilc::%entry-point
 
+DOCKER_BUILD_TARGET=all
+DOCKER_TAG=rigetti/quilc:$(COMMIT_HASH)
 .PHONY: docker
 docker: Dockerfile
-	docker build -t rigetti/quilc:$(COMMIT_HASH) .
+	docker build --build-arg build_target=$(DOCKER_BUILD_TARGET) \
+		-t $(DOCKER_TAG) .
+
+docker-sdk: DOCKER_BUILD_TARGET=quilc-sdk
+docker-sdk: DOCKER_TAG=quilc-sdk
+docker-sdk: docker
+
+docker-sdk-barebones: DOCKER_BUILD_TARGET=quilc-sdk-barebones
+docker-sdk-barebones: DOCKER_TAG=quilc-sdk-barebones
+docker-sdk-barebones: docker
+
 
 ###############################################################################
 # TEST


### PR DESCRIPTION
- "make docker-sdk" will use docker to build a Linux SDK binary

- "make docker-sdk-barebones" does the same but doesn't mangle the
  shared library paths, as needed by the barebones SDK installer