### PR TITLE
Clean up matrix printing in quilc

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -367,7 +367,7 @@ HTTP server for good.
 (defun process-program (program chip-specification)
   (let* ((original-matrix
            (when (and *protoquil* *compute-matrix-reps*)
-             (quil::gate-applications-to-logical-matrix program)))
+             (quil::parsed-program-to-logical-matrix program)))
          (quil::*compiler-noise-stream* *verbose*)
          (*statistics-dictionary* (make-hash-table :test 'equal))
          (*random-state* (make-random-state t)))
@@ -446,7 +446,7 @@ HTTP server for good.
           (print-2Q-gate-depth lschedule)))
 
       (when (and *protoquil* *compute-matrix-reps*)
-        (let* ((processed-program-matrix (quil::gate-applications-to-logical-matrix processed-program :compress-qubits t))
+        (let* ((processed-program-matrix (quil::parsed-program-to-logical-matrix processed-program :compress-qubits t))
                (same-same-but-different (quil::scale-out-matrix-phases processed-program-matrix
                                                                        original-matrix)))
           (format *human-readable-stream* "~%#Matrix read off from input code~%")

--- a/app/src/printers.lisp
+++ b/app/src/printers.lisp
@@ -13,52 +13,6 @@
                   *human-readable-stream*
                   *json-stream*))
 
-
-(defun print-matrix-representations (initial-l2p processed-quil final-l2p original-matrix)
-  (let* ((initial-l2p (quil::trim-rewiring initial-l2p))
-         (final-l2p (quil::trim-rewiring final-l2p))
-         (raw-new-matrix (quil::make-matrix-from-quil processed-quil))
-         (qubit-count (max (1- (integer-length (magicl:matrix-rows raw-new-matrix)))
-                           (1- (integer-length (magicl:matrix-rows original-matrix)))
-                           (quil::rewiring-length initial-l2p)
-                           (quil::rewiring-length final-l2p)))
-         (wire-out (quil::kq-gate-on-lines (quil::rewiring-to-permutation-matrix-p2l final-l2p)
-                                           qubit-count
-                                           (alexandria:iota (quil::rewiring-length final-l2p) :start (1- (quil::rewiring-length final-l2p)) :step -1)))
-         (wire-in (quil::kq-gate-on-lines (quil::rewiring-to-permutation-matrix-l2p initial-l2p)
-                                          qubit-count
-                                          (alexandria:iota (quil::rewiring-length initial-l2p) :start (1- (quil::rewiring-length initial-l2p)) :step -1)))
-         (stretched-raw-new-matrix (quil::kq-gate-on-lines raw-new-matrix
-                                                           qubit-count
-                                                           (alexandria:iota (1- (integer-length (magicl:matrix-rows raw-new-matrix)))
-                                                                            :start (- (integer-length (magicl:matrix-rows raw-new-matrix)) 2)
-                                                                            :step -1)))
-         (stretched-original-matrix (quil::kq-gate-on-lines original-matrix
-                                                            qubit-count
-                                                            (alexandria:iota (1- (integer-length (magicl:matrix-rows original-matrix)))
-                                                                             :start (- (integer-length (magicl:matrix-rows original-matrix)) 2)
-                                                                             :step -1)))
-         (new-matrix
-           (reduce #'magicl:multiply-complex-matrices
-                   (list
-                    wire-out
-                    stretched-raw-new-matrix
-                    wire-in))))
-    (setf new-matrix (quil::scale-out-matrix-phases new-matrix stretched-original-matrix))
-    (format *human-readable-stream* "~%#Matrix read off from input code~%")
-    (print-matrix-with-comment-hashes stretched-original-matrix *human-readable-stream*)
-    (setf (gethash "original_matrix" *statistics-dictionary*)
-          (with-output-to-string (s)
-            (print-matrix-with-comment-hashes stretched-original-matrix s)))
-    (format *human-readable-stream* "~%#Matrix read off from compiled code~%")
-    (print-matrix-with-comment-hashes new-matrix *human-readable-stream*)
-    (setf (gethash "compiled_matrix" *statistics-dictionary*)
-          (with-output-to-string (s)
-            (print-matrix-with-comment-hashes new-matrix s)))
-    (format *human-readable-stream* "~%")
-    (finish-output *standard-output*)
-    (finish-output *human-readable-stream*)))
-
 (defun print-gate-depth (lschedule)
   (let ((depth (quil::lscheduler-calculate-depth lschedule)))
     (setf (gethash "gate_depth" *statistics-dictionary*) depth)

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -94,7 +94,7 @@ as needed so that they are the same size."
   (multiple-value-bind (mat1 mat2) (matrix-rescale mat1 mat2)
     (magicl:multiply-complex-matrices mat1 mat2)))
 
-(defun gate-applications-to-logical-matrix (pp &key compress-qubits)
+(defun parsed-program-to-logical-matrix (pp &key compress-qubits)
   "Convert a parsed program PP, consisting of only i) gate
  applications ii) trivial control operations (HALT and NOP), and iii)
  pragmas, to an equivalent matrix. If present, rewiring pragmas will

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -375,7 +375,7 @@
 
   ;; matrix-operations.lisp
   (:export
-   #:gate-applications-to-logical-matrix ; FUNCTION
+   #:parsed-program-to-logical-matrix ; FUNCTION
    )
   
   ;; type-safety.lisp

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -41,3 +41,21 @@
        (system:atomic-incf ,counter-name)
        #-(or sbcl lispworks)
        (incf ,counter-name))))
+
+(defun first-column-operator= (mat1 mat2)
+  (multiple-value-bind (mat1 mat2) (matrix-rescale mat1 mat2)
+    (setf mat1 (scale-out-matrix-phases mat1 mat2))
+    (matrix-first-column-equality mat1 mat2)))
+
+(defun operator= (mat1 mat2)
+  (multiple-value-bind (mat1 mat2) (matrix-rescale mat1 mat2)
+    (setf mat1 (scale-out-matrix-phases mat1 mat2))
+    (matrix-equality mat1 mat2)))
+
+(defun matrix-equals-dwim (mat1 mat2)
+  "Returns true if mat1 is equal to mat2. DWIM (Do What I Mean) means take into
+account whether *ENABLE-STATE-PREP-COMPRESSION* is enabled, and use the
+appropriate method of comparison."
+  (if *enable-state-prep-compression*
+      (first-column-operator= mat1 mat2)
+      (operator= mat1 mat2)))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -219,9 +219,9 @@ ISWAP 5 2"))
 CNOT 1 0
 CNOT 2 1
 CNOT 0 2"))
-         (orig-matrix (quil::gate-applications-to-logical-matrix orig-prog))
+         (orig-matrix (quil::parsed-program-to-logical-matrix orig-prog))
          (proc-prog (quil::compiler-hook orig-prog chip))
-         (proc-matrix (quil::gate-applications-to-logical-matrix proc-prog))
+         (proc-matrix (quil::parsed-program-to-logical-matrix proc-prog))
          (2q-code (program-2q-instructions proc-prog)))
     (is (matrix-equals-dwim orig-matrix proc-matrix))
     (is (every (link-nativep chip) 2q-code))))

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -21,8 +21,8 @@ CNOT 0 1
 CNOT 0 2
 PRAGMA CURRENT_REWIRING \"#(2 0 1)\"
 ")))
-    (is (operator= (quil::gate-applications-to-logical-matrix pp)
-                   (quil::gate-applications-to-logical-matrix pp-rewired)))))
+    (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
+                         (quil::gate-applications-to-logical-matrix pp-rewired)))))
 
 (deftest test-gate-applications-to-logical-matrix-swap-rewiring ()
   "Test whether quil::gate-applications-to-logical-matrix converts equivalent
@@ -34,8 +34,8 @@ SWAP 0 1"))
 PRAGMA EXPECTED_REWIRING \"#(0 1)\"
 CNOT 0 1
 PRAGMA CURRENT_REWIRING \"#(1 0)\"")))
-    (is (operator= (quil::gate-applications-to-logical-matrix pp)
-                   (quil::gate-applications-to-logical-matrix pp-rewired)))))
+    (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
+                         (quil::gate-applications-to-logical-matrix pp-rewired)))))
 
 
 (deftest test-rewiring-modes ()
@@ -51,8 +51,8 @@ CNOT 1 4")
            (cpp (quil::compiler-hook (quil::parse-quil-string pstring)
                                      (quil::build-8Q-chip)
                                      :protoquil t)))
-      (is (operator= (quil::gate-applications-to-logical-matrix pp)
-                     (quil::gate-applications-to-logical-matrix cpp)))))
+      (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
+                           (quil::gate-applications-to-logical-matrix cpp)))))
   ;; then, the block-to-block rewiring methods.
   ;; i'm too lazy to check correctness, but we're at least exercising the pathway.
   (dolist (quil::*addresser-move-to-rewiring-swap-search-type* '(:greedy-path :greedy-qubit :a*))
@@ -66,7 +66,6 @@ CNOT 0 2
 JUMP @a")))
       (quil::compiler-hook pp (quil::build-8Q-chip))
       (is t))))
-
 
 (deftest test-compiler-hook ()
   "Test whether the compiler hook preserves semantic equivalence for
@@ -83,8 +82,8 @@ some test programs."
                       (quil::compiler-hook (quil::transform 'quil::compress-qubits
                                                             (cl-quil::read-quil-file file))
                                            (quil::build-nQ-linear-chip 5 :architecture architecture))))
-               (is (matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-prog)
-                                       (quil::gate-applications-to-logical-matrix proc-prog :compress-qubits t))))))
+               (is (quil::matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-prog)
+                                             (quil::gate-applications-to-logical-matrix proc-prog :compress-qubits t))))))
     (finish-output *debug-io*)
     (dolist (state-prep '(nil t))
       (let ((quil::*enable-state-prep-compression* state-prep))
@@ -156,8 +155,8 @@ RX(pi) 2
                (processed-program
                  (quil::compiler-hook parsed-prog (quil::build-nQ-linear-chip num-qubits
                                                                               :architecture architecture))))
-          (is (matrix-equals-dwim (quil::kq-gate-on-lines v num-qubits args)
-                                  (quil::gate-applications-to-logical-matrix processed-program))))))))
+          (is (quil::matrix-equals-dwim (quil::kq-gate-on-lines v num-qubits args)
+                                        (quil::gate-applications-to-logical-matrix processed-program))))))))
 
 
 
@@ -227,12 +226,12 @@ CZ 2 7
            (quil::transform 'quil::resolve-applications
                             (quil::parse-quil program-string))))
     (let* ((chip (quil::build-8Q-chip :architecture ':cz))
-             (processed-pp (compiler-hook (make-pp) chip))
-             (orig-pp (make-pp)))
-        (substitute-params orig-pp segment-table)
-        (substitute-params processed-pp segment-table)
-        (is (matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-pp :compress-qubits t)
-                                (quil::gate-applications-to-logical-matrix processed-pp :compress-qubits t))))))
+           (processed-pp (compiler-hook (make-pp) chip))
+           (orig-pp (make-pp)))
+      (substitute-params orig-pp segment-table)
+      (substitute-params processed-pp segment-table)
+      (is (quil::matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-pp :compress-qubits t)
+                                    (quil::gate-applications-to-logical-matrix processed-pp :compress-qubits t))))))
 
 (deftest test-parametric-compiler-cphase ()
   (dolist (quil::*enable-state-prep-compression* '(nil t))
@@ -274,7 +273,7 @@ CNOT 1 2"))
              (old-matrix (quil::gate-applications-to-logical-matrix pp))
              (cpp (quil::compiler-hook pp chip-spec :protoquil t))
              (new-matrix (quil::gate-applications-to-logical-matrix cpp)))
-        (is (matrix-equals-dwim old-matrix new-matrix))))))
+        (is (quil::matrix-equals-dwim old-matrix new-matrix))))))
 
 (deftest test-rewiring-backfilling ()
   (let ((pp (quil::parse-quil "

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -9,8 +9,8 @@
    ':cl-quil-tests
    "tests/compiler-hook-test-files/"))
 
-(deftest test-gate-applications-to-logical-matrix-cnot-rewiring ()
-  "Test whether quil::gate-applications-to-logical-matrix converts equivalent
+(deftest test-parsed-program-to-logical-matrix-cnot-rewiring ()
+  "Test whether quil::parsed-program-to-logical-matrix converts equivalent
 programs (modulo rewiring) to equivalent matrices."
   (let ((pp (quil::parse-quil-string "
 CNOT 1 2
@@ -21,11 +21,11 @@ CNOT 0 1
 CNOT 0 2
 PRAGMA CURRENT_REWIRING \"#(2 0 1)\"
 ")))
-    (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
-                         (quil::gate-applications-to-logical-matrix pp-rewired)))))
+    (is (quil::operator= (quil::parsed-program-to-logical-matrix pp)
+                         (quil::parsed-program-to-logical-matrix pp-rewired)))))
 
-(deftest test-gate-applications-to-logical-matrix-swap-rewiring ()
-  "Test whether quil::gate-applications-to-logical-matrix converts equivalent
+(deftest test-parsed-program-to-logical-matrix-swap-rewiring ()
+  "Test whether quil::parsed-program-to-logical-matrix converts equivalent
 programs (modulo rewiring) to equivalent matrices."
   (let ((pp (quil::parse-quil-string "
 CNOT 0 1
@@ -34,8 +34,8 @@ SWAP 0 1"))
 PRAGMA EXPECTED_REWIRING \"#(0 1)\"
 CNOT 0 1
 PRAGMA CURRENT_REWIRING \"#(1 0)\"")))
-    (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
-                         (quil::gate-applications-to-logical-matrix pp-rewired)))))
+    (is (quil::operator= (quil::parsed-program-to-logical-matrix pp)
+                         (quil::parsed-program-to-logical-matrix pp-rewired)))))
 
 
 (deftest test-rewiring-modes ()
@@ -51,8 +51,8 @@ CNOT 1 4")
            (cpp (quil::compiler-hook (quil::parse-quil-string pstring)
                                      (quil::build-8Q-chip)
                                      :protoquil t)))
-      (is (quil::operator= (quil::gate-applications-to-logical-matrix pp)
-                           (quil::gate-applications-to-logical-matrix cpp)))))
+      (is (quil::operator= (quil::parsed-program-to-logical-matrix pp)
+                           (quil::parsed-program-to-logical-matrix cpp)))))
   ;; then, the block-to-block rewiring methods.
   ;; i'm too lazy to check correctness, but we're at least exercising the pathway.
   (dolist (quil::*addresser-move-to-rewiring-swap-search-type* '(:greedy-path :greedy-qubit :a*))
@@ -82,8 +82,8 @@ some test programs."
                       (quil::compiler-hook (quil::transform 'quil::compress-qubits
                                                             (cl-quil::read-quil-file file))
                                            (quil::build-nQ-linear-chip 5 :architecture architecture))))
-               (is (quil::matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-prog)
-                                             (quil::gate-applications-to-logical-matrix proc-prog :compress-qubits t))))))
+               (is (quil::matrix-equals-dwim (quil::parsed-program-to-logical-matrix orig-prog)
+                                             (quil::parsed-program-to-logical-matrix proc-prog :compress-qubits t))))))
     (finish-output *debug-io*)
     (dolist (state-prep '(nil t))
       (let ((quil::*enable-state-prep-compression* state-prep))
@@ -156,7 +156,7 @@ RX(pi) 2
                  (quil::compiler-hook parsed-prog (quil::build-nQ-linear-chip num-qubits
                                                                               :architecture architecture))))
           (is (quil::matrix-equals-dwim (quil::kq-gate-on-lines v num-qubits args)
-                                        (quil::gate-applications-to-logical-matrix processed-program))))))))
+                                        (quil::parsed-program-to-logical-matrix processed-program))))))))
 
 
 
@@ -230,8 +230,8 @@ CZ 2 7
            (orig-pp (make-pp)))
       (substitute-params orig-pp segment-table)
       (substitute-params processed-pp segment-table)
-      (is (quil::matrix-equals-dwim (quil::gate-applications-to-logical-matrix orig-pp :compress-qubits t)
-                                    (quil::gate-applications-to-logical-matrix processed-pp :compress-qubits t))))))
+      (is (quil::matrix-equals-dwim (quil::parsed-program-to-logical-matrix orig-pp :compress-qubits t)
+                                    (quil::parsed-program-to-logical-matrix processed-pp :compress-qubits t))))))
 
 (deftest test-parametric-compiler-cphase ()
   (dolist (quil::*enable-state-prep-compression* '(nil t))
@@ -270,9 +270,9 @@ RX(pi/3) 0
              (pp (quil::parse-quil-string "
 H 1
 CNOT 1 2"))
-             (old-matrix (quil::gate-applications-to-logical-matrix pp))
+             (old-matrix (quil::parsed-program-to-logical-matrix pp))
              (cpp (quil::compiler-hook pp chip-spec :protoquil t))
-             (new-matrix (quil::gate-applications-to-logical-matrix cpp)))
+             (new-matrix (quil::parsed-program-to-logical-matrix cpp)))
         (is (quil::matrix-equals-dwim old-matrix new-matrix))))))
 
 (deftest test-rewiring-backfilling ()


### PR DESCRIPTION
I *think* the new stuff is equivalent to the old. The old stuff was
doing a lot of matrix calculations and rescaling and etc. There are
functions now that do all of this for us (gate-apps-to-log-mat,
scale-out-matrix-phases, etc)

I borrowed the matrix equality stuff from cl-quil-tests. Couple
questions,
  1. Is this all equivalent?
  2. Should matrix equality stuff live elsewhere (so that it's not
  duplicated across quilc/cl-quil/cl-quil-tests)
  3. Should that place be magicl?

Have a good weekend xxx