### PR TITLE
Fix type checking of instructions in clifford stuff

### DIFF
--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -192,13 +192,13 @@
         :unless (or (typep instr 'quil:application)
                     (typep instr 'quil:pragma)
                     (and quil::*allow-unresolved-applications*
-                         (typep instr 'quil:unresolved-application)))
-                (error "Cannot extract clifford from the instr ~/cl-quil:instruction-fmt/"
-                       instr)
+                         (typep instr 'quil:unresolved-application))) :do
+                           (error "Cannot extract clifford from the instr ~/cl-quil:qinstruction-fmt/"
+                                  instr)
         :collect (matrix-to-clifford (quil:gate-matrix instr))))
 
 (defun clifford-circuit-p (parsed-quil)
-  "If the parsed circuit PARSED-QUIL a clifford circuit, return the CLIFFORD corresponding to it. Otherwise return NIL. This will generate a clifford that acts on the number of qubits in the program, rather than a number of qubits that is the difference between the maximum and minimum index."
+  "If the parsed circuit PARSED-QUIL is a clifford circuit, return the CLIFFORD corresponding to it. Otherwise return NIL. This will generate a clifford that acts on the number of qubits in the program, rather than a number of qubits that is the difference between the maximum and minimum index."
   (let* ((cliffords (extract-cliffords parsed-quil))
          (qubit-targets (cl-quil::qubits-used parsed-quil))
 	 (qubits (sort qubit-targets #'<))

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -186,10 +186,13 @@
 (defun extract-cliffords (parsed-quil)
   "Given PARSED-QUIL generate the CLIFFORD for each gate"
   (loop :for gate-application :across (quil:parsed-program-executable-code parsed-quil)
+        ;; Collect cliffords of all applications (and unresolved
+        ;; applications). If any other instruction type is
+        ;; encountered, raise error.
         :unless (or (typep gate-application 'quil:application)
                     (and quil::*allow-unresolved-applications*
-                         (typep gate-application 'quil:unresolved-application))) :do
-                           (error "ouf")
+                         (typep gate-application 'quil:unresolved-application)))
+                (error "ouf")
         :collect (matrix-to-clifford (quil:gate-matrix gate-application))))
 
 (defun extract-qubits-used (parsed-quil)

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -186,12 +186,14 @@
 (defun extract-cliffords (parsed-quil)
   "Given PARSED-QUIL generate the CLIFFORD for each gate"
   (loop :for gate-application :across (quil::parsed-program-executable-code parsed-quil)
-        :collect (matrix-to-clifford (quil:gate-matrix gate-application))))
+        :when (typep gate-application 'quil::application)
+          :collect (matrix-to-clifford (quil:gate-matrix gate-application))))
 
 (defun extract-qubits-used (parsed-quil)
   "Given PARSED-QUIL return the indices of the qubits used. The result is given as a list of the qubits used per instruction in the PARSED-QUIL."
   (loop :for parsed-clifford :across (quil::parsed-program-executable-code parsed-quil)
-        :collect (mapcar #'quil::qubit-index (quil::application-arguments parsed-clifford))))
+        :when (typep parsed-clifford 'quil::application)
+          :collect (mapcar #'quil::qubit-index (quil::application-arguments parsed-clifford))))
 
 (defun clifford-circuit-p (parsed-quil)
   "If the parsed circuit PARSED-QUIL a clifford circuit, return the CLIFFORD corresponding to it. Otherwise return NIL. This will generate a clifford that acts on the number of qubits in the program, rather than a number of qubits that is the difference between the maximum and minimum index."

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -184,7 +184,10 @@
                          (pauli-from-string (concatenate 'string phase conj))))))))
 
 (defun extract-cliffords (parsed-quil)
-  "Given PARSED-QUIL generate the CLIFFORD for each gate"
+  "Given PARSED-QUIL generate a list of pairs (CLIFFORD_i QUBITS_i) where CLIFFORD_i is the clifford for the ith instruction in PARSED-QUIL and QUBITS_i is a list of the qubits used in that instruction.
+
+Note: will raise an error if PARSED-QUIL contains instruction types
+other than APPLICATION, PRAGMA, or UNRESOLVED-APPLICATION."
   (loop :for instr :across (quil:parsed-program-executable-code parsed-quil)
         ;; Collect cliffords of all applications (and pragmas,
         ;; unresolved applications). If any other instruction type is

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -185,15 +185,20 @@
 
 (defun extract-cliffords (parsed-quil)
   "Given PARSED-QUIL generate the CLIFFORD for each gate"
-  (loop :for gate-application :across (quil::parsed-program-executable-code parsed-quil)
-        :when (typep gate-application 'quil::application)
-          :collect (matrix-to-clifford (quil:gate-matrix gate-application))))
+  (loop :for gate-application :across (quil:parsed-program-executable-code parsed-quil)
+        :unless (or (typep gate-application 'quil:application)
+                    (and quil::*allow-unresolved-applications*
+                         (typep gate-application 'quil:unresolved-application))) :do
+                           (error "ouf")
+        :collect (matrix-to-clifford (quil:gate-matrix gate-application))))
 
 (defun extract-qubits-used (parsed-quil)
   "Given PARSED-QUIL return the indices of the qubits used. The result is given as a list of the qubits used per instruction in the PARSED-QUIL."
-  (loop :for parsed-clifford :across (quil::parsed-program-executable-code parsed-quil)
-        :when (typep parsed-clifford 'quil::application)
-          :collect (mapcar #'quil::qubit-index (quil::application-arguments parsed-clifford))))
+  (loop :for parsed-clifford :across (quil:parsed-program-executable-code parsed-quil)
+        :when (or (typep parsed-clifford 'quil:application)
+                  (and quil::*allow-unresolved-applications*
+                       (typep parsed-clifford 'quil:unresolved-application)))
+          :collect (mapcar #'quil:qubit-index (quil:application-arguments parsed-clifford))))
 
 (defun clifford-circuit-p (parsed-quil)
   "If the parsed circuit PARSED-QUIL a clifford circuit, return the CLIFFORD corresponding to it. Otherwise return NIL. This will generate a clifford that acts on the number of qubits in the program, rather than a number of qubits that is the difference between the maximum and minimum index."


### PR DESCRIPTION
I assume this code was written before pragmas etc were introduced. Executable
code now contains non-application stuff (pragmas) and so must be careful with
types.

Fixes rigetti/pyquil#858.