### PR TITLE
Fixes for test-faithfulness in quilc-tests

### DIFF
--- a/app/tests/faithfulness-tests.lisp
+++ b/app/tests/faithfulness-tests.lisp
@@ -2,23 +2,33 @@
 ;;;;
 ;;;; Author: Eric Peterson
 ;;;;
-;;;; Ensures that quilc's output matches its input,, according to the -m switch.
+;;;; Ensures that quilc's output matches its input, according to the -m switch.
 
 (in-package #:quilc-tests)
 
 (defparameter *faithfulness-test-file-directory*
   (asdf:system-relative-pathname
    ':quilc-tests
-   "tests/faithfulness-test-files/"))
+   "app/tests/faithfulness-test-files/"))
 
 (deftest test-faithfulness ()
   "Test whether compilation preserves semantic equivalence for some test programs."
   (finish-output *debug-io*)
-  (dolist (file (uiop:directory-files *faithfulness-test-file-directory* #P"*.quil"))
-    (format *debug-io* "    Testing file ~a~%" (pathname-name file))
-    (let ((*error-output* (make-broadcast-stream))
-          (*standard-output* (make-broadcast-stream)))
-      (with-open-file (*standard-input* file :direction :input)
-        (locally
-            (declare #+sbcl(sb-ext:muffle-conditions common-lisp:style-warning))
-          (quilc::%entry-point (list "quilc" "-mp")))))))
+  (let ((test-files (uiop:directory-files *faithfulness-test-file-directory* #P"*.quil")))
+    (is (not (null test-files)))
+    (fresh-line)
+    (dolist (file test-files)
+      (format t "    Testing file ~a~%" (pathname-name file))
+      (let ((*standard-output* (make-broadcast-stream))
+            ;; quilc::process-options sets *protoquil* and *compute-matrix-reps* when passed "-mP"
+            ;; flags. Bind them here so that the global bindings are not affected; otherwise,
+            ;; subsequent tests that depend on the default values will fail.
+            quilc::*protoquil*
+            quilc::*compute-matrix-reps*)
+        (is (search "#Matrices are equal"
+                    (with-open-file (*standard-input* file :direction :input)
+                      (with-output-to-string (*error-output*)
+                        (locally
+                            (declare #+sbcl(sb-ext:muffle-conditions style-warning))
+                          (quilc::%entry-point (list "quilc" "-mP")))))
+                    :from-end t))))))


### PR DESCRIPTION
I am new to Quil and quilc, but I am trying to learn by poking quilc with a stick. I noticed these tests weren't running, so I took a stab at fixing them. But I am unsure about points 4) and 5), below. Feedback welcomed.

Test output prior to this fix:

```
QUILC-TESTS (Suite)
  TEST-FAITHFULNESS.......................................................[ OK ]
  TEST-EASY-VERSION-CALL..................................................[ OK ]
  TEST-QUIL-ROUNDTRIP.....................................................[ OK ]
```

After the fix:

```
QUILC-TESTS (Suite)
    Testing file CCNOTs
    Testing file johannes
    Testing file some-CZs
  TEST-FAITHFULNESS.......................................................[ OK ]
  TEST-EASY-VERSION-CALL..................................................[ OK ]
  TEST-QUIL-ROUNDTRIP.....................................................[ OK ]
```

1) Fix the path to the `*faithfulness-test-file-directory*`

   The invalid path was causing uiop:directory-files to return nil, which resulted in the test passing without actually testing any files.

2) Ensure that the test fails if no test files are found

3) Pass -P not -p to `quilc::%entry-point`

   Lowercase -p is --port. Uppercase -P is --protoquil, which is required by -m (--compute-matrix-reps). Apparently, -m without -P has no effect.

4) Bind `quilc::*protoquil*` and `quilc::*compute-matrix-reps*` before calling `quilc::%entry-point`. The "-mP" flags cause these variables to be set, which causes some downstream test to fail if the global bindings are modified.

   I am not certain about the root cause of the downstream test failure here. If I bind `*protoquil*` and `*compute-matrix-reps*`, the downstream test consistently passes; without the bindings, it consistently fails. My assumption was that twiddling the global bindings for these variables might cause other tests to fail, but maybe it's only indirectly related. Specifically, the test failure is in `quilc-tests::test-quil-roundtrip`, with the error apparently originating from `quil:parsed-program-to-logical-matrix`:

   ```
   RPC request 016c5cdb-5125-484f-80d5-01fbc2cb0982 resulted in error:
   Instruction #<H 0> is not a gate application.
      [Condition of type RPCQ:RPC-ERROR]
   
   ...
   
   Backtrace:
     0: ((LABELS RPCQ::LOOP-TIL-REPLY :IN RPCQ:RPC-CALL))
     1: ((LABELS QUILC-TESTS::TEST-QUIL-ROUNDTRIP :IN QUILC-TESTS::TEST-QUIL-ROUNDTRIP))
     2: ((LABELS FIASCO::RUN-TEST-BODY :IN FIASCO::RUN-TEST-BODY-IN-HANDLERS))
     3: (FIASCO::CALL-WITH-TEST-HANDLERS #<CLOSURE (LAMBDA NIL :IN FIASCO::RUN-TEST-BODY-IN-HANDLERS) {10039B973B}>)
     4: (FIASCO::PRETTY-RUN-TEST #<test QUILC-TESTS::TEST-QUIL-ROUNDTRIP> #<FUNCTION (LABELS QUILC-TESTS::TEST-QUIL-ROUNDTRIP :IN QUILC-TESTS::TEST-QUIL-ROUNDTRIP) {5412D62B}>)
   ...
    16: (EVAL (QUILC-TESTS:RUN-QUILC-TESTS))
   ```

   Note that `*protoquil*` and `*compute-matrix-reps*` are not the only variables that get set by `process-options`. Several others like `*isa-descriptor*`, `*human-readable-stream*`, and `*quil-stream*` (possibly others) are also set.

5) Assert that quilc reports that the computed matrices are equal.

   This was my best guess at a reasonable pass/fail assertion, but I may be missing the point entirely. The original test didn't have any assertions, so perhaps it's meant to signal an error on failure?
