### PR TITLE
Nicer error message when ALEXA lexing fails on unexpected input.

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -167,10 +167,9 @@ INPUT-STRING that triggered the condition."
       (alexa:lexer-match-error (c)
         (multiple-value-bind (context-line failing-char)
             (tokenization-failure-context string c)
-          (error "At line ~D: unexpected input text ~S in ~S"
-                 *line-number*
-                 (string failing-char)
-                 context-line))))))
+          (quil-parse-error "unexpected input text ~S in ~S"
+                            (string failing-char)
+                            context-line))))))
 
 (defun process-indentation (toks)
   "Given a list of token lines TOKS, map all changes to :INDENTATION levels to :INDENT and :DEDENT tokens."


### PR DESCRIPTION
Before:

    Couldn't find match at position 51 within the lexer CL-QUIL::LINE-LEXER.

After:

    At line 7: unexpected input text "?" in "S? 7"