### PR TITLE
Add an all-to-all chip constructor

### DIFF
--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -554,6 +554,20 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
       (install-link-onto-chip chip-spec i (1+ i) :architecture architecture))
     chip-spec))
 
+(defun build-nQ-fully-connected-chip (n &key (architecture ':cz))
+  (let ((chip-spec (make-chip-specification
+                    :generic-rewriting-rules (coerce (global-rewriting-rules) 'vector))))
+    (install-generic-compilers chip-spec architecture)
+    ;; prep the qubits
+    (loop :repeat n :do
+      (adjoin-hardware-object (build-qubit) chip-spec))
+    ;; prep the links
+    (dotimes (i n)
+      (dotimes (j i)
+        (format t "~a, ~a~%" j i)
+        (install-link-onto-chip chip-spec j i :architecture architecture)))
+    chip-spec))
+
 (defun build-16QMUX-chip ()
   (qpu-hash-table-to-chip-specification
    (alexandria:plist-hash-table

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -562,11 +562,9 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
     (loop :repeat n :do
       (adjoin-hardware-object (build-qubit) chip-spec))
     ;; prep the links
-    (dotimes (i n)
+    (dotimes (i n chip-spec)
       (dotimes (j i)
-        (format t "~a, ~a~%" j i)
-        (install-link-onto-chip chip-spec j i :architecture architecture)))
-    chip-spec))
+        (install-link-onto-chip chip-spec j i :architecture architecture)))))
 
 (defun build-16QMUX-chip ()
   (qpu-hash-table-to-chip-specification


### PR DESCRIPTION
As written on the tin.

Looking at `chip-specification.lisp`, it might be wise to separate out all these example chips from the rest of the file.