### PR TITLE
Make originating-file optional

### DIFF
--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -42,7 +42,7 @@
                                         (parsed-program-executable-code incl-pp)))
       pp)))
 
-(defun process-includes (pp originating-file)
+(defun process-includes (pp &optional originating-file)
   "Process all INCLUDE forms by reading files off the disk. Produces a new PARSED-PROGRAM object."
   (let ((originating-directory (if (null originating-file)
                                    (pathname (uiop:getcwd))


### PR DESCRIPTION
I think this was originally optional, but at somepoint was changed?
This is causing a bug in QVM, where the patch-labels transform depends
on the process-includes transform, but doesn't provide an originating
file. Should it?