### PR TITLE
preserve the 'Exiting rewiring' comment when deleting the HALT instruction on a protoquil program

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -420,6 +420,7 @@ HTTP server for good.
         (setf (quil::parsed-program-executable-code processed-program)
               (coerce
                (loop :for instr :across (quil::parsed-program-executable-code processed-program)
+                     :for j :from 0
                      :when (quil::comment instr)
                        :do (cond
                              ((uiop:string-prefix-p "Entering rewiring: " (quil::comment instr))
@@ -433,6 +434,10 @@ HTTP server for good.
                                                                               (/ (- (length comment) length) 2)
                                                                               2)))))
                              (t nil))
+                     :when (and (typep instr 'quil::halt) (quil::comment instr))
+                       :do (setf (quil::comment (aref (quil::parsed-program-executable-code processed-program)
+                                                      (1- j)))
+                                 (quil::comment instr))
                      :unless (typep instr 'quil::halt)
                        :collect instr)
                'vector)))


### PR DESCRIPTION
This PR fixes a bad interaction between #159 and #189.

Closes #199, fixes the build failure in #197 (and probably also #190). H/t to @appleby for both spotting the error and correctly guessing the solution.