### PR TITLE
Compiling PHASE gate to RZ to allow for parametric compilation

### DIFF
--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -451,6 +451,7 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
     ;; we happen to have better CCNOT translations for specific target
     ;; gate sets.
     (vector-push-extend #'CCNOT-to-CNOT ret)
+    (vector-push-extend #'PHASE-to-RZ ret)
     (cond
       ((optimal-2q-target-meets-requirements architecture ':cz)
        (vector-push-extend #'ucr-compiler ret))


### PR DESCRIPTION
Currently, the PHASE gate does not lend itself to parametric compilation. Since the RZ gate does, and the PHASE gate is just the RZ gate in disguise, this is a simple fix to allow programs using the PHASE gate to get parametrically compiled.