### PR TITLE
Respect time-limit configuration

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -56,10 +56,10 @@
     (("enable-state-prep-reductions") :type boolean :optional t :documentation "assume that the program starts in the ground state")
     (("protoquil" #\P) :type boolean :optional t :documentation "restrict input/output to ProtoQuil")
     (("help" #\h) :type boolean :optional t :documentation "print this help information and exit")
-    (("server-mode-http" #\S) :type boolean :optional t :documentation "run as a web server *and* an RPCQ server. ignores --port and uses 6000 and 5555 respectively.")
+    (("server-mode-http" #\S) :type boolean :optional t :documentation "run as a web server *and* an RPCQ server. ignores --port and uses 6000 and 5555 respectively")
     (("server-mode-rpc" #\R) :type boolean :optional t :documentation "run as an RPCQ server")
     (("port" #\p) :type integer :optional t :documentation "port to run the RPCQ server on")
-    (("time-limit") :type integer :initial-value 0 :documentation "time limit for server requests (0 => unlimited, ms)")
+    (("time-limit") :type integer :initial-value 0 :documentation "time limit (in seconds) for server requests (0 => unlimited)")
     (("version" #\v) :type boolean :optional t :documentation "print version information")
     (("check-libraries") :type boolean :optional t :documentation "check that foreign libraries are adequate")
     #-forest-sdk
@@ -250,8 +250,11 @@
   (when benchmark
     (benchmarks))
 
-  (when (plusp time-limit)
-    (setf *time-limit* (/ time-limit 1000.0d0)))
+  (when (minusp time-limit)
+    (format t "WARNING: a negative value (~D) was provided for the server time-limit; using default value (~D) instead."
+            time-limit *time-limit*)
+    (setf time-limit 60))
+  (setf *time-limit* time-limit)
 
   (setf quil::*prefer-ranged-gates-to-SWAPs* prefer-gate-ladders)
   (setf *compute-gate-depth* compute-gate-depth)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -251,9 +251,7 @@
     (benchmarks))
 
   (when (minusp time-limit)
-    (format t "WARNING: a negative value (~D) was provided for the server time-limit; using default value (~D) instead."
-            time-limit *time-limit*)
-    (setf time-limit 60))
+    (error "A negative value (~D) was provided for the server time-limit." time-limit))
   (setf *time-limit* time-limit)
 
   (setf quil::*prefer-ranged-gates-to-SWAPs* prefer-gate-ladders)

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -169,4 +169,4 @@
     (rpcq:start-server :dispatch-table dt
                        :listen-addresses (list (format nil "tcp://*:~a" port))
                        :logger logger
-                       :timeout 60)))
+                       :timeout *time-limit*)))

--- a/app/src/web-server.lisp
+++ b/app/src/web-server.lisp
@@ -148,8 +148,8 @@ If ALLOW-EMPTY-PAYLOADS is true, then an empty payload resolves to the same thin
         tbnl:*catch-errors-p* t)
   (tbnl:reset-session-secret)
 
-  (unless (zerop *time-limit*)
-    (setq tbnl:*default-connection-timeout* (/ *time-limit* 1000)))
+  (setq tbnl:*default-connection-timeout* *time-limit*)
+
   (setq *app* (make-instance 'vhost
                              :address *server-host*
                              :port *server-port*


### PR DESCRIPTION
Previously the time-limit option had no effect on the RPCQ server. Closes #124.

Some redundant/bad stuff has been removed.

Squashed commit msgs below

1. a time-limit of zero should correspond to no timeout, yet this code
leaves the default huchentoot timeout of 20s
2. in entry-point.lisp the conversion from milliseconds to seconds is
already performed, so (/ ... 1000) is unnecessary here

Specify time-limit in seconds rather than ms

And prevent negative values

Use configurable time-limit for rpcq server

Ooops - actually set time-limit