### PR TITLE
Compile PHASE to RZ

### DIFF
--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -313,7 +313,8 @@ MISC-DATA is a hashtable of miscellaneous data associated to this hardware objec
                              (find  ':X/2 lower-precedence))
                          (not (find ':RZ  higher-precedence))
                          (not (find ':Z/2 higher-precedence)))
-                    (list #'RY-to-XZX
+                    (list #'PHASE-to-RZ
+                          #'RY-to-XZX
                           #'RX-to-ZXZXZ
                           #'euler-compiler)))
             :into compilation-methods

--- a/src/compilers/translators.lisp
+++ b/src/compilers/translators.lisp
@@ -51,6 +51,9 @@
         (build-gate "RX" '(#.(/ pi -2)) q)
         (build-gate "RZ" '(#.(/ pi -2)) q)))
 
+(define-translator PHASE-to-RZ (("PHASE" (alpha) q) phase-gate)
+  (list (build-gate "RZ" `(,alpha) q)))
+
 ;; standard 2Q gate translators
 
 (define-translator CZ-to-CPHASE (("CZ" () q1 q0) CZ-gate)

--- a/tests/translator-tests.lisp
+++ b/tests/translator-tests.lisp
@@ -147,4 +147,21 @@
     ;; bad paths
     (is (null (cl-quil::find-shortest-path-on-chip-spec pathological 2 1)))))
 
+(deftest test-phase-compiles-to-rz ()
+  "A PHASE gate should trivially compile to a RZ gate, preserving parameters."
+  (let* ((cphase (quil::parse-quil-string "PHASE(0) 0"))
+         (cphase-compiled (quil::compiler-hook cphase (quil::build-8q-chip)))
+         (cphase-parametric (quil::parse-quil-string "DECLARE gamma REAL[1]
+PHASE(2*gamma[0]) 0"))
+         (cphase-parametric-compiled (quil::compiler-hook cphase-parametric (build-8q-chip)))
+         (rz (quil::compiler-hook (quil::parse-quil-string "RZ(0) 0") (build-8q-chip)))
+         (rz-parametric (quil::compiler-hook (quil::parse-quil-string "DECLARE gamma REAL[1]
+RZ(2*gamma[0]) 0") (quil::build-8q-chip))))
+    (fiasco-assert-matrices-are-equal
+     (quil::make-matrix-from-quil (coerce (quil::parsed-program-executable-code cphase-compiled) 'list))
+     (quil::make-matrix-from-quil (coerce (quil::parsed-program-executable-code rz) 'list)))
+    ;; one phase should compile to one rz
+    (is (= (length (quil::parsed-program-executable-code cphase-parametric-compiled))
+           (length (quil::parsed-program-executable-code rz-parametric))))))
+
 


### PR DESCRIPTION
The translation employed here is pretty interesting. When you look at
the matrices of
```
    PHASE(θ) = | 1  0   |
               | 0  eⁱᶿ |
```
and
```
    RZ(2α) = | e⁻ⁱᵅ  0   |
             | 0     eⁱᵅ |
```
you might notice that PHASE is equivalent to RZ × e^(iθ/2). So you
seek how to write the follow gate in terms of Quil's native gates
```
    RZ(β) = | eⁱᵝ  0   |
            | 0    eⁱᵝ |.
```
Then it's problem solved.

Instead, remember that during measurement, any phase factor is
irrelevant! Hence PHASE ≡ RZ × e^(iθ/2) ≡ RZ.

This closes #57.