### PR TITLE
Question about rewirings in parsed-program-to-logical-matrix

### DIFF
--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -159,9 +159,9 @@ as needed so that they are the same size."
                  (destructuring-bind (entering-vector . exiting-vector)
                      (read-from-string (subseq (comment instr)
                                                (length "Entering/exiting rewiring: ")))
-                   (apply-entering-rewiring instr exiting-vector)
+                   (apply-entering-rewiring instr entering-vector)
                    (apply-instr instr)
-                   (apply-exiting-rewiring instr entering-vector))))
+                   (apply-exiting-rewiring instr exiting-vector))))
               (t
                (when (and (comment instr)
                           (uiop:string-prefix-p "Entering rewiring: " (comment instr)))


### PR DESCRIPTION
While gazing at these lovely codes I noticed that in `quil::parsed-program-to-logical-matrix`, when there is a combined entering/exiting rewiring on a single instruction, it calls the locally-defined function `apply-entering-rewiring` on the `exiting-vector` and `apply-exiting-rewiring` on the `entering-vector`. This seemed backwards to me, but I am noob and lack understanding.

Is this a bug? Expected?

I wrote a test that I think indicates a bug, but I might be holding it wrong. Prior to these changes, the new test fails like so (after, all tests pass):

``` common-lisp
CL-USER> (fiasco:run-tests 'cl-quil-tests::test-parsed-program-to-logical-matrix-entering-exiting-rewiring)
TEST-PARSED-PROGRAM-TO-LOGICAL-MATRIX-ENTERING-EXITING-REWIRING...........[FAIL]


Test run had 1 failure:

  Failure 1: FAILED-ASSERTION when running CL-QUIL-TESTS::TEST-PARSED-PROGRAM-TO-LOGICAL-MATRIX-ENTERING-EXITING-REWIRING
    Binary predicate (OPERATOR= X Y) failed.
    x: (CL-QUIL:PARSED-PROGRAM-TO-LOGICAL-MATRIX CL-QUIL-TESTS::PP) => #<MAGICL:MATRIX [Z] 4x4:
                                                                          1.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j
                                                                          0.000 + 0.000j     0.000 + 0.000j     1.000 + 0.000j     0.000 + 0.000j
                                                                          0.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j     1.000 + 0.000j
                                                                          0.000 + 0.000j     1.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j>
    y: (CL-QUIL:PARSED-PROGRAM-TO-LOGICAL-MATRIX CL-QUIL-TESTS::PP-REWIRED) => #<MAGICL:MATRIX [Z] 4x4:
                                                                                  1.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j
                                                                                  0.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j     1.000 + 0.000j
                                                                                  0.000 + 0.000j     1.000 + 0.000j     0.000 + 0.000j     0.000 + 0.000j
                                                                                  0.000 + 0.000j     0.000 + 0.000j     1.000 + 0.000j     0.000 + 0.000j>
NIL
(#<test-run of TEST-PARSED-PROGRAM-TO-LOGICAL-MATRIX-ENTERING-EXITING-REWIRING: 1 test, 1 assertion, 1 failure in 0.0 sec (1 failed assertion, 0 errors, none expected)>)
```