### PR TITLE
Saner version checking

### DIFF
--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -36,6 +36,23 @@
   :test #'string=
   :documentation "The git hash of the quilc repo.")
 
+(defun version-string-values (version &key (delimiter #\.))
+  (check-type version string)
+  (split-sequence:split-sequence delimiter version))
+
+(defun version> (version-a version-b &key (test #'>) (key #'parse-integer))
+  "Test whether VERSION-A is \"greater than\" VERSION-B, where both
+are version strings with components \"major.minor.patch\". Comparison
+is made left-to-right component-wise with the binary predicate TEST on
+the result of applying KEY to each component, terminating with the
+first non-nil result."
+  (check-type version-a string)
+  (check-type version-b string)
+  (loop :for a :in (mapcar key (version-string-values version-a))
+        :for b :in (mapcar key (version-string-values version-b))
+        :when (funcall test a b) :do
+          (return-from version> t)))
+
 (defun latest-sdk-version ()
   "Get the latest SDK quilc version, or NIL if unavailable."
   (handler-case
@@ -54,5 +71,5 @@
   "Test whether the current SDK version is the latest SDK
 version. Second value returned indicates the latest version."
   (let ((latest (latest-sdk-version)))
-    (values (and latest (not (string= latest current-version)))
+    (values (and latest (version> latest current-version))
             latest)))

--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -40,19 +40,6 @@
   (check-type version string)
   (split-sequence:split-sequence delimiter version))
 
-(defun version> (version-a version-b &key (test #'>) (key #'parse-integer))
-  "Test whether VERSION-A is \"greater than\" VERSION-B, where both
-are version strings with components \"major.minor.patch\". Comparison
-is made left-to-right component-wise with the binary predicate TEST on
-the result of applying KEY to each component, terminating with the
-first non-nil result."
-  (check-type version-a string)
-  (check-type version-b string)
-  (loop :for a :in (mapcar key (version-string-values version-a))
-        :for b :in (mapcar key (version-string-values version-b))
-        :when (funcall test a b) :do
-          (return-from version> t)))
-
 (defun latest-sdk-version ()
   "Get the latest SDK quilc version, or NIL if unavailable."
   (handler-case
@@ -71,5 +58,5 @@ first non-nil result."
   "Test whether the current SDK version is the latest SDK
 version. Second value returned indicates the latest version."
   (let ((latest (latest-sdk-version)))
-    (values (and latest (version> latest current-version))
+    (values (and latest (uiop:version< current-version latest))
             latest)))

--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -36,10 +36,6 @@
   :test #'string=
   :documentation "The git hash of the quilc repo.")
 
-(defun version-string-values (version &key (delimiter #\.))
-  (check-type version string)
-  (split-sequence:split-sequence delimiter version))
-
 (defun latest-sdk-version ()
   "Get the latest SDK quilc version, or NIL if unavailable."
   (handler-case

--- a/app/tests/misc-tests.lisp
+++ b/app/tests/misc-tests.lisp
@@ -11,4 +11,10 @@
         ;; If the network is down, then update-available-p is NIL, but
         ;; we don't want to error in that case. Skip instead.
         (is update)
-        (skip))))
+        (skip)))
+
+  (with-mocked-function-definitions
+      ((quilc::latest-sdk-version (lambda () "1.0.0")))
+    (multiple-value-bind (update-available-p update)
+        (quilc::sdk-update-available-p "1.5.0")
+      (is (not update-available-p)))))

--- a/app/tests/utils.lisp
+++ b/app/tests/utils.lisp
@@ -1,0 +1,31 @@
+(in-package :quilc-tests)
+
+(defmacro with-mocked-function-definitions (defs &body body)
+  "Dynamically re-define global functions named in DEFS within BODY.
+
+DEFS are LET-like bindings (not FLET) whose binding keys are symbols
+that name global functions, and whose binding values are evaluated and
+return functions. These functions should have conforming lambda lists,
+types, and return values, though this is not enforced by the macro.
+
+e.g.
+(defun testfunc (a b) (+ a b))
+(with-mocked-function-definitions
+    ((testfunc (lambda (a b) (* a b))))
+  (testfunc 3 4)) ;; => 12
+"
+  (let* ((names (mapcar #'first defs))
+         (gnames (mapcar (alexandria:compose #'gensym #'symbol-name) names)))
+    `(let (,@(loop :for name :in names
+                   :for gname :in gnames
+                   :collect `(,gname (fdefinition ',name))))
+       (unwind-protect
+            (progn
+              (setf ,@(loop :for (name value) :in defs
+                            :collect `(fdefinition ',name)
+                            :collect `,value))
+              ,@body)
+         (setf ,@(loop :for name :in names
+                       :for gname :in gnames
+                       :collect `(fdefinition ',name)
+                       :collect `,gname))))))

--- a/app/tests/utils.lisp
+++ b/app/tests/utils.lisp
@@ -1,4 +1,4 @@
-(in-package :quilc-tests)
+(in-package #:quilc-tests)
 
 (defmacro with-mocked-function-definitions (defs &body body)
   "Dynamically re-define global functions named in DEFS within BODY.

--- a/quilc-tests.asd
+++ b/quilc-tests.asd
@@ -19,4 +19,5 @@
                (:file "suite")
                (:file "faithfulness-tests")
                (:file "rpcq-tests")
-               (:file "misc-tests")))
+               (:file "misc-tests")
+               (:file "utils")))

--- a/quilc-tests.asd
+++ b/quilc-tests.asd
@@ -16,8 +16,8 @@
   :pathname "app/tests/"
   :serial t
   :components ((:file "package")
+               (:file "utils")
                (:file "suite")
                (:file "faithfulness-tests")
                (:file "rpcq-tests")
-               (:file "misc-tests")
-               (:file "utils")))
+               (:file "misc-tests")))


### PR DESCRIPTION
Previously, we said "1.2.0" was newer than "1.1.0" because we relied
on string= for kinda valid reasons.