### PR TITLE
Fixup/various

### DIFF
--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -490,12 +490,12 @@ other's."
                             (eql final-wf-reduced-prep ':not-simulated))
                        (collinearp final-wf final-wf-reduced-prep))))
              (assert final-wf-reduced-instrs-collinearp
-                     ()
+                     (final-wf final-wf-reduced-instrs)
                      "During careful checking of instruction compression, the produced ~
                    wavefunction by instruction reduction was detected to not be ~
                    collinear with the target wavefunction.")
              (assert final-wf-reduced-prep-collinearp
-                     ()
+                     (final-wf final-wf-reduced-prep)
                      "During careful checking of instruction compression, the produced ~
                    wavefunction by state prep reduction was detected to not be ~
                    collinear with the target wavefunction.")))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -390,12 +390,12 @@ other's."
     (labels
         (;; produce a sequence of native instructions that have the effect of
          ;; carrying START-WF to FINAL-WF (= INSTRUCTIONS |START-WF>)
-         (decompile-instructions-into-state-prep (start-wf final-wf)
+         (decompile-instructions-into-state-prep (start-wf final-wf qc)
            (expand-to-native-instructions
             (list (make-instance 'state-prep-application
                                  :source-wf (copy-seq start-wf)
                                  :target-wf final-wf
-                                 :arguments (nreverse (mapcar #'qubit qubits-on-obj))))
+                                 :arguments (reverse (mapcar #'qubit qc))))
             chip-specification))
          
          ;; produce a sequence of native instructions that have the same effect
@@ -420,16 +420,16 @@ other's."
         ;;
         ;; it's conceivable that something more fine-grained could go here, if
         ;; there were a theory of multidimensional state prep.
-        (when (and (not (eql ':not-simulated start-wf))
-                   (subsetp wf-qc qubits-on-obj)
-                   *enable-state-prep-compression*)
+        (when (and *enable-state-prep-compression*
+                   (not (eql ':not-simulated start-wf))
+                   (subsetp wf-qc qubits-on-obj))
           (let ((final-wf (nondestructively-apply-instrs-to-wf instructions
                                                                start-wf
-                                                               qubits-on-obj)))
+                                                               wf-qc)))
             (when (and final-wf
                        (not (eql ':not-simulated final-wf)))
               (return-from decompile-instructions-in-context
-                (decompile-instructions-into-state-prep start-wf final-wf)))))
+                (decompile-instructions-into-state-prep start-wf final-wf wf-qc)))))
         ;; otherwise, we're obligated to do full unitary compilation.
         (decompile-instructions-into-full-unitary)))))
 

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -413,7 +413,7 @@ other's."
             (list (make-instance 'state-prep-application
                                  :source-wf (copy-seq start-wf)
                                  :target-wf final-wf
-                                 :arguments (reverse (mapcar #'qubit qc))))
+                                 :arguments (nreverse (mapcar #'qubit qc))))
             chip-specification))
          
          ;; produce a sequence of native instructions that have the same effect

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -259,7 +259,7 @@ as needed so that they are the same size."
           scalar)
       (loop :for r :across vect1
             :for s :across vect2
-            :when (and (not (double= 0.0d0 (abs r)))
+            :when (and (not (double= 0d0 (abs r)))
                        (not (double= 0d0 (abs s)))
                        (< (abs (- 1 (abs r))) peak-abs))
             :do (setf peak-abs (abs (- 1 (abs r))))
@@ -267,9 +267,9 @@ as needed so that they are the same size."
       ;; rather than computing the full norm, this could be replaced by the
       ;; component-wise calculation (loop ... :always (double= 0d0 (expt ...)))
       ;; which has the potential to terminate early on a negative result
-      (when scalar
-        (let ((norm (sqrt (dot-product vect1 vect2 (cis scalar)))))
-          (double= 1d0 norm))))))
+      (and scalar
+           (let ((norm (sqrt (dot-product vect1 vect2 (cis scalar)))))
+             (double= 1d0 norm))))))
 
 
 ;; also just some general math routines

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -259,21 +259,17 @@ as needed so that they are the same size."
           scalar)
       (loop :for r :across vect1
             :for s :across vect2
-            :do (cond
-                  ((or (and (double= 0d0 r)
-                            (not (double= 0d0 s)))
-                       (and (not (double= 0d0 r))
-                            (double= 0d0 s)))
-                   (return-from collinearp nil))
-                  ((and (not (double= 0.0d0 (abs r)))
-                        (< (abs (- 1 (abs r))) peak-abs))
-                   (setf peak-abs (abs (- 1 (abs r))))
-                   (setf scalar (/ r s)))))
+            :when (and (not (double= 0.0d0 (abs r)))
+                       (not (double= 0d0 (abs s)))
+                       (< (abs (- 1 (abs r))) peak-abs))
+            :do (setf peak-abs (abs (- 1 (abs r))))
+                (setf scalar (- (phase r) (phase s))))
       ;; rather than computing the full norm, this could be replaced by the
       ;; component-wise calculation (loop ... :always (double= 0d0 (expt ...)))
       ;; which has the potential to terminate early on a negative result
-      (let ((norm (sqrt (dot-product vect1 vect2 scalar))))
-        (double= 1d0 norm)))))
+      (when scalar
+        (let ((norm (sqrt (dot-product vect1 vect2 (cis scalar)))))
+          (double= 1d0 norm))))))
 
 
 ;; also just some general math routines


### PR DESCRIPTION
This PR has a handful of fixes that have come up in testing:

* More work on the numerical stability of `collinearp`.
* Fix the ordering of instruction qubits during state-aware compression: the wavefunction is ordered against `wf-qc`, which agrees with `qubits-on-obj` as sets but which might not have the same ordering.
* Improves the runtime of the test suite by generating smaller matrices during careful compression.
* Make it easier to see bad state on assert.