### PR TITLE
Remove use of buildapp for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG build_target
 # install build dependencies
 COPY Makefile /src/quilc/Makefile
 WORKDIR /src/quilc
-RUN make dump-version-info install-build-deps
+RUN make dump-version-info install-test-deps
 
 # build the quilc app
 ADD . /src/quilc

--- a/Makefile
+++ b/Makefile
@@ -57,45 +57,32 @@ else
 	echo "Non-Linux-based platforms unsupported"
 endif
 
-install-build-deps: install-test-deps
-	$(QUICKLISP) \
-		--eval '(ql:quickload "buildapp")' \
-		--eval '(buildapp:build-buildapp "/usr/local/bin/buildapp")'
-
 ###############################################################################
 # BUILD
 ###############################################################################
 
 .PHONY: quilc
 quilc: system-index.txt
-	buildapp --output quilc \
-		--manifest-file system-index.txt \
+	$(SBCL) $(FOREST_SDK_FEATURE) \
+	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
 		--eval '(push :hunchentoot-no-ssl *features*)' \
-		--asdf-path . \
-		--load-system quilc \
-		$(FOREST_SDK_LOAD) \
-		--eval '(quilc::zap-info)' \
-		--eval '(quilc::setup-debugger)' \
-		--compress-core \
-		--entry quilc::entry-point
+		--load "build-app.lisp" \
+		$(FOREST_SDK_OPTION) \
+		$(QUILC_UNSAFE_OPTION)
+
 
 quilc-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)'
 quilc-sdk-base: clean clean-cache quilc
 
 # By default, relocate shared libraries on SDK builds
-quilc-sdk: FOREST_SDK_LOAD=--load app/src/mangle-shared-objects.lisp
+quilc-sdk: FOREST_SDK_OPTION=--quilc-sdk
 quilc-sdk: quilc-sdk-base
 
 # Don't relocate shared libraries on barebones SDK builds
 quilc-sdk-barebones: quilc-sdk-base
 
-quilc-unsafe: system-index.txt
-	buildapp --output quilc \
-		--manifest-file system-index.txt \
-		--asdf-path . \
-		--load-system quilc \
-		--compress-core \
-		--entry quilc::%entry-point
+quilc-unsafe: QUILC_UNSAFE_OPTION=--unsafe
+quilc-unsafe: quilc
 
 DOCKER_BUILD_TARGET=all
 DOCKER_TAG=rigetti/quilc:$(COMMIT_HASH)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Prerequisites to building `quilc` are:
 1. Standard UNIX build tools
 2. [SBCL (a recent version)](http://www.sbcl.org/): Common Lisp compiler
 3. [Quicklisp](https://www.quicklisp.org/beta/): Common Lisp library manager
-4. [buildapp](https://github.com/xach/buildapp): Builds executable binaries from Common Lisp software
 
 Follow [these instructions](https://github.com/rigetti/qvm/blob/master/doc/lisp-setup.md)
 to get started from scratch.

--- a/app/src/mangle-shared-objects.lisp
+++ b/app/src/mangle-shared-objects.lisp
@@ -1,7 +1,6 @@
 ;;;; mangle-shared-objects.lisp
 ;;;;
-;;;; This is loaded (as with CL:LOAD) before the final image is saved
-;;;; by buildapp.
+;;;; This is loaded (as with CL:LOAD) before the final image is saved.
 ;;;;
 ;;;; Rewrites shared library references on SDK targets to use the
 ;;;; Rigetti package path /usr/local/lib/rigetti. This is so the exact

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -1,0 +1,55 @@
+;;;; build-app.lisp
+;;;;
+;;;; This file is loaded by the Makefile to produce a quilc[.exe] binary.
+;;;;
+
+(unless *load-truename*
+  (error "This file is meant to be loaded."))
+
+(pushnew :hunchentoot-no-ssl *features*)
+
+(require 'asdf)
+
+(let ((*default-pathname-defaults* (make-pathname :type nil
+                                                  :name nil
+                                                  :defaults *load-truename*))
+      (output-file (make-pathname :name "quilc"
+                                  :type #+windows "exe" #-windows nil))
+      (system-table (make-hash-table :test 'equal))
+      (entry-point "quilc::entry-point"))
+  (flet ((option-present-p (name)
+           (find name sb-ext:*posix-argv* :test 'string=))
+         (make-toplevel-function (entry)
+           (lambda ()
+                  (with-simple-restart (abort "Abort")
+                    (funcall (read-from-string entry)
+                             sb-ext:*posix-argv*))))
+         (load-systems-table ()
+           (unless (probe-file "system-index.txt")
+             (error "Generate system-index.txt with 'make system-index.txt' first."))
+           (setf (gethash "quilc" system-table) (merge-pathnames "quilc.asd"))
+           (with-open-file (stream "system-index.txt")
+             (loop
+               :for system-file := (read-line stream nil)
+               :while system-file
+               :do (setf (gethash (pathname-name system-file) system-table)
+                         (merge-pathnames system-file)))))
+         (local-system-search (name)
+           (values (gethash name system-table))))
+    (load-systems-table)
+    (push #'local-system-search asdf:*system-definition-search-functions*)
+    (asdf:load-system "quilc")
+    (funcall (read-from-string "quilc::zap-info"))
+    (funcall (read-from-string "quilc::setup-debugger"))
+    (when (option-present-p "--quilc-sdk")
+      (load "app/src/mangle-shared-objects.lisp"))
+    (when (option-present-p "--unsafe")
+      (format t "~&Using unsafe entry point~%")
+      (setf entry-point "quilc::%entry-point"))
+    (force-output)
+    (sb-ext:save-lisp-and-die output-file
+                              :compression t
+                              :save-runtime-options t
+                              :executable t
+                              :toplevel (make-toplevel-function entry-point))))
+


### PR DESCRIPTION
Instead, use a build-app.lisp file to load quilc and save the quilc
application binary.