### PR TITLE
Install SWAPs on recently used links

### DIFF
--- a/src/addresser/outgoing-schedule.lisp
+++ b/src/addresser/outgoing-schedule.lisp
@@ -97,6 +97,13 @@ BEFORE-INST to make use of RESOURCE."
     (chip-schedule-end-time schedule inst)
     0))
 
+(defun chip-schedule-resource-carving-point (schedule resource)
+  "Returns the latest time in SCHEDULE after which RESOURCE does not communicate with any other resources (i.e., RESOURCE is only touched by instructions whose resource utilization is a subset of RESOURCE)."
+  (loop :for instr :being :the :hash-keys :of (chip-schedule-times schedule)
+      :when (and (resources-intersect-p (instruction-resources instr) resource)
+                 (not (resource-subsetp (instruction-resources instr) resource)))
+        :maximize (chip-schedule-end-time schedule instr)))
+
 (defun chip-schedule-qubit-times (schedule)
   "Find the first time a qubit is available, for each qubit in the schedule."
   (map 'vector

--- a/src/addresser/temporal-addresser.lisp
+++ b/src/addresser/temporal-addresser.lisp
@@ -161,7 +161,6 @@ following swaps. Perform translations under ENVIRONS."
 ;; this function searched for a SWAP that lowers a user-defined
 ;; objective function.  it guarantees that if such a SWAP exists,
 ;; it returns it, and it errors if it cannot find one.
-;;
 (defun select-cost-lowering-swap (chip-spec chip-sched use-free-swaps cost-function rewirings-tried working-l2p
                                   &optional
                                     (depth *addresser-swap-lookahead-depth*))
@@ -206,19 +205,45 @@ following swaps. Perform translations under ENVIRONS."
       (dolist (index potential-first-links)
         ;; TODO: this assumes only SWAPs exist in the permutation list
         (destructuring-bind (q0 q1) (coerce (chip-spec-qubits-on-link chip-spec index) 'list)
-          (let* ((swap-duration (permutation-record-duration
-                                 (vnth 0 (hardware-object-permutation-gates
-                                          (chip-spec-nth-link chip-spec index)))))
-                 (old-horizon (chip-schedule-resource-end-time
-                               chip-sched
-                               (make-qubit-resource q0 q1)))
-                 (new-horizon (cond
-                                ((not (zerop old-horizon))
-                                 (+ old-horizon swap-duration))
-                                (use-free-swaps
-                                 0)
-                                (t
-                                 swap-duration))))
+          (let ((swap-duration (permutation-record-duration
+                                (vnth 0 (hardware-object-permutation-gates
+                                         (chip-spec-nth-link chip-spec index)))))
+                old-horizon new-horizon)
+            ;; populate old-horizon and new-horizon based on a bunch of goofy case work
+            (cond
+              ;; if we know that 2Q programs have a bounded length...
+              ((gethash "time-bound"
+                        (hardware-object-misc-data
+                         (chip-spec-nth-link chip-spec index)))
+               (let ((time-bound (gethash "time-bound"
+                                          (hardware-object-misc-data
+                                           (chip-spec-nth-link chip-spec index)))))
+                 ;; calculate the "start" of the active 2Q program
+                 (setf old-horizon (chip-schedule-resource-carving-point
+                                    chip-sched
+                                    (make-qubit-resource q0 q1)))
+                 (setf new-horizon
+                       (cond
+                         ((not (zerop old-horizon))
+                          (+ old-horizon time-bound))
+                         (use-free-swaps
+                          0)
+                         (t
+                          time-bound)))))
+              ;; otherwise, we don't have a guarantee on the length of a 2Q program
+              (t
+               ;; find the current time that the 2Q resource becomes free
+               (setf old-horizon (chip-schedule-resource-end-time
+                                  chip-sched
+                                  (make-qubit-resource q0 q1)))
+               (setf new-horizon
+                     (cond
+                       ((not (zerop old-horizon))
+                        (+ old-horizon swap-duration))
+                       (use-free-swaps
+                        0)
+                       (t
+                        swap-duration)))))
             (format *compiler-noise-stream* "SELECT-COST-LOWERING-SWAP: Considering ~d: this ~,3f vs best ~,3f.~%"
                     (chip-spec-qubits-on-link chip-spec index)
                     new-horizon
@@ -280,7 +305,7 @@ Optional arguments:
  + INITIAL-REWIRING launches with the addresser with a nontrivial qubit
    permutation.
  + USE-FREE-SWAPS treats the initial rewiring as virtual (able to be changed).
-   If INITIAL-REWIRING is not provided this option has not effect
+   If INITIAL-REWIRING is not provided this option has no effect.
 "
   (format *compiler-noise-stream*
           "GREEDY-TEMPORAL-ADDRESSING: entrance.~%")

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -439,6 +439,10 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
       (vector-push-extend (lambda (instr)
                             (CNOT-to-native-CNOTs chip-spec instr))
                           ret))
+    ;; We make this unconditional. We could later conditionalize it if
+    ;; we happen to have better CCNOT translations for specific target
+    ;; gate sets.
+    (vector-push-extend #'CCNOT-to-CNOT ret)
     (cond
       ((optimal-2q-target-meets-requirements architecture ':cz)
        (vector-push-extend #'ucr-compiler ret))

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -322,6 +322,14 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
     ;; set up the basic optimal 2Q compiler
     (vector-push-extend (optimal-2q-compiler-for type)
                         (hardware-object-compilation-methods obj))
+    ;; based on the optimal 2Q compiler, tag this hardware object with the
+    ;; longest duration any compiled sequence of instructions could possibly
+    ;; take to run on it.
+    (when (or (member ':cz type)
+              (member ':iswap type))
+      ;; TODO: compute this based on duration data
+      (setf (gethash "time-bound" misc-data)
+            #.(+ (* 3 150) (* 6 9)))) ; this is the maximum amt of time that a 2Q program might take
     ;; return the qubit
     obj))
 

--- a/src/compilers/translators.lisp
+++ b/src/compilers/translators.lisp
@@ -165,6 +165,23 @@
         (build-gate "RY"    '(#.(/ pi 2)) q0)
         (build-gate "RZ"    '(#.pi)       q0)))
 
+(define-translator CCNOT-to-CNOT (("CCNOT" () q0 q1 q2) ccnot-gate)
+  (list (build-gate "H"    ()             q2)
+        (build-gate "CNOT" ()             q1 q2)
+        (build-gate "RZ"   '(#.(/ pi -4)) q2)
+        (build-gate "CNOT" ()             q0 q2)
+        (build-gate "RZ"   '(#.(/ pi 4))  q2)
+        (build-gate "CNOT" ()             q1 q2)
+        (build-gate "RZ"   '(#.(/ pi -4)) q2)
+        (build-gate "CNOT" ()             q0 q2)
+        (build-gate "RZ"   '(#.(/ pi 4))  q1)
+        (build-gate "RZ"   '(#.(/ pi 4))  q2)
+        (build-gate "CNOT" ()             q0 q1)
+        (build-gate "H"    ()             q2)
+        (build-gate "RZ"   '(#.(/ pi 4))  q0)
+        (build-gate "RZ"   '(#.(/ pi -4)) q1)
+        (build-gate "CNOT" ()             q0 q1)))
+
 (defun find-shortest-path-on-chip-spec (chip-spec start-node target-node)
   "Returns a sequence of qubit indices that reach from START-NODE to TARGET-NODE on CHIP-SPEC, or NIL if no path can be found.
 

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -225,3 +225,17 @@ CNOT 0 2"))
          (2q-code (program-2q-instructions proc-prog)))
     (is (matrix-equals-dwim orig-matrix proc-matrix))
     (is (every (link-nativep chip) 2q-code))))
+
+(deftest test-ccnot-compilation-on-cphase-iswap ()
+  "Test that CCNOT compiles nicely on a line having the (:CPHASE ISWAP) architecture."
+  (let* ((chip (quil::build-nq-linear-chip 3 :architecture '(:cphase :iswap)))
+         (orig-prog (quil::parse-quil-string "CCNOT 0 1 2"))
+         (orig-matrix (quil::parsed-program-to-logical-matrix orig-prog))
+         (proc-prog (quil::compiler-hook orig-prog chip))
+         (proc-matrix (quil::parsed-program-to-logical-matrix proc-prog))
+         (2q-code (program-2q-instructions proc-prog)))
+    (is (matrix-equals-dwim orig-matrix proc-matrix))
+    (is (every (link-nativep chip) 2q-code))
+    ;; NOTE: Decomposing into five 2q gates is more of a regression
+    ;; test on quality of compilation, and not on correctness.
+    (is (= 5 (length 2q-code)))))

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -423,3 +423,42 @@ MEASURE 1
     (is (= 1 (count-if (lambda (x) (typep x 'quil::pragma-initial-rewiring)) cp)))
     (is (= 1 (count-if (lambda (x) (typep x 'quil::pragma-readout-povm)) cp)))
     (is (= 2 (count-if (lambda (x) (typep x 'quil::pragma-add-kraus)) cp)))))
+
+(deftest test-clever-CCNOT-depth-reduction ()
+  "Test that the ':GREEDY-QUBIT swap selection strategy brings CZ depth down to optimal for CCNOT."
+  (let ((p (quil::compiler-hook (quil::parse-quil "
+PRAGMA INITIAL_REWIRING \"GREEDY\"
+CCNOT 0 1 2")
+                                (quil::build-8Q-chip)))
+        (ls (quil::make-lscheduler)))
+    (quil::append-instructions-to-lschedule ls (coerce (quil::parsed-program-executable-code p)
+                                                       'list))
+    (flet
+        ((value-bumper (instr value)
+           (cond
+             ((not (typep instr 'gate-application))
+              value)
+             (t
+              (quil::operator-match
+                (((("CZ" () _ _) instr))
+                 (1+ value))
+                (_
+                 value))))))
+      (let ((CZ-depth (quil::lscheduler-walk-graph ls :bump-value #'value-bumper)))
+        (is (>= 8 CZ-depth))))))
+
+(deftest test-resource-carving-basic ()
+  (let* ((chip (build-8Q-chip))
+         (sched (quil::make-chip-schedule chip)))
+    (map nil (lambda (instr) (quil::chip-schedule-append sched instr))
+         (list (quil::build-gate "CZ" () 0 1)
+               (quil::build-gate "CZ" () 2 3)
+               (quil::build-gate "CZ" () 1 2)
+               (quil::build-gate "CZ" () 0 3)
+               (quil::build-gate "RX" '(#.(/ pi 2)) 1)))
+    (multiple-value-bind (order index obj)
+        (quil::lookup-hardware-address-by-qubits chip (list 1 2))
+      (declare (ignore order index))
+      (is (= (funcall (quil::hardware-object-native-instructions obj)
+                      (quil::build-gate "CZ" () 1 2))
+             (quil::chip-schedule-resource-carving-point sched (quil::make-qubit-resource 1 2)))))))


### PR DESCRIPTION
This PR changes the behavior of the `:GREEDY-QUBIT` SWAP-search strategy on CZ- or CNOT-based chips: by knowing that the compressor will eventually emit a two-qubit instruction sequence no longer than `optimal-2q` guarantees, we can elect to install a SWAP onto a recently used link, knowing that it will collapse the preceding instructions that we recently placed there.

Without this improvement, quilc decomposed `CCNOT 0 1 2` on a linear chip into a sequence of multiqubit gate depth of 11; with this it comes down to 9; and with this *and* an all-to-all CCNOT translator it comes down to 7.

Closes #80 and #84 . (#80 could be extended to cover the `:A*` search strategy too, but that looks quite complicated.)

Has a bit of a kludge in it for calculating the expected maximum duration. Improving this kludge sounds related to #18 .