### PR TITLE
Move the DIMENSION slot from the GATE abstract base class into the PARAMETERIZED-GATE class

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -229,7 +229,7 @@ EXPRESSION should be an arithetic (Lisp) form which refers to LAMBDA-PARAMS."
 (defmethod gate-definition-qubits-needed ((gate permutation-gate-definition))
   (ilog2 (length (permutation-gate-definition-permutation gate))))
 
-(defun permutation-from-gate-entries-p (entries)
+(defun permutation-from-gate-entries (entries)
   "Create the permutation (list of natural numbers) that represents
 the input matrix ENTRIES. Return nil if ENTRIES cannot be represented
 as a permutation."
@@ -242,13 +242,13 @@ as a permutation."
             ((0.0d0) nil)
             ((1.0d0) (cond
                        ((or found-one (nth j perm))
-                        (return-from permutation-from-gate-entries-p nil))
+                        (return-from permutation-from-gate-entries nil))
                        (t
                         (setf (nth j perm) i)
                         (setf found-one t))))
-            (otherwise (return-from permutation-from-gate-entries-p nil))))
+            (otherwise (return-from permutation-from-gate-entries nil))))
         (unless found-one
-          (return-from permutation-from-gate-entries-p nil))))))
+          (return-from permutation-from-gate-entries nil))))))
 
 (defun make-gate-definition (name parameters entries)
   "Make a static or parameterized gate definition instance, depending on the existence of PARAMETERS."
@@ -259,7 +259,7 @@ as a permutation."
                     :name name
                     :parameters parameters
                     :entries entries)
-      (alexandria:if-let ((perm (permutation-from-gate-entries-p entries)))
+      (alexandria:if-let ((perm (permutation-from-gate-entries entries)))
         (make-instance 'permutation-gate-definition
                        :name name
                        :permutation perm)

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -101,9 +101,8 @@
 
 (defun valid-pauli-dim (m n)
   "T if M and N are valid dimensions of a Pauli matrix, NIL otherwise."
-  (and (= m n) (>= m n 2)
-       (cl-quil::power-of-two-p m)
-       (cl-quil::power-of-two-p n)))
+  (and (= m n)
+       (cl-quil::positive-power-of-two-p m)))
 
 (defun concatenate-or-nil (a b)
   "If A and B are both not NIL, concatenate them and return a STRING."

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -104,10 +104,10 @@
 (defmethod initialize-instance :after ((gate simple-gate) &key)
   (with-slots (matrix) gate
     (assert (and (magicl:square-matrix-p matrix)
-                 (power-of-two-p (magicl:matrix-rows matrix)))
+                 (positive-power-of-two-p (magicl:matrix-rows matrix)))
             (matrix)
-            "MATRIX must be of dimension NxN where N is a power of two. ~
-             Actual dimensions are ~a x ~a."
+            "MATRIX must be square whose dimension is a positive power of two.~@
+             Actual dimensions are ~D x ~D."
             (magicl:matrix-rows matrix)
             (magicl:matrix-cols matrix))))
 
@@ -126,10 +126,10 @@
 
 (defmethod initialize-instance :after ((gate permutation-gate) &key)
   (with-slots (permutation) gate
-    (assert (power-of-two-p (length permutation))
+    (assert (positive-power-of-two-p (length permutation))
             (permutation)
-            "PERMUTATION length must be a power of two. ~@
-             PERMUTATION ~A has length ~a which is not a power of two."
+            "PERMUTATION length must be a positive power of two. ~@
+             PERMUTATION ~A has length ~D which is not a power of two."
             permutation (length permutation))
     (check-permutation permutation)))
 
@@ -179,9 +179,9 @@
 
 (defmethod initialize-instance :after ((gate parameterized-gate) &key)
   (with-slots (dimension) gate
-    (assert (power-of-two-p dimension)
+    (assert (positive-power-of-two-p dimension)
             (dimension)
-            "DIMENSION ~A must be a power of two."
+            "DIMENSION ~D must be a positive power of two."
             dimension)))
 
 (defmethod gate-matrix ((gate parameterized-gate) &rest parameters)

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -152,14 +152,11 @@
          (bits (make-array n :element-type 'bit :initial-element 0)))
     (flet ((mark-bit (i)
              (cond
+               ((not (<= 0 i (1- n)))
+                (error "Invalid permutation ~A. Entry out of range [0, ~A): ~A" perm n i))
                ((zerop (sbit bits i)) (setf (sbit bits i) 1))
                (t (error "Invalid permutation ~A. Found duplicate entry: ~A" perm i)))))
-      ;; Mark all of the bits.
-      (mapc #'mark-bit perm)
-      ;; Check that they're all marked.
-      (dotimes (i n t)
-        (when (zerop (sbit bits i))
-          (error "Invalid permutation ~A. Missing entry: ~A" perm i))))))
+      (mapc #'mark-bit perm))))
 
 (defun make-permutation-gate (name &rest permutation)
   "Make a permutation gate from the given PERMUTATION."

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -897,15 +897,15 @@ INPUT-STRING that triggered the condition."
 (defun parse-gate-entries-as-permutation (body-lines name)
   (multiple-value-bind (parsed-entries rest-lines)
       (parse-permutation-gate-entries body-lines)
-    (unless (validate-gate-permutation-size-p (length parsed-entries))
-      (quil-parse-error "Permutation gate entries do not represent a square matrix."))
+    (validate-gate-permutation-size (length parsed-entries))
     (values (make-instance 'permutation-gate-definition
                            :name name
                            :permutation parsed-entries)
             rest-lines)))
 
-(defun validate-gate-permutation-size-p (size)
-  (positive-power-of-two-p size))
+(defun validate-gate-permutation-size (size)
+  (unless (positive-power-of-two-p size)
+    (quil-parse-error "Permutation gate entries do not represent a square matrix.")))
 
 (defun parse-gate-entries-as-matrix (body-lines params name)
   ;; Parse out the gate entries.

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -797,9 +797,7 @@ INPUT-STRING that triggered the condition."
 (defun validate-gate-matrix-size (gate-name num-entries)
   "For the gate named GATE-NAME, check that NUM-ENTRIES is a valid number of entries for a gate matrix."
   (flet ((perfect-square-p (n)
-           (= n (expt (isqrt n) 2)))
-         (power-of-two-p (n)
-           (zerop (logand n (1- n)))))
+           (= n (expt (isqrt n) 2))))
     (unless (<= 4 num-entries)
       (quil-parse-error "There must be at least 4 entries (a one-qubit ~
                          operator) for the gate ~A being defined. Got ~D."
@@ -811,7 +809,7 @@ INPUT-STRING that triggered the condition."
                          matrix. I got ~D entries."
                         gate-name
                         num-entries))
-    (unless (power-of-two-p (isqrt num-entries))
+    (unless (positive-power-of-two-p (isqrt num-entries))
       (quil-parse-error "The gate ~A being defined isn't a square 2^n x 2^n ~
                          matrix. In particular, it is a ~D x ~D matrix."
                         gate-name
@@ -907,7 +905,7 @@ INPUT-STRING that triggered the condition."
             rest-lines)))
 
 (defun validate-gate-permutation-size-p (size)
-  (power-of-two-p size))
+  (positive-power-of-two-p size))
 
 (defun parse-gate-entries-as-matrix (body-lines params name)
   ;; Parse out the gate entries.

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -129,6 +129,6 @@ Return two values:
   "Compute integer logarithm of X to the base 2."
   (1- (integer-length x)))
 
-(defun power-of-two-p (n)
+(defun positive-power-of-two-p (n)
   "Given an INTEGER N, return true if N is a power of 2, greater than 1."
-  (zerop (logand n (1- n))))
+  (and (> n 1) (= 1 (logcount n))))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -242,3 +242,27 @@
         :do (progn
               (is (quil::positive-power-of-two-p power-of-two))
               (is (not (quil::positive-power-of-two-p (1- power-of-two)))))))
+
+(deftest test-check-permutation ()
+  "Test that CHECK-PERMUTATION signals error iff input is not valid."
+  ;; Duplicates
+  (signals simple-error (quil::check-permutation '(0 0)))
+  (signals simple-error (quil::check-permutation '(0 0 1)))
+  (signals simple-error (quil::check-permutation '(0 1 0)))
+  (signals simple-error (quil::check-permutation '(1 0 0)))
+  (signals simple-error (quil::check-permutation '(0 1 2 3 4 5 2)))
+  ;; Out of range values
+  (signals simple-error (quil::check-permutation '(1)))
+  (signals simple-error (quil::check-permutation '(-1)))
+  (signals simple-error (quil::check-permutation '(0 2)))
+  (signals simple-error (quil::check-permutation '(2 0)))
+  (signals simple-error (quil::check-permutation '(0 1 3)))
+  (signals simple-error (quil::check-permutation '(0 3 1)))
+  (signals simple-error (quil::check-permutation '(3 1 0)))
+  (signals simple-error (quil::check-permutation '(0 1 2 5 3)))
+  ;; Valid permutations. Grows as n!, so don't get too crazy here.
+  (dotimes (n 6)
+    (alexandria:map-permutations
+     (lambda (permutation)
+       (not-signals simple-error (quil::check-permutation permutation)))
+     (alexandria:iota n))))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -231,3 +231,14 @@
     (is (= (* 11 11) (quil::chip-spec-n-links chip)))
     (is (plusp (length (parsed-program-executable-code prgm))))
     (is (plusp (length (parsed-program-executable-code (compiler-hook prgm chip)))))))
+
+(deftest test-positive-power-of-two-p ()
+  "Test that POSITIVE-POWER-OF-TWO-P does what it says on the tin."
+  (is (not (quil::positive-power-of-two-p -2)))
+  (is (not (quil::positive-power-of-two-p -1)))
+  (is (not (quil::positive-power-of-two-p 0)))
+  (loop :for power-of-two = 2 :then (* 2 power-of-two)
+        :while (<= power-of-two 1024)
+        :do (progn
+              (is (quil::positive-power-of-two-p power-of-two))
+              (is (not (quil::positive-power-of-two-p (1- power-of-two)))))))


### PR DESCRIPTION
I am not sure if this fix is semantically correct, but it fixed `make test` in the qvm repo :).

Note that there exists a wrapper function `cl-quil:make-permutation-gate`. As far as I can tell it's not used anywhere, but in theory the handful of individual calls to `(make-instance 'permutation-gate ...)` could be replaced with calls to `make-permutation-gate`, which handles setting `:dimension` for you.

Fixes rigetti/qvm#85