### PR TITLE
Add an ilog2 function.

### DIFF
--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -42,9 +42,9 @@
                     (distinct-indices (remove-duplicates qubit-indices))
                     (expected-qubits
                       (+ addl-qubits
-                         (1- (integer-length
-                              (isqrt
-                               (length (gate-definition-entries found-gate-defn))))))))
+                         (ilog2
+                          (isqrt
+                           (length (gate-definition-entries found-gate-defn)))))))
                ;; Check that all arguments are distinct
                (assert-and-print-instruction (= (length qubit-indices) (length distinct-indices))
                                              ()
@@ -82,7 +82,7 @@
                       (distinct-indices (remove-duplicates args :test 'equalp))
                       (default-gate-dimension (gate-dimension in-default-gateset))
                       (expected-qubits (+ addl-qubits
-                                          (1- (integer-length default-gate-dimension))))
+                                          (ilog2 default-gate-dimension)))
                       (default-gate-arity (dynamic-gate-arity in-default-gateset)))
 
                  ;; Check that the parameters are the correct number

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -171,7 +171,7 @@
   (loop :for gate-application :across (quil::parsed-program-executable-code parsed-quil)
         :collect
         (let* ((gate (quil:gate-matrix gate-application))
-               (num-qubits (1- (integer-length (magicl:matrix-cols gate)))))
+               (num-qubits (ilog2 (magicl:matrix-cols gate))))
           (make-clifford
            :num-qubits num-qubits
            :basis-map (make-array

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -171,7 +171,7 @@
   (loop :for gate-application :across (quil::parsed-program-executable-code parsed-quil)
         :collect
         (let* ((gate (quil:gate-matrix gate-application))
-               (num-qubits (ilog2 (magicl:matrix-cols gate))))
+               (num-qubits (quil::ilog2 (magicl:matrix-cols gate))))
           (make-clifford
            :num-qubits num-qubits
            :basis-map (make-array

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -171,7 +171,7 @@
   (loop :for gate-application :across (quil::parsed-program-executable-code parsed-quil)
         :collect
         (let* ((gate (quil:gate-matrix gate-application))
-               (num-qubits (quil::ilog2 (magicl:matrix-cols gate))))
+               (num-qubits (quil:ilog2 (magicl:matrix-cols gate))))
           (make-clifford
            :num-qubits num-qubits
            :basis-map (make-array

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -385,8 +385,8 @@ other's."
                                                      :relabeling reassignment))
                      (mat (make-matrix-from-quil translation-results
                                                  :relabeling reassignment))
-                     (kron-size (max (1- (integer-length (magicl:matrix-rows ref-mat)))
-                                     (1- (integer-length (magicl:matrix-rows mat)))))
+                     (kron-size (max (ilog2 (magicl:matrix-rows ref-mat))
+                                     (ilog2 (magicl:matrix-rows mat))))
                      (kroned-mat (kron-matrix-up mat kron-size))
                      (kroned-ref-mat (kron-matrix-up ref-mat kron-size)))
                 (assert
@@ -489,11 +489,11 @@ other's."
                   (reduced-matrix
                    (kron-matrix-up (make-matrix-from-quil reduced-instructions
                                                           :relabeling relabeling)
-                                   (1- (integer-length (magicl:matrix-rows stretched-matrix)))))
+                                   (ilog2 (magicl:matrix-rows stretched-matrix))))
                   (reduced-decompiled-matrix
                    (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions
                                                           :relabeling relabeling)
-                                   (1- (integer-length (magicl:matrix-rows stretched-matrix))))))
+                                   (ilog2 (magicl:matrix-rows stretched-matrix)))))
              (assert (matrix-equality stretched-matrix
                                       (scale-out-matrix-phases reduced-matrix
                                                                stretched-matrix)))
@@ -536,13 +536,13 @@ other's."
          
          (check-quil-is-near-as-matrices ()
            (alexandria:when-let ((stretched-matrix (make-matrix-from-quil instructions)))
-             (let* ((n (1- (integer-length (magicl:matrix-rows stretched-matrix))))
+             (let* ((n (ilog2 (magicl:matrix-rows stretched-matrix)))
                     (reduced-matrix
                      (kron-matrix-up (make-matrix-from-quil reduced-instructions)
-                                     (1- (integer-length (magicl:matrix-rows stretched-matrix)))))
+                                     (ilog2 (magicl:matrix-rows stretched-matrix))))
                     (reduced-decompiled-matrix
                      (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions)
-                                     (1- (integer-length (magicl:matrix-rows stretched-matrix))))))
+                                     (ilog2 (magicl:matrix-rows stretched-matrix)))))
                (assert (matrix-equality stretched-matrix
                                         (scale-out-matrix-phases reduced-matrix stretched-matrix)))
                (when decompiled-instructions

--- a/src/compressor/wavefunctions.lisp
+++ b/src/compressor/wavefunctions.lisp
@@ -70,7 +70,7 @@ Both arrays may be populated instead by the keyword :NOT-SIMULATED, which indica
 
 (defun qubit-count (wf)
   "For a wavefunction WF expressed as an array of components, return the number of qubits involved."
-  (1- (integer-length (length wf))))
+  (ilog2 (length wf)))
 
 (defun wavefunction-size (qubit-indices)
   "For a collection of qubit indices, calculate how large of an array is needed to store a wavefunction on these qubits."

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -553,7 +553,7 @@ Note that this is a controlled version of a R_z gate multiplied by a phase."
   (check-type m magicl:matrix)
   (check-type instr application)
   (alexandria:when-let ((defn (gate-matrix instr)))
-    (let* ((mat-size (1- (integer-length (magicl:matrix-rows m))))
+    (let* ((mat-size (ilog2 (magicl:matrix-rows m)))
            (size (max mat-size
                       (apply #'max
                              (map 'list (lambda (x) (1+ (qubit-index x)))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -26,10 +26,6 @@
         :always (>= (+ x +double-comparison-threshold-strict+)
                     (- y +double-comparison-threshold-strict+))))
 
-(defun ilog2 (x)
-  "Compute integer logarithm of x to the base 2."
-  (1- (integer-length x)))
-
 (defun matrix-first-column-equality (x y)
   (check-type x magicl:matrix)
   (check-type y magicl:matrix)

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -26,6 +26,10 @@
         :always (>= (+ x +double-comparison-threshold-strict+)
                     (- y +double-comparison-threshold-strict+))))
 
+(defun ilog2 (x)
+  "Compute integer logarithm of x to the base 2."
+  (1- (integer-length x)))
+
 (defun matrix-first-column-equality (x y)
   (check-type x magicl:matrix)
   (check-type y magicl:matrix)
@@ -71,7 +75,7 @@
   d. It is required that MAT is n x n with n <= d. Returns the matrix
   MAT (+) I, where (+) denotes direct sum and I is the (d-n) x (d-n)
   identity matrix."
-  (let ((n (1- (integer-length (magicl:matrix-rows mat)))))
+  (let ((n (ilog2 (magicl:matrix-rows mat))))
     (assert (<= n d)
             (d)
             "The resulting matrix must have at least ~D rows, but only ~D were requested."
@@ -86,8 +90,8 @@
   "Given square matrices MAT1 and MAT2, returns a pair of matrices of
 equal dimensions, extending the smaller matrix by a tensor product
 with the identity matrix."
-  (let ((size1 (1- (integer-length (magicl:matrix-rows mat1))))
-        (size2 (1- (integer-length (magicl:matrix-rows mat2)))))
+  (let ((size1 (ilog2 (magicl:matrix-rows mat1)))
+        (size2 (ilog2 (magicl:matrix-rows mat2))))
     (cond ((< size1 size2)
            (setf mat1 (extend-by-identity mat1 size2)))
           ((< size2 size1)
@@ -202,7 +206,7 @@ as needed so that they are the same size."
 
 (defun kron-matrix-up (matrix n)
   "Thinking of a 2^m x 2^m MATRIX as an operator on m qubits, m < N, produces a 2^n x 2^n matrix acting on qubits 0, ..., m, ..., n-1."
-  (let ((m (1- (integer-length (magicl:matrix-rows matrix)))))
+  (let ((m (ilog2 (magicl:matrix-rows matrix))))
     (assert (<= m n))
     (if (= m n)
         matrix

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -407,6 +407,11 @@
   (:export
    #:quil-type-error                    ; FUNCTION
    )
+
+  ;; utilities.lisp
+  (:export
+   #:ilog2                              ; FUNCTION
+   )
   )
 
 (defpackage #:cl-quil.clifford

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -124,3 +124,7 @@ Return two values:
          (values (nreverse segments)
                  ;; I'm not even gonna comment this.
                  (alexandria:xor current-satisfaction (evenp num-segments))))))))
+
+(defun ilog2 (x)
+  "Compute integer logarithm of X to the base 2."
+  (1- (integer-length x)))


### PR DESCRIPTION
Closes #167. An ilog2 function has been added and all the calls to `(1- (integer-length x)` has been replace.