### PR TITLE
Define, signal, and handle specific conditions for compression issues

### DIFF
--- a/cl-quil-tests.asd
+++ b/cl-quil-tests.asd
@@ -38,4 +38,5 @@
                (:file "compiler-hook-tests")
                (:file "benchmarking-procedures-tests")
                (:file "typed-memory-tests")
-               (:file "approximation-tests")))
+               (:file "approximation-tests")
+               (:file "compressor-tests")))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -449,6 +449,10 @@ other's."
         ;; otherwise, we're obligated to do full unitary compilation.
         (decompile-instructions-into-full-unitary)))))
 
+(define-condition quil-compression-error (simple-error))
+(define-condition quil-compression-matrices-disagree (quil-compression-error))
+(define-condition quil-compression-states-disagree (quil-compression-error))
+(define-condition quil-compression-matrices-not-close (quil-compression-error))
 
 (defun check-contextual-compression-was-well-behaved (instructions
                                                       decompiled-instructions
@@ -481,19 +485,20 @@ other's."
                   (stretched-matrix (or (make-matrix-from-quil instructions :relabeling relabeling)
                                         (return-from check-quil-agrees-as-matrices nil)))
                   (decompiled-matrix
-                   (make-matrix-from-quil decompiled-instructions
-                                          :relabeling relabeling))
+                    (make-matrix-from-quil decompiled-instructions
+                                           :relabeling relabeling))
                   (reduced-matrix
-                   (kron-matrix-up (make-matrix-from-quil reduced-instructions
-                                                          :relabeling relabeling)
-                                   (ilog2 (magicl:matrix-rows stretched-matrix))))
+                    (kron-matrix-up (make-matrix-from-quil reduced-instructions
+                                                           :relabeling relabeling)
+                                    (ilog2 (magicl:matrix-rows stretched-matrix))))
                   (reduced-decompiled-matrix
-                   (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions
-                                                          :relabeling relabeling)
-                                   (ilog2 (magicl:matrix-rows stretched-matrix)))))
-             (assert (matrix-equality stretched-matrix
+                    (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions
+                                                           :relabeling relabeling)
+                                    (ilog2 (magicl:matrix-rows stretched-matrix)))))
+             (unless (matrix-equality stretched-matrix
                                       (scale-out-matrix-phases reduced-matrix
-                                                               stretched-matrix)))
+                                                               stretched-matrix))
+               (signal ))
              (when decompiled-instructions
                (assert (matrix-equality stretched-matrix
                                         (scale-out-matrix-phases decompiled-matrix
@@ -508,18 +513,18 @@ other's."
                                             start-wf
                                             wf-qc))
                   (final-wf-reduced-instrs-collinearp
-                   (or (and (eql final-wf ':not-simulated)
-                            (eql final-wf-reduced-instrs ':not-simulated))
-                       (collinearp final-wf final-wf-reduced-instrs)))
+                    (or (and (eql final-wf ':not-simulated)
+                             (eql final-wf-reduced-instrs ':not-simulated))
+                        (collinearp final-wf final-wf-reduced-instrs)))
                   (final-wf-reduced-prep (nondestructively-apply-instrs-to-wf
                                           reduced-decompiled-instructions
                                           start-wf
                                           wf-qc))
                   (final-wf-reduced-prep-collinearp
-                   (or (null decompiled-instructions)
-                       (and (eql final-wf ':not-simulated)
-                            (eql final-wf-reduced-prep ':not-simulated))
-                       (collinearp final-wf final-wf-reduced-prep))))
+                    (or (null decompiled-instructions)
+                        (and (eql final-wf ':not-simulated)
+                             (eql final-wf-reduced-prep ':not-simulated))
+                        (collinearp final-wf final-wf-reduced-prep))))
              (assert final-wf-reduced-instrs-collinearp
                      (final-wf final-wf-reduced-instrs)
                      "During careful checking of instruction compression, the produced ~
@@ -535,11 +540,11 @@ other's."
            (alexandria:when-let ((stretched-matrix (make-matrix-from-quil instructions)))
              (let* ((n (ilog2 (magicl:matrix-rows stretched-matrix)))
                     (reduced-matrix
-                     (kron-matrix-up (make-matrix-from-quil reduced-instructions)
-                                     (ilog2 (magicl:matrix-rows stretched-matrix))))
+                      (kron-matrix-up (make-matrix-from-quil reduced-instructions)
+                                      (ilog2 (magicl:matrix-rows stretched-matrix))))
                     (reduced-decompiled-matrix
-                     (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions)
-                                     (ilog2 (magicl:matrix-rows stretched-matrix)))))
+                      (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions)
+                                      (ilog2 (magicl:matrix-rows stretched-matrix)))))
                (assert (matrix-equality stretched-matrix
                                         (scale-out-matrix-phases reduced-matrix stretched-matrix)))
                (when decompiled-instructions

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -461,13 +461,13 @@ other's."
   ())
 
 (define-condition compression-states-disagree-error (compiler-correctness-error)
-  ((final-wf :initarg :final-wf :accessor compiler-correctness-error-final-wf)
-   (final-wf-reduced :initarg :final-wf-reduced :accessor compiler-correctness-error-final-wf-reduced)
-   (type :initarg :type :accessor compiler-correctness-error-type))
+  ((final-wf :initarg :final-wf :reader compiler-correctness-error-final-wf)
+   (final-wf-reduced :initarg :final-wf-reduced :reader compiler-correctness-error-final-wf-reduced)
+   (type :initarg :type :reader compiler-correctness-error-type))
   (:report
    (lambda (c s)
      (declare (ignore c))
-     (format s "During careful checking of instruction compression, the wavefunction produced by by ~A was detected to not be collinear with the target wavefunction."
+     (format s "During careful checking of instruction compression, the wavefunction produced by ~A was detected to not be collinear with the target wavefunction."
              (compiler-correctness-error-type c)))))
 
 (define-condition compression-matrices-not-close-error (compiler-correctness-error)

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -454,14 +454,20 @@ other's."
   `(unless ,check-form
      (error ',condition-name ,@init-forms)))
 
-(define-condition quil-compression-error (simple-error) ())
-(define-condition quil-compression-matrices-disagree-error (quil-compression-error) ())
+(define-condition quil-compression-error (error)
+  ())
+
+(define-condition quil-compression-matrices-disagree-error (quil-compression-error)
+  ())
+
 (define-condition quil-compression-states-disagree-error (quil-compression-error)
   ((final-wf :initarg :final-wf :accessor quil-compression-error-final-wf)
    (final-wf-reduced :initarg :final-wf-reduced :accessor quil-compression-error-final-wf-reduced)
    (type :initarg :type :accessor quil-compression-error-type))
-  (:report (lambda (c s) (format s "During careful checking of instruction compression, the wavefunction produced by by ~A was detected to not be collinear with the target wavefunction."
-                            (quil-compression-error-type c)))))
+  (:report
+   (lambda (c s) (format s "During careful checking of instruction compression, the wavefunction produced by by ~A was detected to not be collinear with the target wavefunction."
+                    (quil-compression-error-type c)))))
+
 (define-condition quil-compression-matrices-not-close-error (quil-compression-error)
   ()
   (:report (lambda (c s) (format s "During careful checking of instruction compression, the recomputed instruction sequence has an unreasonably large fidelity drop from the original sequence."))))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -455,14 +455,14 @@ other's."
      (error ',condition-name ,@init-forms)))
 
 (define-condition quil-compression-error (simple-error) ())
-(define-condition quil-compression-matrices-disagree (quil-compression-error) ())
-(define-condition quil-compression-states-disagree (quil-compression-error)
+(define-condition quil-compression-matrices-disagree-error (quil-compression-error) ())
+(define-condition quil-compression-states-disagree-error (quil-compression-error)
   ((final-wf :initarg :final-wf :accessor quil-compression-error-final-wf)
    (final-wf-reduced :initarg :final-wf-reduced :accessor quil-compression-error-final-wf-reduced)
    (type :initarg :type :accessor quil-compression-error-type))
   (:report (lambda (c s) (format s "During careful checking of instruction compression, the wavefunction produced by by ~A was detected to not be collinear with the target wavefunction."
                             (quil-compression-error-type c)))))
-(define-condition quil-compression-matrices-not-close (quil-compression-error)
+(define-condition quil-compression-matrices-not-close-error (quil-compression-error)
   ()
   (:report (lambda (c s) (format s "During careful checking of instruction compression, the recomputed instruction sequence has an unreasonably large fidelity drop from the original sequence."))))
 
@@ -508,13 +508,13 @@ other's."
                                                            :relabeling relabeling)
                                     (ilog2 (magicl:matrix-rows stretched-matrix)))))
              (assert-compiler-correctness
-              quil-compression-matrices-disagree
+              quil-compression-matrices-disagree-error
               (and (matrix-equality stretched-matrix
                                     (scale-out-matrix-phases reduced-matrix
                                                              stretched-matrix))))
              (when decompiled-instructions
                (assert-compiler-correctness
-                quil-compression-matrices-disagree
+                quil-compression-matrices-disagree-error
                 (and (matrix-equality stretched-matrix
                                       (scale-out-matrix-phases decompiled-matrix
                                                                stretched-matrix))
@@ -541,10 +541,10 @@ other's."
                              (eql final-wf-reduced-prep ':not-simulated))
                         (collinearp final-wf final-wf-reduced-prep))))
              (assert-compiler-correctness
-              quil-compression-states-disagree
+              quil-compression-states-disagree-error
               final-wf-reduced-instrs-collinearp)
              (assert-compiler-correctness
-              quil-compression-states-disagree
+              quil-compression-states-disagree-error
               final-wf-reduced-prep-collinearp)))
 
          (check-quil-is-near-as-matrices ()
@@ -557,7 +557,7 @@ other's."
                       (kron-matrix-up (make-matrix-from-quil reduced-decompiled-instructions)
                                       (ilog2 (magicl:matrix-rows stretched-matrix)))))
                (assert-compiler-correctness
-                quil-compression-matrices-not-close
+                quil-compression-matrices-not-close-error
                 (matrix-equality stretched-matrix
                                  (scale-out-matrix-phases reduced-matrix stretched-matrix)))
                (when decompiled-instructions
@@ -572,7 +572,7 @@ other's."
                    (append-instructions-to-lschedule ls-reduced reduced-instructions)
                    (append-instructions-to-lschedule ls-reduced-decompiled reduced-decompiled-instructions)
                    (assert-compiler-correctness
-                    quil-compression-matrices-not-close
+                    quil-compression-matrices-not-close-error
                     (>= (* trace-fidelity
                            (lscheduler-calculate-fidelity ls-reduced-decompiled chip-spec))
                         (lscheduler-calculate-fidelity ls-reduced chip-spec)))))))))

--- a/src/compressor/wavefunctions.lisp
+++ b/src/compressor/wavefunctions.lisp
@@ -169,13 +169,14 @@ If DESTRUCTIVE-UPDATE is T, we will update AQVM's internal structure to correlat
   "Given a wavefunction WF, represented as an array of complex doubles, together with a list QC of qubit indices describing what the components of the wavefunction represent, applies the instruction INSTR and returns the resulting wavefunction (with the same qubit ordering).  Does not modify any of its inputs."
   (unless (eq wf ':not-simulated)
     (handler-case 
-        (let* ((qubit-indices (mapcar #'qubit-index (application-arguments instr)))
-               (rewiring (mapcar (lambda (q) (- (length qc) 1 (position q qc)))
-                                 qubit-indices))
-               (matrix (gate-matrix instr)))
-          (nondestructively-apply-matrix-to-vector
-           (kq-gate-on-lines matrix (length qc) rewiring)
-           wf))
+        (progn
+          (let* ((qubit-indices (mapcar #'qubit-index (application-arguments instr)))
+                 (rewiring (mapcar (lambda (q) (- (length qc) 1 (position q qc)))
+                                   qubit-indices))
+                 (matrix (gate-matrix instr)))
+            (nondestructively-apply-matrix-to-vector
+             (kq-gate-on-lines matrix (length qc) rewiring)
+             wf)))
       (unknown-gate-parameter () ':not-simulated))))
 
 (defun nondestructively-apply-instrs-to-wf (instrs wf qc)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -422,6 +422,14 @@
   (:export
    #:standard-qubit-relabeler           ; FUNCTION
    )
+
+  ;; compressor/compressor.lisp
+  (:export
+   #:quil-compression-error                      ; CONDITION
+   #:quil-compression-matrices-disagree-error    ; CONDITION
+   #:quil-compression-states-disagree-error      ; CONDITION
+   #:quil-compression-matrices-not-close-error   ; CONDITION
+   )
   )
 
 (defpackage #:cl-quil.clifford

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -425,10 +425,10 @@
 
   ;; compressor/compressor.lisp
   (:export
-   #:quil-compression-error                      ; CONDITION
-   #:quil-compression-matrices-disagree-error    ; CONDITION
-   #:quil-compression-states-disagree-error      ; CONDITION
-   #:quil-compression-matrices-not-close-error   ; CONDITION
+   #:compiler-correctness-error                  ; CONDITION
+   #:compression-matrices-disagree-error         ; CONDITION
+   #:compression-states-disagree-error           ; CONDITION
+   #:compression-matrices-not-close-error        ; CONDITION
    )
   )
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -425,11 +425,13 @@
 
   ;; compressor/compressor.lisp
   (:export
-   #:quil-compression-error                     ; CONDITION
-   #:quil-compression-matrices-disagree-error   ; CONDITION
-   #:quil-compression-states-disagree-error     ; CONDITION
-   #:quil-compression-matrices-not-equal-error  ; CONDITION
-   #:quil-compression-unnacceptable-trace-fidelity-drop-error ; CONDITION
+   #:compression-error                    ; CONDITION
+   #:compression-matrices-disagree-error  ; CONDITION
+   #:compression-states-disagree-error    ; CONDITION
+   #:compression-matrices-not-equal-error ; CONDITION
+   #:compression-error-final-wf           ; FUNCTION
+   #:compression-error-final-wf-reduced   ; FUNCTION
+   #:compression-error-type               ; FUNCTION
    )
   )
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -425,10 +425,11 @@
 
   ;; compressor/compressor.lisp
   (:export
-   #:compiler-correctness-error                  ; CONDITION
-   #:compression-matrices-disagree-error         ; CONDITION
-   #:compression-states-disagree-error           ; CONDITION
-   #:compression-matrices-not-close-error        ; CONDITION
+   #:quil-compression-error                     ; CONDITION
+   #:quil-compression-matrices-disagree-error   ; CONDITION
+   #:quil-compression-states-disagree-error     ; CONDITION
+   #:quil-compression-matrices-not-equal-error  ; CONDITION
+   #:quil-compression-unnacceptable-trace-fidelity-drop-error ; CONDITION
    )
   )
 


### PR DESCRIPTION
This is mostly to remove the handler that has a `error` case. If an unrelated error was caused around the same time that compression occurs, it would be caught by this handler and not provide a particularly useful error message.