### PR TITLE
Refactoring isa descriptor selection in entry-point.lisp

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -67,10 +67,10 @@
 
 (defparameter *isa-descriptors*
   (alexandria::alist-hash-table
-   '(("8Q" . (quil::build-8Q-chip))
-     ("20Q" . (quil::build-skew-rectangular-chip 0 4 5))
-     ("16QMUX" . (quil::build-nQ-trivalent-chip 1 1 8 4))
-     ("bristlecone" . (quil::build-bristlecone-chip)))
+   `(("8Q" . ,(quil::build-8Q-chip))
+     ("20Q" . ,(quil::build-skew-rectangular-chip 0 4 5))
+     ("16QMUX" . ,(quil::build-nQ-trivalent-chip 1 1 8 4))
+     ("bristlecone" . ,(quil::build-bristlecone-chip)))
    :test 'equal))
 
 (defun slurp-lines (&optional (stream *standard-input*))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -52,7 +52,7 @@
     (("json-serialize" #\j) :type boolean :optional t :documentation "serialize output as a JSON object")
     #-forest-sdk
     (("print-logical-schedule" #\s) :type boolean :optional t :documentation "include logically parallelized schedule in JSON output; requires -P")
-    (("isa") :type string :optional t :documentation "set ISA to one of \"8Q\", \"20Q\", \"16QMUX\", \"bristlecone\", \"ibmqx5\", or path to QPU description file")
+    (("isa") :type string :optional t :initial-value "8Q" :documentation "set ISA to one of \"8Q\", \"20Q\", \"16QMUX\", \"bristlecone\", \"ibmqx5\", or path to QPU description file")
     (("enable-state-prep-reductions") :type boolean :optional t :documentation "assume that the program starts in the ground state")
     (("protoquil" #\P) :type boolean :optional t :documentation "restrict input/output to ProtoQuil")
     (("help" #\h) :type boolean :optional t :documentation "print this help information and exit")
@@ -102,16 +102,14 @@
            (coerce #(#\Newline #\#) 'string))))
 
 (defun lookup-isa-descriptor-for-name (isa)
-  (if (null isa)
-      (gethash "8Q" *isa-descriptors*)
-      (let ((isa-hash-value (gethash isa *isa-descriptors*)))
-        (cond
-          ((not (null isa-hash-value))
-           isa-hash-value)
-          ((probe-file isa)
-           (quil::read-chip-spec-file isa))
-          (t
-           (error "ISA descriptor does not name a known template or an extant file."))))))
+  (let ((isa-hash-value (gethash isa *isa-descriptors*)))
+    (cond
+      ((not (null isa-hash-value))
+       isa-hash-value)
+      ((probe-file isa)
+       (quil::read-chip-spec-file isa))
+      (t
+       (error "ISA descriptor does not name a known template or an extant file.")))))
 
 (defvar *nick-banner* t)
 

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -70,7 +70,8 @@
    `(("8Q" . ,(quil::build-8Q-chip))
      ("20Q" . ,(quil::build-skew-rectangular-chip 0 4 5))
      ("16QMUX" . ,(quil::build-nQ-trivalent-chip 1 1 8 4))
-     ("bristlecone" . ,(quil::build-bristlecone-chip)))
+     ("bristlecone" . ,(quil::build-bristlecone-chip))
+     ("ibmqx5" . ,(quil::build-ibm-qx5)))
    :test 'equal))
 
 (defun slurp-lines (&optional (stream *standard-input*))


### PR DESCRIPTION
[More in line now with suggestions outlined here](https://github.com/rigetti/quilc/issues/31)

Simply defined a dynamic variable holding a hash of known isa values and what they map to. There is still some conditional logic outside of that simple lookup however - just less than the original cond. A little more easily edited now perhaps.

Also looks like some white space was picked up by my config - sorry about the noise. 