### PR TITLE
fix error encoding in SDK web server

### DIFF
--- a/app/src/web-server.lisp
+++ b/app/src/web-server.lisp
@@ -71,12 +71,8 @@
   (with-output-to-string (s)
     (yason:encode
      (alexandria:plist-hash-table
-      (list* "error_type" "quilc_error"
-             #-forest-sdk
-             (list
-              "status" error)
-             #+forest-sdk
-             nil))
+      (list "error_type" "quilc_error"
+            "status" error))
      s)))
 
 (defun create-prefix/method-dispatcher (prefix method handler)


### PR DESCRIPTION
pyQuil expects error payloads to have a "status" key, which the previous `forest-sdk` conditional was removing. FYI: even with this conditional removed, the printed error returned to the user doesn't include a traceback.