### PR TITLE
fix missing upward links into commuting_blocks threads

### DIFF
--- a/src/addresser/logical-schedule.lisp
+++ b/src/addresser/logical-schedule.lisp
@@ -232,8 +232,7 @@
          (let ((bottom-resources (instruction-resources bottom-instr)))
            (when (resources-intersect-p resources bottom-resources)
              (push bottom-instr (gethash instr (lscheduler-earlier-instrs lschedule)))
-             (push instr (gethash bottom-instr (lscheduler-later-instrs lschedule)))
-             (setf resources (resource-difference resources bottom-resources))))))))
+             (push instr (gethash bottom-instr (lscheduler-later-instrs lschedule)))))))))
   ;; are we a topmost instr?
   (unless (gethash instr (lscheduler-earlier-instrs lschedule))
     (push instr (lscheduler-first-instrs lschedule)))

--- a/tests/compiler-hook-test-files/more-commuting-blocks.quil
+++ b/tests/compiler-hook-test-files/more-commuting-blocks.quil
@@ -1,0 +1,19 @@
+# this caused a headache on 2019-01-23, where it revealed that lscheduler-clean-up-last-instrs had a bug in it
+# when confronted with commuting blocks that shared some qubit resource (0, below) as well as instructions
+# before and after it which also used the qubit resource, plus a few other happenstance conditions.
+
+Y 0
+
+PRAGMA COMMUTING_BLOCKS
+
+PRAGMA BLOCK
+CPHASE(-4.8) 0 1
+PRAGMA END_BLOCK
+
+PRAGMA BLOCK
+CNOT 0 3
+PRAGMA END_BLOCK
+
+PRAGMA END_COMMUTING_BLOCKS
+
+X 0


### PR DESCRIPTION
Matt H found a bug in the handling of `COMMUTING_BLOCKS` inside of `logical-scheduler` objects. Such an object tracks the resource dependency graph of a list of instructions, constructed inductively by keeping track of the 'bottom fringe' of the graph and attaching new instructions along that fringe. In the case where the fringe contains a bunch of `COMMUTING_BLOCKS` subregions, each such region that shares resources with the new instruction needs to be marked as a predecessor. Previously, only one such instruction would be marked before an early exit.

I am *not* confident that this is a perfect fix to this bug. It may well be the case that we only want to avoid doing this resource deletion if the instruction we're comparing with is a `COMMUTING_BLOCKS` subregion. I don't think that this change will *break* the validity of the compiler, but the extra ancestors it introduces might cause significant slowdown.

cc @karalekas , @mpharrigan .