### PR TITLE
add INSTRUCTION-FMT for FORMATting instructions

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -985,9 +985,23 @@ N.B., The fractions of pi will be printed up to a certain precision!")
                 (format nil "~Fi" (imagpart z))))))))
 
 (defun print-instruction (instr &optional (stream *standard-output*))
+  "Print the Qul instruction INSTR to the stream STREAM.
+
+If STREAM is NIL, then it will be printed to a string."
   (print-instruction-generic instr stream))
 
+(defun instruction-fmt (stream instr &optional colon-modifier at-modifier)
+  "Like the function PRINT-INSTRUCTION, but is compatible with format strings using the ~/.../ directive.
+
+For example,
+
+    (format t \"the instruction was ~/cl-quil:instruction-fmt/\" instr)
+"
+  (declare (ignore colon-modifier at-modifier))
+  (print-instruction instr stream))
+
 (defun print-instruction-to-string (instr)
+  "Print the Quil instruction INSTR to a string."
   (print-instruction instr nil))
 
 (defgeneric print-instruction-generic (instr stream) ; total function

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -48,11 +48,10 @@
 (defun format-quil-sequence (s instructions &optional prefix)
   "Nicely prints a sequence of INSTRUCTIONS to a stream S. If PREFIX is present, prepend it to the overall output."
   (when prefix
-    (format s prefix))
+    (format s prefix)
+    (terpri s))
   (dolist (instr instructions)
-    (write-string "    " s)
-    (print-instruction instr s)
-    (terpri s)))
+    (format s "    ~/cl-quil:instruction-fmt/~%" instr)))
 
 (defun qubits-in-instr-list (instructions)
   "Produces a list of all of the (unboxed) qubit indices appearing in INSTRUCTIONS, a list of applications."

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -319,7 +319,8 @@
    #:parsed-program-executable-code     ; READER
 
    #:*print-fractional-radians*         ; PARAMETER
-   #:print-instruction                  ; GENERIC, METHOD
+   #:print-instruction                  ; FUNCTION
+   #:instruction-fmt                    ; FUNCTION (format directive)
    )
 
   ;; gates.lisp


### PR DESCRIPTION
This also changes some (current 1) call site of PRINT-INSTRUCTION to use the new format directive.

This addresses #116.