### PR TITLE
treat stdgates uniformly with other DEFGATES (and more)

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -35,7 +35,10 @@
                     (let (#+sbcl(sb-ext:*derive-function-types* t))
                       (funcall compile)))
   :serial t
-  :components ((:file "package")
+  :components ((:module "quil"
+                :serial t
+                :components ((:static-file "stdgates.quil")))
+               (:file "package")
                (:file "options")
                (:file "utilities")
                (:file "matrix-operations")

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -36,24 +36,24 @@
            ;; Verify correct arguments
            (let ((args (application-arguments app)))
              ;; Check that all arguments are qubits
-             (unless *in-circuit-body*
-               (assert-and-print-instruction (every #'qubit-p args)
-                                             ()
-                                             "All arguments must be qubits."))
-             (let* ((qubit-indices (if *in-circuit-body*
-                                       args
-                                       (map 'list #'qubit-index args)))
-                    (num-qubits (length qubit-indices))
-                    (distinct-indices (remove-duplicates qubit-indices))
+             (assert-and-print-instruction (every (alexandria:disjoin #'qubit-p
+                                                                      (if *in-circuit-body*
+                                                                          #'is-formal
+                                                                          (constantly nil)))
+                                                  args)
+                                           ()
+                                           "All arguments must be qubits. Check type of args: ~S." args)
+             (let* ((num-qubits (length args))
+                    (distinct-args (remove-duplicates args :test 'equalp))
                     (expected-qubits
                       (+ addl-qubits
                          (ilog2
                           (isqrt
                            (length (gate-definition-entries found-gate-defn)))))))
                ;; Check that all arguments are distinct
-               (assert-and-print-instruction (= (length qubit-indices) (length distinct-indices))
+               (assert-and-print-instruction (= (length args) (length distinct-args))
                                              ()
-                                             "All arguments must have distinct indices. Check indices for duplicates.")
+                                             "All arguments must have distinct arguments. Check arguments for duplicates.")
                ;; Check that number of arguments matches gate matrix dimension
                (assert-and-print-instruction (= expected-qubits num-qubits)
                                              ()

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -53,7 +53,7 @@
                ;; Check that all arguments are distinct
                (assert-and-print-instruction (= (length args) (length distinct-args))
                                              ()
-                                             "All arguments must have distinct arguments. Check arguments for duplicates.")
+                                             "All arguments must be distinct. Check arguments for duplicates.")
                ;; Check that number of arguments matches gate matrix dimension
                (assert-and-print-instruction (= expected-qubits num-qubits)
                                              ()

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -190,7 +190,12 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
   ((name :initarg :name
          :reader gate-definition-name)
    (entries :initarg :entries
-            :reader gate-definition-entries))
+            :reader gate-definition-entries)
+   ;; This is a private slot and is here to increase the performance
+   ;; of many repeated calculations of a GATE object. See the function
+   ;; GATE-DEFINITION-TO-GATE.
+   (cached-gate :initform nil
+                :accessor %gate-definition-cached-gate))
   (:metaclass abstract-class)
   (:documentation "A representation of a raw, user-specified gate definition. This is *not* supposed to be an executable representation."))
 

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -905,10 +905,23 @@ Determining this requires the context of the surrounding program."))
 This definition does *not* incorporate the operator description (i.e., any operator modifiers like CONTROLLED).
 
 If this slot is not supplied, then the gate is considered *anonymous*. If this is the case, then the GATE slot must be supplied.")
+   ;; N.B. See the generic function GATE-APPLICATION-GATE as well.
    (gate :initarg :gate
-         :accessor gate-application-gate
-         :documentation "The actual gate object that is being applied. N.B. After applications are resolved, one can always look at the definition of a gate via GATE-APPLICATION-RESOLUTION. But this slot is reserved for actual *execution*, which may depend on the execution backend and how one wishes to optimize."))
+         :initform nil
+         :reader %get-gate-application-gate
+         :writer %set-gate-application-gate
+         :documentation "The actual gate object that is being applied. N.B. After applications are resolved, one can always look at the definition of a gate via GATE-APPLICATION-RESOLUTION. But this slot is reserved for actual *execution*, which may depend on the execution backend and how one wishes to optimize.
+
+N.B. This slot shoould not be accessed directly! Consider using GATE-APPLICATION-GATE, or, if you really know what you're doing, %SET-GATE-APPLICATION-GATE."))
   (:documentation "An instruction representing an application of a known gate."))
+
+(defgeneric gate-application-gate (app)
+  ;; See the actual definition of this in gates.lisp.
+  (:documentation "Return a gate-like object represented in the application APP.")
+  (:method :around ((app gate-application))
+    (alexandria:if-let ((gate (%get-gate-application-gate app)))
+      gate
+      (%set-gate-application-gate (call-next-method) app))))
 
 (defgeneric anonymous-gate-application-p (app)
   (:documentation "Is the gate application APP an anonymous application?")

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -632,8 +632,8 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
               (reduce #'magicl:multiply-complex-matrices
                       (list
                        m
-                       (su2-on-line 0 (gate-matrix (lookup-standard-gate "RY") sigma))
-                       (gate-matrix (lookup-standard-gate "ISWAP"))))))))
+                       (su2-on-line 0 (gate-matrix (gate-definition-to-gate (lookup-standard-gate "RY")) sigma))
+                       (gate-matrix (gate-definition-to-gate (lookup-standard-gate "ISWAP")))))))))
     (multiple-value-bind (sigma mprime) (twist-to-real (build-canonical-gate coord))
       (multiple-value-bind (a d b) (orthogonal-decomposition mprime)
         (let* ((coordprime (get-canonical-coords-from-diagonal d)))

--- a/src/compilers/optimal-2q.lisp
+++ b/src/compilers/optimal-2q.lisp
@@ -48,8 +48,8 @@ NOTE: I believe that even though both objects (the double-coset space and the sp
      (reduce #'magicl:multiply-complex-matrices
              (list
               m
-              (su2-on-line 0 (gate-matrix (lookup-standard-gate "RY") sigma))
-              (gate-matrix (lookup-standard-gate "ISWAP")))))))
+              (su2-on-line 0 (gate-matrix (gate-definition-to-gate (lookup-standard-gate "RY")) sigma))
+              (gate-matrix (gate-definition-to-gate (lookup-standard-gate "ISWAP"))))))))
 
 (defun chi-from-evals (evals)
   "Computes the characteristic polynomial of a 4x4 matrix with all

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -240,19 +240,18 @@
 
 ;;;;;;;;;;;;;;;;;;;;;; Default Gate Definitions ;;;;;;;;;;;;;;;;;;;;;;
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (global-vars:define-global-var **default-gate-definitions** (make-hash-table :test 'equal)
-    "A table of default gate definitions, mapping string name to a GATE-DEFINITION object."))
-
 ;;; Load all of the standard gates from src/quil/stdgates.quil
-(eval-when (:compile-toplevel)
-  (let ((gate-defs (parsed-program-gate-definitions
-                    (parse-quil-into-raw-program
-                     (alexandria:read-file-into-string
-                      (asdf:system-relative-pathname "cl-quil" "src/quil/stdgates.quil"))))))
-    (dolist (gate-def gate-defs)
-      (setf (gethash (gate-definition-name gate-def) **default-gate-definitions**)
-            gate-def))))
+(global-vars:define-global-var **default-gate-definitions**
+    (let ((table (make-hash-table :test 'equal))
+          (gate-defs (parsed-program-gate-definitions
+                      (parse-quil-into-raw-program
+                       (alexandria:read-file-into-string
+                        (asdf:system-relative-pathname
+                         "cl-quil" "src/quil/stdgates.quil"))))))
+      (dolist (gate-def gate-defs table)
+        (setf (gethash (gate-definition-name gate-def) table)
+              gate-def)))
+  "A table of default gate definitions, mapping string name to a GATE-DEFINITION object.")
 
 (defun standard-gate-names ()
   "Query for the list of standard Quil gate names."

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -272,7 +272,11 @@
 ;;; analysis on the gate.
 
 (defgeneric gate-definition-to-gate (gate-def)
-  (:documentation "Convert a parsed Quil gate definition to a usable, executable gate."))
+  (:documentation "Convert a parsed Quil gate definition to a usable, executable gate.")
+  (:method :around ((gate-def gate-definition))
+    (alexandria:if-let ((gate (%gate-definition-cached-gate gate-def)))
+      gate
+      (setf (%gate-definition-cached-gate gate-def) (call-next-method)))))
 
 (defmethod gate-definition-to-gate ((gate-def static-gate-definition))
   (let* ((name (gate-definition-name gate-def))

--- a/src/operator-bind.lisp
+++ b/src/operator-bind.lisp
@@ -31,6 +31,7 @@
       (make-instance 'gate-application
                      :operator (named-operator operator)
                      :name-resolution gate-def
+                     :gate (gate-definition-to-gate gate-def)
                      :parameters (mapcar #'capture-param params)
                      :arguments (mapcar #'capture-arg qubits)))))
 

--- a/src/operator-bind.lisp
+++ b/src/operator-bind.lisp
@@ -26,11 +26,11 @@
               (formal (string-downcase (symbol-name arg))))
              (otherwise
               arg))))
-    (let ((gate (lookup-standard-gate operator)))
-      (assert (not (null gate)) (operator) "BUILD-GATE only takes standard gate names.")
+    (let ((gate-def (lookup-standard-gate operator)))
+      (assert (not (null gate-def)) (operator) "BUILD-GATE only takes standard gate names.")
       (make-instance 'gate-application
                      :operator (named-operator operator)
-                     :gate gate
+                     :name-resolution gate-def
                      :parameters (mapcar #'capture-param params)
                      :arguments (mapcar #'capture-arg qubits)))))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -304,6 +304,7 @@
    #:unresolved-application             ; CLASS
 
    #:gate-application                   ; CLASS
+   #:gate-application-gate              ; GENERIC, METHOD
 
    #:gate-definition                    ; CLASS
    #:static-gate-definition             ; CLASS

--- a/src/quil/README.txt
+++ b/src/quil/README.txt
@@ -1,0 +1,3 @@
+Aside from this text file, this directory contains Quil code (inside
+of files with a .quil extension) that is useful for parsing,
+compilation, etc.

--- a/src/quil/stdgates.quil
+++ b/src/quil/stdgates.quil
@@ -1,0 +1,137 @@
+### Quil standard gate defintions.
+
+## Pauli Gates
+
+DEFGATE I:
+    1, 0
+    0, 1
+
+DEFGATE X:
+    0, 1
+    1, 0
+
+DEFGATE Y:
+    0, -i
+    i, 0
+
+DEFGATE Z:
+    1, 0
+    0, -1
+
+
+## Hadamard Gate
+
+DEFGATE H:
+    1/sqrt(2), 1/sqrt(2)
+    1/sqrt(2), -1/sqrt(2)
+
+
+## Cartesian Rotation Gates
+
+DEFGATE RX(%theta):
+    cos(%theta/2),    -i*sin(%theta/2)
+    -i*sin(%theta/2), cos(%theta/2)
+
+DEFGATE RY(%theta):
+    cos(%theta/2), -sin(%theta/2)
+    sin(%theta/2), cos(%theta/2)
+
+DEFGATE RZ(%theta):
+    cis(-%theta/2), 0
+    0,              cis(%theta/2)
+
+
+## Controlled-NOT Variants
+
+DEFGATE CNOT:
+    1, 0, 0, 0
+    0, 1, 0, 0
+    0, 0, 0, 1
+    0, 0, 1, 0
+
+# Also known as the Toffoli gate.
+DEFGATE CCNOT:
+    1, 0, 0, 0, 0, 0, 0, 0
+    0, 1, 0, 0, 0, 0, 0, 0
+    0, 0, 1, 0, 0, 0, 0, 0
+    0, 0, 0, 1, 0, 0, 0, 0
+    0, 0, 0, 0, 1, 0, 0, 0
+    0, 0, 0, 0, 0, 1, 0, 0
+    0, 0, 0, 0, 0, 0, 0, 1
+    0, 0, 0, 0, 0, 0, 1, 0
+
+
+## Phase Gates
+
+DEFGATE S:
+    1, 0
+    0, i
+
+DEFGATE T:
+    1, 0
+    0, cis(pi/4)
+
+DEFGATE PHASE(%alpha):
+    1, 0
+    0, cis(%alpha)
+
+DEFGATE CPHASE00(%alpha):
+    cis(%alpha), 0, 0, 0
+    0,           1, 0, 0
+    0,           0, 1, 0
+    0,           0, 0, 1
+
+DEFGATE CPHASE01(%alpha):
+    1, 0,           0, 0
+    0, cis(%alpha), 0, 0
+    0, 0,           1, 0
+    0, 0,           0, 1
+
+DEFGATE CPHASE10(%alpha):
+    1, 0, 0,           0
+    0, 1, 0,           0
+    0, 0, cis(%alpha), 0
+    0, 0, 0,           1
+
+DEFGATE CPHASE(%alpha):
+    1, 0, 0, 0
+    0, 1, 0, 0
+    0, 0, 1, 0
+    0, 0, 0, cis(%alpha)
+
+DEFGATE CZ:
+    1, 0, 0,  0
+    0, 1, 0,  0
+    0, 0, 1,  0
+    0, 0, 0, -1
+
+## Swap Gates
+
+DEFGATE SWAP:
+    1, 0, 0, 0
+    0, 0, 1, 0
+    0, 1, 0, 0
+    0, 0, 0, 1
+
+# Also known as the Fredkin gate.
+DEFGATE CSWAP:
+    1, 0, 0, 0, 0, 0, 0, 0
+    0, 1, 0, 0, 0, 0, 0, 0
+    0, 0, 1, 0, 0, 0, 0, 0
+    0, 0, 0, 1, 0, 0, 0, 0
+    0, 0, 0, 0, 1, 0, 0, 0
+    0, 0, 0, 0, 0, 0, 1, 0
+    0, 0, 0, 0, 0, 1, 0, 0
+    0, 0, 0, 0, 0, 0, 0, 1
+
+DEFGATE ISWAP:
+    1, 0, 0, 0
+    0, 0, i, 0
+    0, i, 0, 0
+    0, 0, 0, 1
+
+DEFGATE PSWAP(%theta):
+    1, 0,           0,           0
+    0, 0,           cis(%theta), 0
+    0, cis(%theta), 0,           0
+    0, 0,           0,           1

--- a/src/quil/stdgates.quil
+++ b/src/quil/stdgates.quil
@@ -135,3 +135,9 @@ DEFGATE PSWAP(%theta):
     0, 0,           cis(%theta), 0
     0, cis(%theta), 0,           0
     0, 0,           0,           1
+
+DEFGATE PISWAP(%theta):
+    1, 0,               0,               0
+    0, cos(%theta/2),   i*sin(%theta/2), 0
+    0, i*sin(%theta/2), cos(%theta/2),   0
+    0, 0,               0,               1


### PR DESCRIPTION
This commit does a good helping of refactoring, further clarifying
confusion over what a gate is, how a standard gate rears its head, and
how CONTROLLED and DAGGER gates get simplified.

Three big notable things in this PR:

- Standard gates are read from a new file src/quil/stdgates.quil.

- GATE-APPLICATION-GATE is not an accessor anymore, but a function
      that computes and caches a gate object depending on the resolved
      name.

- Hooks to optimize the representation of a CONTROLLED gate and a
      DAGGER gate exist with the generic functions CONTROL-GATE and
      DAGGER-GATE, which are to be read as verbs.

This is intended to replace PR #217, and should **NOT** be merged only until @notmgsk's PR #150 is merged. (The reason to wait is because all of the standard gates are being boiled away to their Quil definitions, and thus will not be optimized any longer until that PR is merged.)

From Eric's PR:

- [x] `lookup-standard-gate` should return a `gate-definition` of sorts, _not_ a gate.
- [x] `resolve-applications` should be modified so that we stash away that definition in the `name-resolution` field.
- [x] We make generic functions `control-gate` and `dagger-gate` which are responsible for the kind of logic you wrote. This way the dispatch can be nicely specialized.
- [x] To `gate-application`, we add the `:writer` called `%set-gate-definition-gate`.
- [x] To `gate-application`, we add the `:reader` called `%get-gate-definition-gate`.
- [x] To `gate-application`, we make the `:initform` to the `gate` form `nil`.
- [x] We eliminate the `:accessor gate-definition-gate`, and instead make it a function that first tries to `%get-gate-definition-gate`, and if not, builds (but does not `%set`!) using the lifter.
- [x] We modify `operator-description-lifter` to make use of `control-gate` and `dagger-gate` GFs. This should make that function _much_ simpler, even simpler than before, since you're composing these GF's directly instead of making lambdas that are `make-instance`ing things all over.
- [x] Change the documentation to `operator-description-lifter` to be clear that it could construct any manner of `gate`-like object, but will try to produce a reasonable, direct, and efficient representation.
- [x] Make sure tests pass. (They're not right now!)
- [x] Fix the QVM in any way that this breaks it.