### PR TITLE
fix type of 'final_rewiring' in quil_to_native_quil response

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -417,15 +417,19 @@ HTTP server for good.
                      :when (quil::comment instr)
                        :do (cond
                              ((uiop:string-prefix-p "Exiting rewiring: " (quil::comment instr))
-                              (setf (gethash "final_rewiring" *statistics-dictionary*)
-                                    (subseq (quil::comment instr) (length "Exiting rewiring: "))))
+                              (let ((*read-eval* nil))
+                                (setf (gethash "final_rewiring" *statistics-dictionary*)
+                                      (read-from-string
+                                       (subseq (quil::comment instr) (length "Exiting rewiring: "))))))
                              ((uiop:string-prefix-p "Entering/exiting rewiring: " (quil::comment instr))
                               (let ((comment (quil::comment instr))
-                                    (length (length "Entering/exiting rewiring: (")))
+                                    (length (length "Entering/exiting rewiring: ("))
+                                    (*read-eval* nil))
                                 (setf (gethash "final_rewiring" *statistics-dictionary*)
-                                      (subseq (quil::comment instr) length (- (length comment)
-                                                                              (/ (- (length comment) length) 2)
-                                                                              2)))))
+                                      (read-from-string
+                                       (subseq (quil::comment instr) length (- (length comment)
+                                                                               (/ (- (length comment) length) 2)
+                                                                               2))))))
                              (t nil))
                      ;; if there's a HALT instruction with a rewiring comment on
                      ;; it, we need to migrate the comment up one instruction


### PR DESCRIPTION
This is declared as `(:list :integer)` in the RPCQ spec, but quilc was putting the unevaluated `:string` into the slot instead.

(cf. https://rigetti-forest.slack.com/archives/C77UQCY57/p1557087073119200 )