### PR TITLE
Various improvements to the CI infra and release process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ test-cl-quil:
     - github
   only:
     - branches
-  image: rigetti/quicklisp
+  image: rigetti/rpcq
   script:
     - make dump-version-info
     - make install-test-deps
@@ -23,10 +23,8 @@ test-quilc:
     - github
   only:
     - branches
-  image: rigetti/quicklisp
+  image: rigetti/rpcq
   script:
     - make dump-version-info
     - make install-test-deps
-    # clone rpcq to work around QuickLisp
-    - pushd /builds/rigetti && rm -rf rpcq && git clone https://github.com/rigetti/rpcq.git && popd
     - make test-quilc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ test-quilc:
     - pushd /builds/rigetti && rm -rf rpcq && git clone https://github.com/rigetti/rpcq.git && popd
     - make test-quilc
 
-docker-master:
+docker-edge:
   stage: package
   tags:
     - dockerd
@@ -37,9 +37,10 @@ docker-master:
     - master
   image: docker:stable
   script:
-    - docker build --tag rigetti/quilc:${CI_COMMIT_SHORT_SHA} --tag rigetti/quilc:latest .
+    - docker build --tag rigetti/quilc:${CI_COMMIT_SHORT_SHA} --tag rigetti/quilc:edge .
     - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/quilc && docker rmi -f rigetti/quilc:latest
+    - docker push rigetti/quilc:${CI_COMMIT_SHORT_SHA} && docker push rigetti/quilc:edge
+    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA} rigetti/quilc:edge
 
 docker-branch:
   stage: package
@@ -54,7 +55,8 @@ docker-branch:
   script:
     - docker build --tag rigetti/quilc:${CI_COMMIT_REF_SLUG} .
     - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/quilc && docker rmi -f rigetti/quilc:${CI_COMMIT_REF_SLUG}
+    - docker push rigetti/quilc:${CI_COMMIT_REF_SLUG}
+    - docker rmi rigetti/quilc:${CI_COMMIT_REF_SLUG}
 
 docker-vtag:
   stage: package
@@ -68,6 +70,10 @@ docker-vtag:
     - branches
   image: docker:stable
   script:
-    - docker build --tag rigetti/quilc:${CI_COMMIT_TAG} --tag rigetti/quilc:stable .
+    - export VERSION=`cat VERSION.txt`
+    # make sure tag matches VERSION.txt
+    - if [ "${CI_COMMIT_TAG}" = "v${VERSION}" ]; then return 0; else return 1; fi
+    - docker build --tag rigetti/quilc:$VERSION --tag rigetti/quilc:stable --tag rigetti/quilc:latest .
     - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/quilc && docker rmi -f rigetti/quilc:stable
+    - docker push rigetti rigetti/quilc:$VERSION && docker push rigetti/quilc:stable && docker push rigetti/quilc:latest
+    - docker rmi rigetti/quilc:$VERSION rigetti/quilc:stable rigetti/quilc:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ test-cl-quil:
   script:
     - make dump-version-info
     - make install-test-deps
-    - make test-cl-quil
+    - make test-cl-quil RIGETTI_LISP_LIBRARY_HOME=/src
 
 test-quilc:
   stage: test
@@ -27,4 +27,4 @@ test-quilc:
   script:
     - make dump-version-info
     - make install-test-deps
-    - make test-quilc
+    - make test-quilc RIGETTI_LISP_LIBRARY_HOME=/src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
-stages:
-  - test
-  - package
+include:
+  - project: rigetti/ci
+    file: pipelines/docker.gitlab-ci.yml
+
+variables:
+  IMAGE: rigetti/quilc
 
 test-cl-quil:
   stage: test
@@ -27,53 +30,3 @@ test-quilc:
     # clone rpcq to work around QuickLisp
     - pushd /builds/rigetti && rm -rf rpcq && git clone https://github.com/rigetti/rpcq.git && popd
     - make test-quilc
-
-docker-edge:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/quilc:${CI_COMMIT_SHORT_SHA} --tag rigetti/quilc:edge .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/quilc:${CI_COMMIT_SHORT_SHA} && docker push rigetti/quilc:edge
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA} rigetti/quilc:edge
-
-docker-branch:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - branches
-  except:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/quilc:${CI_COMMIT_REF_SLUG} .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/quilc:${CI_COMMIT_REF_SLUG}
-    - docker rmi rigetti/quilc:${CI_COMMIT_REF_SLUG}
-
-docker-vtag:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  # matches only on tags of the form vX.Y.Z
-  only:
-    - /^v(\d+\.)?(\d+\.)?(\d+)$/
-  except:
-    - branches
-  image: docker:stable
-  script:
-    - export VERSION=`cat VERSION.txt`
-    # make sure tag matches VERSION.txt
-    - if [ "${CI_COMMIT_TAG}" = "v${VERSION}" ]; then return 0; else return 1; fi
-    - docker build --tag rigetti/quilc:$VERSION --tag rigetti/quilc:stable --tag rigetti/quilc:latest .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti rigetti/quilc:$VERSION && docker push rigetti/quilc:stable && docker push rigetti/quilc:latest
-    - docker rmi rigetti/quilc:$VERSION rigetti/quilc:stable rigetti/quilc:latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# default codeowners for all files
+* @rigetti/quilc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM rigetti/quicklisp
+FROM rigetti/rpcq
 
 ARG build_target
 
 # install build dependencies
 COPY Makefile /src/quilc/Makefile
 WORKDIR /src/quilc
-RUN make install-build-deps
-
-# clone rpcq to get version > v2.0.0 (which is available in QL)
-WORKDIR /src
-RUN git clone https://github.com/rigetti/rpcq.git
+RUN make dump-version-info install-build-deps
 
 # build the quilc app
 ADD . /src/quilc

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ system-index.txt: $(QUICKLISP_SETUP)
 ###############################################################################
 
 dump-version-info:
-	sbcl --noinform --non-interactive \
+	$(QUICKLISP) \
 		--eval '(format t "~A ~A" (lisp-implementation-type) (lisp-implementation-version))' \
 		--eval '(print (ql-dist:find-system "alexa"))' \
 		--eval '(print (ql-dist:find-system "magicl"))' \
@@ -58,7 +58,7 @@ else
 endif
 
 install-build-deps: install-test-deps
-	sbcl --noinform --non-interactive \
+	$(QUICKLISP) \
 		--eval '(ql:quickload "buildapp")' \
 		--eval '(buildapp:build-buildapp "/usr/local/bin/buildapp")'
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ you would like to change the port of the server to PORT, you can alter the comma
 
 `docker run --rm -it -p PORT:PORT rigetti/quilc -R -p PORT`
 
+# Release Process
+
+1. Update `VERSION.txt` and dependency versions (if applicable) and push the commit to `master`.
+2. Push a git tag `vX.Y.Z` that contains the same version number as in `VERSION.txt`.
+3. Verify that the resulting build (triggered by pushing the tag) completes successfully.
+4. Publish a [release](https://github.com/rigetti/quilc/releases) using the tag as the name.
+5. Close the [milestone](https://github.com/rigetti/quilc/milestones) associated with this release,
+   and migrate incomplete issues to the next one.
+
 # Get involved!
 
 We welcome and encourage community contributions! Peruse our

--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ The CI pipeline for `quilc` produces a Docker image, available at
 [`rigetti/quilc`](https://hub.docker.com/r/rigetti/quilc). To get the latest stable
 version of `quilc`, run `docker pull rigetti/quilc`.
 
+# Running the Quil Compiler with Docker
+
+As outlined above, the Quil Compiler supports two modes of operation: stdin and server.
+
+To run `quilc` in stdin mode, do one either of the following:
+
+1) `docker run --rm -it rigetti/quilc`
+
+The containerized compiler will then read whatever newline-separated Quil instructions you
+enter, waiting for an EOF signal (C+d) to compile it.
+
+2) `echo "H 0" | docker run --rm -i rigetti/quilc`
+
+You can pipe Quil instructions into the `quilc` container if you drop the `-t`.
+
+To run `quilc` in server mode, do the following:
+
+`docker run --rm -it -p 5555:5555 rigetti/quilc -R`
+
+This will spawn an RPCQ-mode `quilc` server, that you can communicate with over TCP. If
+you would like to change the port of the server to PORT, you can alter the command as follows:
+
+`docker run --rm -it -p PORT:PORT rigetti/quilc -R -p PORT`
+
 # Get involved!
 
 We welcome and encourage community contributions! Peruse our

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ lifting of parsing, compiling, and optimizing Quil code. The second,
 the binary `quilc` application directly, or alternatively by
 communicating with a server (HTTP or [RPCQ](https://github.com/rigetti/rpcq/)).
 
-Quil is the [quantum instruction language](https://arxiv.org/pdf/1608.03355.pdf) developed at [Rigetti
-Computing](https://rigetti.com). In Quil quantum algorithms are expressed using Quil's
+Quil is the [quantum instruction language](https://arxiv.org/pdf/1608.03355.pdf) developed at
+[Rigetti Computing](https://rigetti.com). In Quil quantum algorithms are expressed using Quil's
 native gates and instructions. One can also use Quil's `DEFGATE` to
 define new non-native gates, and `DEFCIRCUIT` to build a named circuit
 that can be referenced elsewhere in Quil code (analogous to a function
@@ -25,7 +25,12 @@ of Quil code. The code can be found under `./src/`.
 
 ### Usage
 
-Follow the instructions in QVM's [doc/lisp-setup.md](https://github.com/rigetti/qvm/blob/master/doc/lisp-setup.md) to satisfy the
+To get up and running quickly using the `quilc` Docker image, head directly to the
+section "Running the Quil Compiler with Docker" below. Otherwise, the following steps
+will walk you through how to build the compiler from source.
+
+Follow the instructions in QVM's
+[doc/lisp-setup.md](https://github.com/rigetti/qvm/blob/master/doc/lisp-setup.md) to satisfy the
 dependencies required to load the `CL-QUIL` library. Afterwhich, the
 library can be loaded
 
@@ -109,7 +114,8 @@ server interface. `quilc` currently supports two server modes:
 
 ##### HTTP
 
-The HTTP server was the original implementation of the server mode. It is now deprecated in favour of the RPCQ server mode. Do not depend on it. You can create the HTTP server with the `-S` flag
+The HTTP server was the original implementation of the server mode. It is now deprecated in favour
+of the RPCQ server mode. Do not depend on it. You can create the HTTP server with the `-S` flag
 ``` shell
 $ quilc -S
 +-----------------+
@@ -135,7 +141,9 @@ to the RPCQ version instead.
 
 ##### RPCQ
 
-[RPCQ](https://github.com/rigetti/rpcq/) is an open-source RPC framework developed at Rigetti for efficient network communication through the QCS stack. The server is started in RPCQ-mode using the `-R` flag
+[RPCQ](https://github.com/rigetti/rpcq/) is an open-source RPC framework developed at Rigetti for
+efficient network communication through the QCS stack. The server is started in RPCQ-mode using
+the `-R` flag
 
 ``` shell
 $ quilc -R
@@ -157,13 +165,21 @@ to communicate with the Quil compiler, thus enabling high-level
 abstractions and tools that are not directly available in Quil. The
 [`pyquil`](https://github.com/rigetti/pyquil) library provides such an interface to `quilc`.
 
+# Automated Packaging with Docker
+
+The CI pipeline for `quilc` produces a Docker image, available at
+[`rigetti/quilc`](https://hub.docker.com/r/rigetti/quilc). To get the latest stable
+version of `quilc`, run `docker pull rigetti/quilc`.
+
 # Get involved!
 
 We welcome and encourage community contributions! Peruse our
 [guidelines for contributing](CONTRIBUTING.md) to get you up to speed on
-expectations. Once that's clear, a good place to start is the [good
-first issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) section. If you have any find bugs, please create an
-[issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). If you need help with some code or want to discuss some
-technical issues, you can find us in the `#dev` channel on [slack](https://slack.rigetti.com/).
+expectations. Once that's clear, a good place to start is the
+[good first issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+section. If you have any find bugs, please create an
+[issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+If you need help with some code or want to discuss some technical issues, you can find us in the
+`#dev` channel on [slack](https://slack.rigetti.com/).
 
 We look forward to meeting and working with you!


### PR DESCRIPTION
1. Use the new [`rigetti/rpcq`](https://hub.docker.com/r/rigetti/rpcq) image
2. Include the [`rigetti/ci`](https://github.com/rigetti/ci) docker job pipeline template rather than redefining
3. Add `README` notes about the [`rigetti/quilc`](https://hub.docker.com/r/rigetti/quilc) Docker image and how to use it
4. Add `README` notes about the release process
5. Add a `CODEOWNERS` file for default/required reviewers