### PR TITLE
 EXPOSE the default quilc server ports in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ ADD . /src/quilc
 WORKDIR /src/quilc
 RUN git clean -fdx && make ${build_target}
 
+EXPOSE 5555
+EXPOSE 6000
+
 ENTRYPOINT ["./quilc"]

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ you would like to change the port of the server to PORT, you can alter the comma
 docker run --rm -it -p PORT:PORT rigetti/quilc -R -p PORT
 ```
 
+Ports 5555 and 6000 are exposed using the EXPOSE directive in the `rigetti/quilc` image, so
+you can additionally use the `-P` to automatically bind these ports to randomly assigned
+host ports. You can then inspect the mapping using `docker port CONTAINER [PORT]`.
+
 ## Release Process
 
 1. Update `VERSION.txt` and dependency versions (if applicable) and push the commit to `master`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # QUILC
 
 [![pipeline status](https://gitlab.com/rigetti/quilc/badges/master/pipeline.svg)](https://gitlab.com/rigetti/quilc/commits/master)
+[![docker pulls](https://img.shields.io/docker/pulls/rigetti/quilc.svg)](https://hub.docker.com/r/rigetti/quilc)
 
 Quilc is an advanced optimizing compiler for the quantum instruction
 language Quil, licensed under the [Apache 2.0 license](LICENSE.txt).
@@ -215,8 +216,8 @@ docker run --rm -it -p PORT:PORT rigetti/quilc -R -p PORT
 ```
 
 Ports 5555 and 6000 are exposed using the EXPOSE directive in the `rigetti/quilc` image, so
-you can additionally use the `-P` to automatically bind these ports to randomly assigned
-host ports. You can then inspect the mapping using `docker port CONTAINER [PORT]`.
+you can additionally use the `-P` option to automatically bind these container ports to randomly
+assigned host ports. You can then inspect the mapping using `docker port CONTAINER [PORT]`.
 
 ## Release Process
 


### PR DESCRIPTION
Fixes #213.

Also adds the docker pulls badge to the README, which shows 4k pulls! :)