### PR TITLE
Rewiring comments

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -26,6 +26,7 @@
                #:cl-algebraic-data-type
                #:global-vars            ; Static globals
                #:salza2                 ; God table compression
+               #:trivial-garbage        ; weak hash tables
                #:cl-permutation
                #:queues.priority-queue
                )

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -153,6 +153,14 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
     (setf (delayed-expression-params c) (mapcar f (delayed-expression-params de)))
     c))
 
+;;;;;;;;;;;;;; Protocols common to (pseudo-)instructions ;;;;;;;;;;;;;
+
+(defgeneric comment (object)
+  (:documentation "Accessor for inline comments associated to (pseudo-)instructions.")
+  (:method ((object t))
+    (declare (ignore object))
+    nil))
+
 ;;;;;;;;;;;;;;;;;;;;;;;; Pseudo-Instructions ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defclass jump-target ()
@@ -1248,9 +1256,6 @@ N.B., The fractions of pi will be printed up to a certain precision!")
    :circuit-definitions nil
    :memory-definitions nil
    :executable-code #()))
-
-(defmethod comment ((object t))
-  nil)
 
 (defun print-instruction-sequence (seq
                                    &key

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1261,7 +1261,7 @@ N.B., The fractions of pi will be printed up to a certain precision!")
                           (print-instruction instr r))
                         (slot-value instr 'comment)))
                (t
-                (print prefix stream)
+                (princ prefix stream)
                 (print-instruction instr stream)
                 (terpri stream))))
        seq))

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -153,29 +153,24 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
     (setf (delayed-expression-params c) (mapcar f (delayed-expression-params de)))
     c))
 
-;;;;;;;;;;;;;; Protocols common to (pseudo-)instructions ;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; Comment protocol for syntax tree objects  ;;;;;;;;;;;;;;;;;;;;
 
-(defgeneric comment (object)
-  (:documentation "Accessor for inline comments associated to (pseudo-)instructions.")
-  (:method ((object t))
-    (declare (ignore object))
-    nil))
+(global-vars:define-global-var **comments**
+    (tg:make-weak-hash-table :test 'eq :weakness ':key)
+  "Weak hash table populated with comments associated to different parts of an AST.")
 
-(defgeneric (setf comment) (val obj)
-  (:documentation "Setter for inline comments associated to (pseudo-)instructions.")
-  (:method (val (obj t))
-    (declare (ignore val obj))
-    (warn "SETF COMMENT does not make sense on arbitrary objects. Only apply this to INSTRUCTION-like objects that support a COMMENT slot.")
-    nil))
+(defun comment (x)
+  (values (gethash x **comments**)))
+
+(defun (setf comment) (comment-string x)
+  (check-type comment-string string)
+  (setf (gethash x **comments**) comment-string))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Pseudo-Instructions ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defclass jump-target ()
   ((label :initarg :label
-          :reader jump-target-label)
-   (comment :initarg :comment
-            :initform nil
-            :accessor comment))
+          :reader jump-target-label))
   (:documentation "A target which can be jumped to. Corresponds to the LABEL directive."))
 
 (declaim (inline jump-target-p))
@@ -249,10 +244,7 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
 ;;; Instructions and their protocol.
 
 (defclass instruction ()
-  ((comment :type string
-            :accessor comment
-            :initarg :comment
-            :initform nil))
+  ()
   (:documentation "Abstract class representing an executable instruction.")
   (:metaclass abstract-class))
 

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -159,7 +159,8 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
   ((label :initarg :label
           :reader jump-target-label)
    (comment :initarg :comment
-            :reader comment))
+            :initform nil
+            :accessor comment))
   (:documentation "A target which can be jumped to. Corresponds to the LABEL directive."))
 
 (declaim (inline jump-target-p))
@@ -235,7 +236,8 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
 (defclass instruction ()
   ((comment :type string
             :accessor comment
-            :initarg :comment))
+            :initarg :comment
+            :initform nil))
   (:documentation "Abstract class representing an executable instruction.")
   (:metaclass abstract-class))
 

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1261,19 +1261,20 @@ N.B., The fractions of pi will be printed up to a certain precision!")
                                    &key
                                      (stream *standard-output*)
                                      (prefix ""))
-  (flet ((print-one-line (instr)
-           (cond
-             ((comment instr)
-              (format stream "~a~a~40T# ~a~%"
-                      prefix
-                      (with-output-to-string (r)
-                        (print-instruction instr r))
-                      (comment instr)))
-             (t
-              (princ prefix stream)
-              (print-instruction instr stream)
-              (terpri stream)))))
-    (map nil #'print-one-line seq)))
+  (let ((*print-pretty* nil))
+    (flet ((print-one-line (instr)
+             (cond
+               ((comment instr)
+                (format stream "~a~a~40T# ~a~%"
+                        prefix
+                        (with-output-to-string (r)
+                          (print-instruction instr r))
+                        (comment instr)))
+               (t
+                (princ prefix stream)
+                (print-instruction instr stream)
+                (terpri stream)))))
+      (map nil #'print-one-line seq))))
 
 (defun print-parsed-program (parsed-program &optional (s *standard-output*))
   ;; write out memory definitions

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -477,22 +477,20 @@ Return the following values:
 
 (defun reconstitute-program (cfg
                              &key
-                               in-comments
-                               out-comments)
+                               (in-comments (make-hash-table))
+                               (out-comments (make-hash-table)))
   "Reconstructs a Quil program given its control flow graph CFG.  IN-COMMENTS and OUT-COMMENTS are hash tables mapping blocks in CFG to optional comment strings to be attached to the opening and closing of each reconstituted block."
   (let* ((blocks (cfg-blocks cfg))
-         (code-list '())
-         (in-comments (or in-comments (make-hash-table)))
-         (out-comments (or out-comments (make-hash-table))))
+         (code-list '()))
 
     ;; Loop though each basic-block
     (dolist (block blocks)
       (let ((reconstituted-code (reconstitute-basic-block block cfg)))
         (alexandria:when-let ((in-comment (gethash block in-comments)))
-          (setf (slot-value (aref reconstituted-code 0) 'comment)
+          (setf (comment (aref reconstituted-code 0))
                 in-comment))
         (alexandria:when-let ((out-comment (gethash block out-comments)))
-          (setf (slot-value (aref reconstituted-code (1- (length reconstituted-code))) 'comment)
+          (setf (comment (aref reconstituted-code (1- (length reconstituted-code))))
                 out-comment))
         (setq code-list
               (if (eq block (entry-point cfg))

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -501,12 +501,13 @@ Return the following values:
       ;; If a jump was never used, we better add one to the end
       (unless jump-used
         (add-to-section end-jump)))
-    (when (basic-block-in-rewiring blk)
-      (setf (comment (aref code-section 0))
-            (format nil "Entering rewiring: ~a" (rewiring-l2p (basic-block-in-rewiring blk)))))
-    (when (basic-block-out-rewiring blk)
-      (setf (comment (aref code-section (1- (length code-section))))
-            (format nil "Exiting rewiring: ~a" (rewiring-l2p (basic-block-out-rewiring blk)))))
+    (let ((*print-pretty* nil))
+      (when (basic-block-in-rewiring blk)
+        (setf (comment (aref code-section 0))
+              (format nil "Entering rewiring: ~a" (rewiring-l2p (basic-block-in-rewiring blk)))))
+      (when (basic-block-out-rewiring blk)
+        (setf (comment (aref code-section (1- (length code-section))))
+              (format nil "Exiting rewiring: ~a" (rewiring-l2p (basic-block-out-rewiring blk))))))
     code-section))
 
 (defun reconstitute-program (cfg)

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -502,12 +502,21 @@ Return the following values:
       (unless jump-used
         (add-to-section end-jump)))
     (let ((*print-pretty* nil))
-      (when (basic-block-in-rewiring blk)
-        (setf (comment (aref code-section 0))
-              (format nil "Entering rewiring: ~a" (rewiring-l2p (basic-block-in-rewiring blk)))))
-      (when (basic-block-out-rewiring blk)
-        (setf (comment (aref code-section (1- (length code-section))))
-              (format nil "Exiting rewiring: ~a" (rewiring-l2p (basic-block-out-rewiring blk))))))
+      (cond
+        ((and (basic-block-in-rewiring blk)
+              (basic-block-out-rewiring blk)
+              (= 1 (length code-section)))
+         (setf (comment (aref code-section 0))
+               (format nil "Entering/exiting rewiring: '(~a . ~a)"
+                       (rewiring-l2p (basic-block-in-rewiring blk))
+                       (rewiring-l2p (basic-block-out-rewiring blk)))))
+        (t
+         (when (basic-block-in-rewiring blk)
+           (setf (comment (aref code-section 0))
+                 (format nil "Entering rewiring: ~a" (rewiring-l2p (basic-block-in-rewiring blk)))))
+         (when (basic-block-out-rewiring blk)
+           (setf (comment (aref code-section (1- (length code-section))))
+                 (format nil "Exiting rewiring: ~a" (rewiring-l2p (basic-block-out-rewiring blk))))))))
     code-section))
 
 (defun reconstitute-program (cfg)

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -507,7 +507,7 @@ Return the following values:
               (basic-block-out-rewiring blk)
               (= 1 (length code-section)))
          (setf (comment (aref code-section 0))
-               (format nil "Entering/exiting rewiring: '(~a . ~a)"
+               (format nil "Entering/exiting rewiring: (~a . ~a)"
                        (rewiring-l2p (basic-block-in-rewiring blk))
                        (rewiring-l2p (basic-block-out-rewiring blk)))))
         (t

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -520,7 +520,7 @@ Return the following values:
     code-section))
 
 (defun reconstitute-program (cfg)
-  "Reconstructs a Quil program given its control flow graph CFG.  IN-COMMENTS and OUT-COMMENTS are hash tables mapping blocks in CFG to optional comment strings to be attached to the opening and closing of each reconstituted block."
+  "Reconstructs a Quil program given its control flow graph CFG."
   (let* ((blocks (cfg-blocks cfg))
          (code-list '()))
 

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -430,7 +430,9 @@ Return the following values:
                       (or (not (basic-block-out-rewiring parent))
                           (not (basic-block-in-rewiring blk))
                           (equalp (basic-block-out-rewiring parent)
-                                  (basic-block-in-rewiring parent))))
+                                  (basic-block-in-rewiring blk))))
+                 
+                 
                  ;; The conditions are met to sequentially merge these blocks
                  (let ((new-blk (merge-sequentially parent blk)))
                    ;; After getting a merged block, update the CFG

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -77,7 +77,15 @@
             :documentation "A LABEL that was originally used to reach this block of code, or NIL if not applicable.")
    (code :initarg :code
          :accessor basic-block-code
-         :documentation "A vector of instructions that this block contains."))
+         :documentation "A vector of instructions that this block contains.")
+   (in-rewiring :initarg :in-rewiring
+                :initform nil
+                :accessor basic-block-in-rewiring
+                :documentation "A REWIRING describing the assignment of qubits at block entry.")
+   (out-rewiring :initarg :out-rewiring
+                 :initform nil
+                 :accessor basic-block-out-rewiring
+                 :documentation "A REWIRING describing the assignment of qubits at block exit."))
   (:documentation "A basic block in a control flow graph.")
   (:default-initargs :name (gensym "BLK-")
                      :incoming nil
@@ -350,6 +358,10 @@ Return the following values:
   "Returns a new BASIC-BLOCK representing a merged BLK1 and BLK2, such that its incoming list is a copy of BLK1's incoming list, its outgoing edge is a copy of BLK2's outgoing edge, and its code is the concatentation of BLK1's code and BLK2's code. Any reference to BLK1 or BLK2 within this new block's edge or incoming list is replaced with a reference to itself."
   (assert (and (typep blk1 (type-of blk2))
                (typep blk2 (type-of blk1))))
+  (assert (or (not (basic-block-out-rewiring blk1))
+              (not (basic-block-in-rewiring blk2))
+              (equalp (basic-block-out-rewiring blk1)
+                      (basic-block-in-rewiring blk2))))
   (let ((new-blk (make-instance (type-of blk1)
                                 :code (concatenate 'vector (basic-block-code blk1)
                                                    (basic-block-code blk2))
@@ -358,6 +370,9 @@ Return the following values:
     (setf (incoming new-blk) (substitute new-blk blk2 (substitute new-blk blk1 (incoming blk1))))
     ;; If an outgoing edge includes a reference to itself, however, we need to update its name
     (setf (outgoing new-blk) (redirect-edge blk1 new-blk (redirect-edge blk2 new-blk (outgoing blk2))))
+    ;; set up the rewirings of the new block
+    (setf (basic-block-out-rewiring new-blk) (basic-block-out-rewiring blk2)
+          (basic-block-in-rewiring new-blk) (basic-block-in-rewiring blk1))
     new-blk))
 
 (defun empty-block-p (blk)
@@ -382,7 +397,17 @@ Return the following values:
                   (= 1 (length (children blk)))
                   (eq parent (first (children blk)))
                   (eq (type-of parent) (type-of blk))
-                  (empty-block-p blk))
+                  (empty-block-p blk)
+                  (or (not (basic-block-out-rewiring parent))
+                      (not (basic-block-in-rewiring blk))
+                      (equalp (basic-block-out-rewiring parent)
+                              (basic-block-in-rewiring blk)))
+                  (or (not (basic-block-out-rewiring parent))
+                      (not (basic-block-in-rewiring blk))
+                      (equalp (basic-block-out-rewiring parent)
+                              (basic-block-in-rewiring blk))))
+                 ;; update the rewiring data
+                 (setf (basic-block-in-rewiring parent) (basic-block-out-rewiring parent))
                  ;; Update the outgoing edge of the parent to point to itself, rather than this block
                  (setf (outgoing parent) (redirect-edge blk
                                                         parent
@@ -396,15 +421,16 @@ Return the following values:
 
                 ;; Condition 2) Paths can be contracted when a block has one parent, that parent has one outgoing edge, and neither are the exit or entry block. There is
                 ;; also the extra condition that and edge cannot be contracted if doing so would cause previously isolated code to be possibly run within a loop.
-                ((not (or
-                       (not (eq (type-of parent) (type-of blk)))
-                       (and
-                        (not (empty-block-p blk))
-                        (> (length (children parent)) 1))
-                       (and
-                        (not (empty-block-p parent))
-                        (find blk (incoming blk)))
-                       (/= 1 (length (children parent)))))
+                ((and (eq (type-of parent) (type-of blk))
+                      (or (empty-block-p blk)
+                          (not (> (length (children parent)) 1)))
+                      (or (empty-block-p parent)
+                          (not (find blk (incoming blk))))
+                      (= 1 (length (children parent)))
+                      (or (not (basic-block-out-rewiring parent))
+                          (not (basic-block-in-rewiring blk))
+                          (equalp (basic-block-out-rewiring parent)
+                                  (basic-block-in-rewiring parent))))
                  ;; The conditions are met to sequentially merge these blocks
                  (let ((new-blk (merge-sequentially parent blk)))
                    ;; After getting a merged block, update the CFG
@@ -473,12 +499,15 @@ Return the following values:
       ;; If a jump was never used, we better add one to the end
       (unless jump-used
         (add-to-section end-jump)))
+    (when (basic-block-in-rewiring blk)
+      (setf (comment (aref code-section 0))
+            (format nil "Entering rewiring: ~a" (rewiring-l2p (basic-block-in-rewiring blk)))))
+    (when (basic-block-out-rewiring blk)
+      (setf (comment (aref code-section (1- (length code-section))))
+            (format nil "Exiting rewiring: ~a" (rewiring-l2p (basic-block-out-rewiring blk)))))
     code-section))
 
-(defun reconstitute-program (cfg
-                             &key
-                               (in-comments (make-hash-table))
-                               (out-comments (make-hash-table)))
+(defun reconstitute-program (cfg)
   "Reconstructs a Quil program given its control flow graph CFG.  IN-COMMENTS and OUT-COMMENTS are hash tables mapping blocks in CFG to optional comment strings to be attached to the opening and closing of each reconstituted block."
   (let* ((blocks (cfg-blocks cfg))
          (code-list '()))
@@ -486,12 +515,6 @@ Return the following values:
     ;; Loop though each basic-block
     (dolist (block blocks)
       (let ((reconstituted-code (reconstitute-basic-block block cfg)))
-        (alexandria:when-let ((in-comment (gethash block in-comments)))
-          (setf (comment (aref reconstituted-code 0))
-                in-comment))
-        (alexandria:when-let ((out-comment (gethash block out-comments)))
-          (setf (comment (aref reconstituted-code (1- (length reconstituted-code))))
-                out-comment))
         (setq code-list
               (if (eq block (entry-point cfg))
                   (concatenate 'vector reconstituted-code code-list)

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -141,8 +141,8 @@ Returns a value list: (processed-program, of type parsed-program
   
   ;; we disallow compilation of programs that use memory aliasing
   (loop :for mdesc :in (parsed-program-memory-definitions parsed-program)
-     :when (memory-descriptor-sharing-parent mdesc)
-     :do (error "Programs with aliased memory are currently unsupported."))
+        :when (memory-descriptor-sharing-parent mdesc)
+          :do (error "Programs with aliased memory are currently unsupported."))
   
   ;; check that the program obeys the dead qubit rule
   (when (eql ':naive rewiring-type)
@@ -180,10 +180,10 @@ Returns a value list: (processed-program, of type parsed-program
             (setf final-blk blk)))
         ;; segments its instructions into the MEASURES and the non-MEASURES
         (loop :for instr :across (basic-block-code final-blk)
-           :if (typep instr 'measure)
-           :do (push instr instrs-measures)
-           :else
-           :do (push instr instrs-rest))
+              :if (typep instr 'measure)
+                :do (push instr instrs-measures)
+              :else
+                :do (push instr instrs-rest))
         ;; store its non-MEASURE instructions back into the block
         (setf (basic-block-code final-blk) (coerce (nreverse instrs-rest) 'vector))
         ;; store its MEASURE instructions into the cordoned-off block

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -115,66 +115,66 @@ as needed so that they are the same size."
   ;; rewiring. this is somewhat complicated by the fact that rewirings
   ;; when we enter a block and when we exit a block may differ.
   (loop
-     :with mat := (magicl:make-complex-matrix 1 1 '(1d0))
-     :with rewiring := (make-rewiring 1)
-     :for instr :across (parsed-program-executable-code pp)
-     :do (progn
-           (flet ((apply-entering-rewiring (instr &optional vector)
-                    (let* ((*read-eval* nil)
-                           (raw-rewiring (if vector
-                                             (make-rewiring-from-l2p vector)
-                                             (make-rewiring-from-l2p
-                                              (read-from-string (subseq (comment instr)
-                                                                        (length "Entering rewiring: "))))))
-                           (trimmed (trim-rewiring raw-rewiring)))
-                      (setf mat (reduce #'matrix-rescale-and-multiply
-                                        (list (rewiring-to-permutation-matrix-l2p trimmed)
-                                              (rewiring-to-permutation-matrix-p2l rewiring)
-                                              mat))
-                            rewiring trimmed)))
-                  (apply-exiting-rewiring (instr &optional vector)
-                    (let* ((*read-eval* nil)
-                           (raw-rewiring (if vector
-                                             (make-rewiring-from-l2p vector)
-                                             (make-rewiring-from-l2p
-                                              (read-from-string (subseq (comment instr)
-                                                                        (length "Exiting rewiring: ")))))))
-                      (setf rewiring (trim-rewiring raw-rewiring))))
-                  (apply-instr (instr)
-                    (typecase instr
-                      (gate-application
-                       (setf mat (apply-gate mat instr)))
-                      (halt
-                       t)
-                      (no-operation
-                       t)
-                      (pragma
-                       t)
-                      (otherwise 
-                       (error "Instruction ~a is not a gate application." instr)))))
-             (cond
-               ((and (comment instr)
-                     (uiop:string-prefix-p "Entering/exiting rewiring: " (comment instr)))
-                (let ((*read-eval* nil))
-                  (destructuring-bind (entering-vector . exiting-vector)
-                      (read-from-string (subseq (comment instr)
-                                                (length "Entering/exiting rewiring: ")))
-                    (apply-entering-rewiring instr exiting-vector)
-                    (apply-instr instr)
-                    (apply-exiting-rewiring instr entering-vector))))
-               (t
-                (when (and (comment instr)
-                           (uiop:string-prefix-p "Entering rewiring: " (comment instr)))
-                  (apply-entering-rewiring instr))
-                (apply-instr instr)
-                (when (and (comment instr)
-                           (uiop:string-prefix-p "Exiting rewiring: " (comment instr)))
-                  (apply-exiting-rewiring instr)))))
-           (when (typep instr 'halt)
-                (loop-finish)))
-     :finally (return (matrix-rescale-and-multiply
-                       (rewiring-to-permutation-matrix-p2l rewiring)
-                       mat))))
+    :with mat := (magicl:make-complex-matrix 1 1 '(1d0))
+    :with rewiring := (make-rewiring 1)
+    :for instr :across (parsed-program-executable-code pp)
+    :do (progn
+          (flet ((apply-entering-rewiring (instr &optional vector)
+                   (let* ((*read-eval* nil)
+                          (raw-rewiring (if vector
+                                            (make-rewiring-from-l2p vector)
+                                            (make-rewiring-from-l2p
+                                             (read-from-string (subseq (comment instr)
+                                                                       (length "Entering rewiring: "))))))
+                          (trimmed (trim-rewiring raw-rewiring)))
+                     (setf mat (reduce #'matrix-rescale-and-multiply
+                                       (list (rewiring-to-permutation-matrix-l2p trimmed)
+                                             (rewiring-to-permutation-matrix-p2l rewiring)
+                                             mat))
+                           rewiring trimmed)))
+                 (apply-exiting-rewiring (instr &optional vector)
+                   (let* ((*read-eval* nil)
+                          (raw-rewiring (if vector
+                                            (make-rewiring-from-l2p vector)
+                                            (make-rewiring-from-l2p
+                                             (read-from-string (subseq (comment instr)
+                                                                       (length "Exiting rewiring: ")))))))
+                     (setf rewiring (trim-rewiring raw-rewiring))))
+                 (apply-instr (instr)
+                   (typecase instr
+                     (gate-application
+                      (setf mat (apply-gate mat instr)))
+                     (halt
+                      t)
+                     (no-operation
+                      t)
+                     (pragma
+                      t)
+                     (otherwise 
+                      (error "Instruction ~a is not a gate application." instr)))))
+            (cond
+              ((and (comment instr)
+                    (uiop:string-prefix-p "Entering/exiting rewiring: " (comment instr)))
+               (let ((*read-eval* nil))
+                 (destructuring-bind (entering-vector . exiting-vector)
+                     (read-from-string (subseq (comment instr)
+                                               (length "Entering/exiting rewiring: ")))
+                   (apply-entering-rewiring instr exiting-vector)
+                   (apply-instr instr)
+                   (apply-exiting-rewiring instr entering-vector))))
+              (t
+               (when (and (comment instr)
+                          (uiop:string-prefix-p "Entering rewiring: " (comment instr)))
+                 (apply-entering-rewiring instr))
+               (apply-instr instr)
+               (when (and (comment instr)
+                          (uiop:string-prefix-p "Exiting rewiring: " (comment instr)))
+                 (apply-exiting-rewiring instr)))))
+          (when (typep instr 'halt)
+            (loop-finish)))
+    :finally (return (matrix-rescale-and-multiply
+                      (rewiring-to-permutation-matrix-p2l rewiring)
+                      mat))))
 
 (defun make-row-major-matrix (rows cols row-major-entries)
   "Make a MAGICL matrix of dimensions ROWS x COLS with the entries ROW-MAJOR-ENTRIES written in row-major order."

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -118,39 +118,60 @@ as needed so that they are the same size."
      :with mat := (magicl:make-complex-matrix 1 1 '(1d0))
      :with rewiring := (make-rewiring 1)
      :for instr :across (parsed-program-executable-code pp)
-       :do (progn
-             (when (and (comment instr)
-                        (uiop:string-prefix-p "Entering rewiring: " (comment instr)))
-               (let* ((*read-eval* nil)
-                      (raw-rewiring (make-rewiring-from-l2p
-                                     (read-from-string (subseq (comment instr)
-                                                               (length "Entering rewiring: ")))))
-                      (trimmed (trim-rewiring raw-rewiring)))
-                 (setf mat (reduce #'matrix-rescale-and-multiply
-                                   (list (rewiring-to-permutation-matrix-l2p trimmed)
-                                         (rewiring-to-permutation-matrix-p2l rewiring)
-                                         mat))
-                       rewiring trimmed)))
-             (typecase instr
-               (gate-application
-                (setf mat (apply-gate mat instr)))
-               (halt
-                t)
-               (no-operation
-                t)
-               (pragma                    ; we ignore all other pragmas
-                t)
-               (otherwise 
-                (error "Instruction ~a is not a gate application." instr)))
-             (when (and (comment instr)
-                        (uiop:string-prefix-p "Exiting rewiring: " (comment instr)))
-               (let* ((*read-eval* nil)
-                      (raw-rewiring (make-rewiring-from-l2p
-                                     (read-from-string (subseq (comment instr)
-                                                               (length "Exiting rewiring: "))))))
-                 (setf rewiring (trim-rewiring raw-rewiring))))
-             (when (typep instr 'halt)
-               (loop-finish)))
+     :do (progn
+           (flet ((apply-entering-rewiring (instr &optional vector)
+                    (let* ((*read-eval* nil)
+                           (raw-rewiring (if vector
+                                             (make-rewiring-from-l2p vector)
+                                             (make-rewiring-from-l2p
+                                              (read-from-string (subseq (comment instr)
+                                                                        (length "Entering rewiring: "))))))
+                           (trimmed (trim-rewiring raw-rewiring)))
+                      (setf mat (reduce #'matrix-rescale-and-multiply
+                                        (list (rewiring-to-permutation-matrix-l2p trimmed)
+                                              (rewiring-to-permutation-matrix-p2l rewiring)
+                                              mat))
+                            rewiring trimmed)))
+                  (apply-exiting-rewiring (instr &optional vector)
+                    (let* ((*read-eval* nil)
+                           (raw-rewiring (if vector
+                                             (make-rewiring-from-l2p vector)
+                                             (make-rewiring-from-l2p
+                                              (read-from-string (subseq (comment instr)
+                                                                        (length "Exiting rewiring: ")))))))
+                      (setf rewiring (trim-rewiring raw-rewiring))))
+                  (apply-instr (instr)
+                    (typecase instr
+                      (gate-application
+                       (setf mat (apply-gate mat instr)))
+                      (halt
+                       t)
+                      (no-operation
+                       t)
+                      (pragma
+                       t)
+                      (otherwise 
+                       (error "Instruction ~a is not a gate application." instr)))))
+             (cond
+               ((and (comment instr)
+                     (uiop:string-prefix-p "Entering/exiting rewiring: " (comment instr)))
+                (let ((*read-eval* nil))
+                  (destructuring-bind (entering-vector . exiting-vector)
+                      (read-from-string (subseq (comment instr)
+                                                (length "Entering/exiting rewiring: ")))
+                    (apply-entering-rewiring instr exiting-vector)
+                    (apply-instr instr)
+                    (apply-exiting-rewiring instr entering-vector))))
+               (t
+                (when (and (comment instr)
+                           (uiop:string-prefix-p "Entering rewiring: " (comment instr)))
+                  (apply-entering-rewiring instr))
+                (apply-instr instr)
+                (when (and (comment instr)
+                           (uiop:string-prefix-p "Exiting rewiring: " (comment instr)))
+                  (apply-exiting-rewiring instr)))))
+           (when (typep instr 'halt)
+                (loop-finish)))
      :finally (return (matrix-rescale-and-multiply
                        (rewiring-to-permutation-matrix-p2l rewiring)
                        mat))))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -121,7 +121,16 @@ as needed so that they are the same size."
     :for instr :across (parsed-program-executable-code pp)
     :do (typecase instr
           (gate-application
-           (setf mat (apply-gate mat instr)))
+           (setf mat (apply-gate mat instr pp))
+           (cond
+             ((and (comment instr)
+                   (uiop:string-prefix-p "Entering rewiring: "))
+              ;;
+              )
+             ((and (comment instr)
+                   (uiop:string-prefix-p "Exiting rewiring: "))
+              ;;
+              )))
           (pragma-expected-rewiring
            (let ((trimmed (trim-rewiring
                            (pragma-rewiring instr))))

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -45,7 +45,6 @@ Z 0")
     (is (quil::operator= (quil::parsed-program-to-logical-matrix pp)
                          (quil::parsed-program-to-logical-matrix pp-rewired)))))
 
-
 (deftest test-rewiring-modes ()
   "Iterates over the rewiring modes and tests that the addresser is well-behaved on each of them."
   ;; first, the straight-line rewiring methods
@@ -88,7 +87,7 @@ JUMP @a")))
                                                  (cl-quil::read-quil-file file))
                                 (quil::build-nQ-linear-chip 5 :architecture architecture))))
     (is (quil::matrix-equals-dwim (quil::parsed-program-to-logical-matrix orig-prog)
-                                  (quil::parsed-program-to-logical-matrix proc-prog :compress-qubits t)))))
+                                  (quil::parsed-program-to-logical-matrix proc-prog)))))
 
 (deftest test-compiler-hook ()
   "Test whether the compiler hook preserves semantic equivalence for

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -11,12 +11,10 @@
 
 (defun attach-rewirings-to-program (pp in-rewiring-vector out-rewiring-vector)
   (setf (quil::comment (aref (quil::parsed-program-executable-code pp) 0))
-        (with-output-to-string (s)
-          (format s "Entering rewiring: ~a" in-rewiring-vector)))
+        (format nil "Entering rewiring: ~a" in-rewiring-vector))
   (setf (quil::comment (aref (quil::parsed-program-executable-code pp)
                              (1- (length (quil::parsed-program-executable-code pp)))))
-        (with-output-to-string (s)
-          (format s "Exiting rewiring: ~a" out-rewiring-vector)))
+        (format nil "Exiting rewiring: ~a" out-rewiring-vector))
   pp)
 
 (deftest test-parsed-program-to-logical-matrix-cnot-rewiring ()

--- a/tests/typed-memory-tests.lisp
+++ b/tests/typed-memory-tests.lisp
@@ -65,7 +65,7 @@ RZ(val[3]) 1")))
     (quil::transform 'quil::expand-circuits pp)
     (quil::transform 'quil::type-check pp)
     (let ((cpp (quil::compiler-hook pp (quil::build-8Q-chip))))
-      (is (= 5 (length (quil::parsed-program-executable-code cpp)))))))
+      (is (= 3 (length (quil::parsed-program-executable-code cpp)))))))
 
 (deftest test-compression-with-classical-angles-+-resource-usage ()
   (let ((pp (quil::parse-quil "
@@ -83,7 +83,7 @@ RZ(val[3]) 1")))
     (quil::transform 'quil::expand-circuits pp)
     (quil::transform 'quil::type-check pp)
     (let ((cpp (quil::compiler-hook pp (quil::build-8Q-chip))))
-      (is (= 7 (length (quil::parsed-program-executable-code cpp)))))))
+      (is (= 5 (length (quil::parsed-program-executable-code cpp)))))))
 
 (deftest test-paltry-type-conversions ()
   "Test that we convert classical base classes into specialized classes correctly."


### PR DESCRIPTION
quilc emits the state of the logical-to-physical assignment of qubits at the start and finish of each block of the CFG. Currently, this information is shared through PRAGMAs, which is a misuse: the PRAGMA directives have no content from the compiler's perspective, and _comments_ are what we're supposed to use to encode things that only have information from a _user_'s perspective. This PR enacts this migration.

Lingering TODOs:
 - [x] Make long comments stay on one line.
 - [x] Consider what happens for one-line blocks, where comment `setf`s probably collide.
 - [x] Consider what happens during the one last call to `simplify-cfg`. Does this mean we really want to store comment labels on the CFG nodes after all, and we should thread those through the reduction rules?
 - [x] Fix the behavior of `program-to-logical-matrix` (or whatever it's called).