### PR TITLE
Miscellaneous trivial fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage-report/html/
 quilc
 .idea/
 system-index.txt

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ We welcome and encourage community contributions! Peruse our
 [guidelines for contributing](CONTRIBUTING.md) to get you up to speed on
 expectations. Once that's clear, a good place to start is the
 [good first issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-section. If you have any find bugs, please create an
+section. If you find any bugs, please create an
 [issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 If you need help with some code or want to discuss some technical issues, you can find us in the
 `#dev` channel on [Slack](https://slack.rigetti.com/).

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -21,7 +21,7 @@
 (defparameter *gate-whitelist* nil)
 (defparameter *gate-blacklist* nil)
 (defparameter *without-pretty-printing* nil)
-(defparameter *ISA-descriptor* nil)
+(defparameter *isa-descriptor* nil)
 (defparameter *verbose* (make-broadcast-stream))
 (defparameter *protoquil* nil)
 (defparameter *log-level* ':info)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -203,17 +203,8 @@
 (defun entry-point (argv)
   (setup-debugger)
 
-  ;; grab the CLI arguments
-  (setf *program-name* (pop argv))
-
   (handler-case
-      (command-line-arguments:handle-command-line
-       *option-spec*
-       'process-options
-       :command-line argv
-       :name "quilc"
-       :positional-arity 0
-       :rest-arity nil)
+      (%entry-point argv)
     (interactive-interrupt (c)
       (declare (ignore c))
       (format *error-output* "~&! ! ! Caught keyboard interrupt. Exiting.~%")

--- a/app/tests/faithfulness-tests.lisp
+++ b/app/tests/faithfulness-tests.lisp
@@ -13,7 +13,7 @@
 
 (deftest test-faithfulness ()
   "Test whether compilation preserves semantic equivalence for some test programs."
-  (finish-output *debug-io*)
+  (finish-output)
   (let ((test-files (uiop:directory-files *faithfulness-test-file-directory* #P"*.quil")))
     (is (not (null test-files)))
     (fresh-line)

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -33,7 +33,7 @@
                                                 :|isa| isa
                                                 :|specs| specs))
                   (server-payload (make-instance 'rpcq::|NativeQuilRequest|
-                                                 :|quil| "H 0"
+                                                 :|quil| quil
                                                  :|target_device| target-device))
                   (server-response (rpcq:rpc-call client "quil-to-native-quil" server-payload))
                   (pp (quil::parse-quil-string quil))

--- a/src/compressor/compressor-configuration.lisp
+++ b/src/compressor/compressor-configuration.lisp
@@ -11,7 +11,7 @@
 ;;;
 ;;; See also:
 ;;;
-;;;  From config.lisp:
+;;;  From options.lisp:
 ;;;
 ;;;     - *COMPRESS-CAREFULLY*
 ;;;     - *ENABLE-APPROXIMATE-COMPILATION*

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -31,7 +31,7 @@
   (check-type y magicl:matrix)
   (and (= (magicl:matrix-rows x) (magicl:matrix-rows y))
        (= (magicl:matrix-cols x) (magicl:matrix-cols y))
-       (loop :for j :below (magicl:matrix-cols x)
+       (loop :for j :below (magicl:matrix-rows x)
              :always (double~ (magicl:ref x j 0) (magicl:ref y j 0)))))
 
 (defun matrix-equality (x y)

--- a/tests/benchmarking-procedures-tests.lisp
+++ b/tests/benchmarking-procedures-tests.lisp
@@ -56,10 +56,10 @@
     (is (equalp (serialize-clifford-sequence cliff-id2) (list (list "XI" "ZI" "IX" "IZ"))))))
 
 (defun matrix-equalp (a b)
-  (let ((ma (magicl::matrix-rows a))
-        (na (magicl::matrix-cols a))
-        (mb (magicl::matrix-rows b))
-        (nb (magicl::matrix-cols b)))
+  (let ((ma (magicl:matrix-rows a))
+        (na (magicl:matrix-cols a))
+        (mb (magicl:matrix-rows b))
+        (nb (magicl:matrix-cols b)))
     (and (= ma mb)
          (= na nb)
          (loop :for i :below ma

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -225,7 +225,7 @@ CNOT 0 2"))
          (proc-prog (quil::compiler-hook orig-prog chip))
          (proc-matrix (quil::parsed-program-to-logical-matrix proc-prog))
          (2q-code (program-2q-instructions proc-prog)))
-    (is (matrix-equals-dwim orig-matrix proc-matrix))
+    (is (quil::matrix-equals-dwim orig-matrix proc-matrix))
     (is (every (link-nativep chip) 2q-code))))
 
 (deftest test-ccnot-compilation-on-cphase-iswap ()
@@ -236,7 +236,7 @@ CNOT 0 2"))
          (proc-prog (quil::compiler-hook orig-prog chip))
          (proc-matrix (quil::parsed-program-to-logical-matrix proc-prog))
          (2q-code (program-2q-instructions proc-prog)))
-    (is (matrix-equals-dwim orig-matrix proc-matrix))
+    (is (quil::matrix-equals-dwim orig-matrix proc-matrix))
     (is (every (link-nativep chip) 2q-code))
     ;; NOTE: Decomposing into five 2q gates is more of a regression
     ;; test on quality of compilation, and not on correctness.

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -75,11 +75,6 @@ JUMP @a")))
       (is t))))
 
 (defun compare-compiled (file architecture)
-  ;; note: we compress qubits twice. the first is a compression of
-  ;; logical qubits in the original, uncompiled program. for the
-  ;; compiled program, we also compress qubits when creating the
-  ;; logical matrix, since the compiler may use a larger range of
-  ;; physical qubits
   (let* ((orig-prog (quil::transform 'quil::compress-qubits
                                      (cl-quil::read-quil-file file)))
          (proc-prog

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -33,22 +33,3 @@
                  :operator (cl-quil::named-operator "TEST")
                  :arguments (mapcar #'cl-quil::qubit qubit-indices)
                  :gate matrix))
-
-(defun first-column-operator= (mat1 mat2)
-  (multiple-value-bind (mat1 mat2) (quil::matrix-rescale mat1 mat2)
-    (setf mat1 (quil::scale-out-matrix-phases mat1 mat2))
-    (quil::matrix-first-column-equality mat1 mat2)))
-
-(defun operator= (mat1 mat2)
-  (multiple-value-bind (mat1 mat2) (quil::matrix-rescale mat1 mat2)
-    (setf mat1 (quil::scale-out-matrix-phases mat1 mat2))
-    (quil::matrix-equality mat1 mat2)))
-
-(defun matrix-equals-dwim (mat1 mat2)
-  "Returns true if mat1 is equal to mat2, with the specific notion of equality
-depending on whether *ENABLE-STATE-PREP-COMPRESSION* is enabled."
-  (funcall (if quil::*enable-state-prep-compression*
-               #'first-column-operator=
-               #'operator=)
-           mat1
-           mat2))


### PR DESCRIPTION
This PR contains miscellaneous fixes for typos, stale comments, minor refactorings and the like that caught my eye while reading over the code. The commits are independent and unrelated, but it seemed liked overkill to create separate pull requests for each, so I rolled them all up into one. If you prefer separate PRs, just say the word.

Individual commit messages copied/pasted here for easier perusal.

- Call `quilc::%entry-point` from `quil::entry-point`

  This removes a tiny bit of code duplication and makes it clear that `entry-point` and `%entry-point` are equivalent, modulo debugger setup and error reporting.

- Remove duplicate code from tests/utilities.lisp

  Copies of `matrix-equals-dwim`, `operator=`, and `first-column-operator=` appear in `cl-quil-tests` and `cl-quil`. Remove the versions in `cl-quil-tests` and add a `quil::` package prefix to the last remaining references to the versions in `cl-quil-tests`.

- Add /coverage-report/html/ to .gitignore
- Remove unnecessary double-colon for exported magicl symbols
- Make use of `quil` variable in `test-quil-roundtrip`
- Fix minor README typo
- Fix comment typo in compressor-configuration.lisp
- Remove stale comment in compiler-hook-tests

  The second qubit compression of the compiled program in `quil::parsed-program-to-logical-matrix` has been removed.

- Use consistent lower case spelling for `*isa-descriptor*`

  The variable is defined as `*ISA-descriptor*`, but referenced everywhere as `*isa-descriptor*`. If some lawless maverick were to set their readtable-case to `:preserve` or `:invert`, they might be momentarily confused.

- Loop over matrix rows not cols in `matrix-first-column-equality`

  Fixes a hypothetical bug that relied on the fact that `matrix-rows` == `matrix-cols` for square matrices.

- Do test output on `*standard-output*` not `*debug-io*`

  This change was requested in code review comments in #189, but that pull request was merged before I could make the change.