### PR TITLE
Reduce global state mutation in quilc

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -21,7 +21,6 @@
 (defparameter *gate-whitelist* nil)
 (defparameter *gate-blacklist* nil)
 (defparameter *without-pretty-printing* nil)
-(defparameter *isa-descriptor* nil)
 (defparameter *verbose* (make-broadcast-stream))
 (defparameter *protoquil* nil)
 (defparameter *log-level* ':info)
@@ -369,13 +368,12 @@ HTTP server for good.
 	    (setf *quil-stream* *standard-output*)))
          (when verbose
            (setf *verbose* *human-readable-stream*))
-         (let ((*isa-descriptor* (lookup-isa-descriptor-for-name isa)))
-           (run-CLI-mode)))))))
+         (run-CLI-mode (lookup-isa-descriptor-for-name isa)))))))
 
-(defun run-CLI-mode ()
+(defun run-CLI-mode (isa-descriptor)
   (let* ((program-text (slurp-lines))
          (program (quil::parse-quil program-text)))
-    (process-program program *isa-descriptor*)))
+    (process-program program isa-descriptor)))
 
 (defun process-program (program chip-specification)
   (let* ((original-matrix

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -201,8 +201,6 @@
   (disable-debugger))
 
 (defun entry-point (argv)
-  (setup-debugger)
-
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -105,7 +105,7 @@
            (coerce #(#\Newline #\#) 'string))))
 
 (defun lookup-isa-descriptor-for-name (isa)
-  (alexandria:switch (isa :test #'equal)
+  (alexandria:switch (isa :test #'string=)
     ("8Q" (quil::build-8Q-chip))
     ("20Q" (quil::build-skew-rectangular-chip 0 4 5))
     ("16QMUX" (quil::build-16QMUX-chip))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -328,7 +328,7 @@ HTTP server for good.
 ~%~%"))
 
 	 (when port
-           (cl-syslog:rfc-log (*logger* :debug "WARNING: -p and -S are incompatible. Dropping -p.")
+           (cl-syslog:rfc-log (*logger* :warning "WARNING: -p and -S are incompatible. Dropping -p.")
              (:msgid "LOG0001")))
 
 	 ;; start the RPCQ server in parallel

--- a/app/tests/faithfulness-tests.lisp
+++ b/app/tests/faithfulness-tests.lisp
@@ -19,12 +19,7 @@
     (fresh-line)
     (dolist (file test-files)
       (format t "    Testing file ~a~%" (pathname-name file))
-      (let ((*standard-output* (make-broadcast-stream))
-            ;; quilc::process-options sets *protoquil* and *compute-matrix-reps* when passed "-mP"
-            ;; flags. Bind them here so that the global bindings are not affected; otherwise,
-            ;; subsequent tests that depend on the default values will fail.
-            quilc::*protoquil*
-            quilc::*compute-matrix-reps*)
+      (let ((*standard-output* (make-broadcast-stream)))
         (is (search "#Matrices are equal"
                     (with-open-file (*standard-input* file :direction :input)
                       (with-output-to-string (*error-output*)


### PR DESCRIPTION
Replace most global state mutation in quilc with let bindings.

This is "option 5" from the discussion in #192. Turns out the state mutation was almost entirely confined to `quilc::process-options`, so switching to let bindings everywhere wasn't too bad.

The only remaining global state mutation occurs in `quilc::setup-debugger` which is called from `quilc::entry-point`, but not `quilc::%entry-point`. Removing this last bit of state mutation is also possible, but slightly uglier since it requires either peeking under the covers of `sb-ext:disable-debugger` to figure out what additional vars to let-bind, or else running the body of `quilc::entry-point` in an `unwind-protect` that calls `quilc::enable-debugger` on exit. Since the whole point of `quilc::%entry-point` is presumably to provide a non-debugger-mangling entry point for interactive use, it didn't seem worth it to take this final step.

Fixes #192