### PR TITLE
Print debug info during compression errors

### DIFF
--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -591,9 +591,7 @@ Return the following values:
 
 (defun print-code-list (code &optional (out *standard-output*))
   "Prints a representation of CODE, which is valid sequence of Quil instructions, to an optional stream OUT, with the *standard-output* stream as the default."
-  (loop :for x :across code :do
-    (print-instruction x out)
-    (terpri out)))
+  (map nil (lambda (isn) (print-instruction isn out) (terpri out)) code))
 
 (defun underscorize (name)
   (substitute #\_ #\- name))


### PR DESCRIPTION
User-reported errors seem to cleave into two sorts:

1. There's only one place such an error message could be triggered, and with a bit of effort you can dream up some bad input that will indeed cause the error.
2. The error message is completely opaque, and the triggering of the error appears to be extremely sensitive to the precise user input.

Errors of type 2 seem to be partially localized: they rarely happen in the addresser, and they rarely (so far: never!) happen in the 'logic' of the compressor. Instead, they always happen deep in the guts of the compressor and require knowledge about which straight-line sequence was fed in to be processed.

This PR adds a `handler-case` that dumps relevant information to `stderr` in the event of such a crash. I don't really know what Best Practices are here, but I think this is the sort of information I'd want (+ maybe also the library version...) and how I'd want it reported.