### PR TITLE
Short term fix for build-app.lisp on Windows, and use ':win32 in build-app.lisp

### DIFF
--- a/build-app.lisp
+++ b/build-app.lisp
@@ -39,6 +39,8 @@
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
+    ;; TODO Something is broken here. If zap-info is left to do it's thing on
+    ;; Windows, there is a weird error. This is a short-term fix.
     #-win32
     (funcall (read-from-string "quilc::zap-info"))
     (funcall (read-from-string "quilc::setup-debugger"))

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -14,7 +14,7 @@
                                                   :name nil
                                                   :defaults *load-truename*))
       (output-file (make-pathname :name "quilc"
-                                  :type #+windows "exe" #-windows nil))
+                                  :type #+win32 "exe" #-win32 nil))
       (system-table (make-hash-table :test 'equal))
       (entry-point "quilc::entry-point"))
   (flet ((option-present-p (name)
@@ -39,6 +39,7 @@
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
+    #-win32
     (funcall (read-from-string "quilc::zap-info"))
     (funcall (read-from-string "quilc::setup-debugger"))
     (when (option-present-p "--quilc-sdk")

--- a/quilc.asd
+++ b/quilc.asd
@@ -21,6 +21,7 @@
                #:cl-syslog
                #:rpcq                 ; to replace HUNCHENTOOT and B-T
                #:drakma
+               #:trivial-features     ; for portable *features*
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:quilc-tests)))
   :around-compile (lambda (compile)


### PR DESCRIPTION
There is something weird going on with build-app.lisp in Windows. My hunch is that somehow shared libraries are getting lost, but can't say more than that.

Also use `':win32` rather than `':windows` in build-app.lisp.