### PR TITLE
Free the foreign string returned by tweedledum_synthesis_dbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 quilc
 .idea/
 system-index.txt
+*.so
+*.dylib

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,13 @@ test-quilc:
 		--eval "(ql:quickload :quilc-tests)" \
 		--eval "(asdf:test-system :quilc)"
 
+# You can specify a different c++17-compatible compiler via the CXX
+# variable. For example: make CXX=/usr/bin/clang++ test-tweedledum
+test-tweedledum:
+	$(QUICKLISP) \
+		--eval "(ql:quickload :cl-quil/tweedledum-tests)" \
+		--eval "(asdf:test-system :cl-quil/tweedledum-tests)"
+
 test-ccl:
 	ccl -n --batch --load $(QUICKLISP_HOME)/setup.lisp \
 		--eval '(push (truename ".") asdf:*central-registry*)' \

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test-ccl:
 clean:
 	rm -f quilc system-index.txt build-output.log
 	rm -f coverage-report/*.html
+	rm -f src/contrib/**/*.so src/contrib/**/*.dylib
 
 clean-cache:
 	@echo "Deleting $(LISP_CACHE)"

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -145,7 +145,8 @@
       (unless (uiop:directory-exists-p tweedlelibdir)
         (error "tweedledum library directory missing. Did you run ~
                 `git submodule init && git submodule update --init`?"))
-      (let ((c++17 "clang++-7")
+      (let ((c++17 (or (uiop:getenv "CXX")
+                       "clang++-7"))
             (c++17-args (list "-std=c++17"
                               "-shared"
                               "-fPIC"

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -25,7 +25,7 @@
   "T if the tweedledum shared library has been loaded by CFFI.")
 
 (defcfun (%synthesis-dbs "tweedledum_synthesis_dbs")
-    :string
+    (:string :free-from-foreign t)
   (perm (:pointer :uint32))
   (size :int))
 


### PR DESCRIPTION
Fixes #221

- Free the foreign string returned by `tweedledum_synthesis_dbs`
- Add `*.so` and `*.dylib` to .gitignore
- Add `test-tweedledum` target to Makefile
- Remove shared objects in `src/contrib/**` during make clean