### PR TITLE
Show human readable time units in PRINT-PROGRAM-RUNTIME

### DIFF
--- a/app/src/printers.lisp
+++ b/app/src/printers.lisp
@@ -104,15 +104,16 @@
 (defun print-program-runtime (lschedule chip-specification)
   (let* ((duration (quil::lscheduler-calculate-duration lschedule
                                                        chip-specification))
+         (duration-picos (* duration 1000))
          (seconds  (floor duration 1000000000))
          (millis   (floor duration 1000000))
          (micros   (floor duration 1000))
          (nanos    (floor duration 1))
-         (picos    (mod (* duration 1000) 1000)))
+         (picos    (mod duration-picos 1000)))
     (setf (gethash "program_duration" *statistics-dictionary*) duration)
     (format *human-readable-stream*
-            "# Compiled program duration: ~4ds ~4dms ~4dus ~4dns ~4dps~%"
-            seconds millis micros nanos picos)))
+            "# Compiled program duration: ~4ds ~4dms ~4dus ~4dns ~4dps    (= ~a ps total)~%"
+            seconds millis micros nanos picos duration-picos)))
 
 (defun print-program-fidelity (lschedule chip-specification)
   (let ((fidelity (quil::lscheduler-calculate-fidelity lschedule

--- a/app/src/printers.lisp
+++ b/app/src/printers.lisp
@@ -102,12 +102,17 @@
             unused-qubits)))
 
 (defun print-program-runtime (lschedule chip-specification)
-  (let ((duration (quil::lscheduler-calculate-duration lschedule
-                                                       chip-specification)))
+  (let* ((duration (quil::lscheduler-calculate-duration lschedule
+                                                       chip-specification))
+         (seconds  (floor duration 1000000000))
+         (millis   (floor duration 1000000))
+         (micros   (floor duration 1000))
+         (nanos    (floor duration 1))
+         (picos    (mod (* duration 1000) 1000)))
     (setf (gethash "program_duration" *statistics-dictionary*) duration)
     (format *human-readable-stream*
-            "# Compiled program duration: ~5d~%"
-            duration)))
+            "# Compiled program duration: ~4ds ~4dms ~4dus ~4dns ~4dps~%"
+            seconds millis micros nanos picos)))
 
 (defun print-program-fidelity (lschedule chip-specification)
   (let ((fidelity (quil::lscheduler-calculate-fidelity lschedule

--- a/src/addresser/logical-schedule.lisp
+++ b/src/addresser/logical-schedule.lisp
@@ -463,11 +463,10 @@ use RESOURCE."
   "Walks the edges in the DAG underlying LSCHEDULE according to a topological
 ordering.
 
-Each instruction begins as being tagged with BASE-VALUE. When we visit an
-instruction INST, we find its bumped value INST-BUMP by calling (BUMP-VALUE INST
-INST-TAG). We visit INST only after all of its incoming edges have been
-propagated. To propagate an edge (SOURCE TARGET) after SOURCE has been visited,
-the TARGET has its tag updated to (TEST-VALUES TARGET-TAG SOURCE-BUMP).
+All instructions begin with a tag of BASE-VALUE. When we visit an instruction
+INSTR, we first compute SOURCE-BUMP, which is a obtained by reducing tags of
+all sources of INSTR's in-edges using TEST-VALUES. Finally, INSTR's tag
+is overwritten by (BUMP-VALUE INSTR SOURCE-BUMP).
 
 Return the reduction of all bumped values by TEST-VALUES, and a hash table
 mapping instructions to their tags. "


### PR DESCRIPTION
Also, slightly reword the comment of LSCHEDULER-WALK-GRAPH
to clarify the explanation.

Fixes #43.

---

For example, this command
```
echo "H 0\nH 1\nCNOT 0 1" | ./quilc -P --compute-runtime
```
now prints
```
...
# Compiled program duration:    0s    0ms    0us  168ns   30ps
```

Not sure if picosecond precision is really needed, but that's what it seemed to report 🤷‍♂️ 