### PR TITLE
Add POWER-OF-TWO-P and call it in CLIFFORD-STABILIZER-ACTION

### DIFF
--- a/src/clifford/stabilizer.lisp
+++ b/src/clifford/stabilizer.lisp
@@ -274,7 +274,7 @@ but the symbols may be uninterned or named differently.
                         ;; record the X or Z variable in that bit's
                         ;; running list. In the end, the running list
                         ;; represents a disjunction of contributions.
-                        (when (power-of-two-p i) ; X and Z's will have power of two indexes.
+                        (when (quil::power-of-two-p i) ; X and Z's will have power of two indexes.
                           (let ((var (nth (1- (integer-length i)) variables)))
                             ;; The var that contributes to X- and Z-FACTORS
                             (loop :with bits := (pauli-index cp)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -129,6 +129,10 @@ Return two values:
   "Compute integer logarithm of X to the base 2."
   (1- (integer-length x)))
 
+(defun power-of-two-p (n)
+  "Given an INTEGER N, return true if N is a power of 2."
+  (and (plusp n) (= 1 (logcount n))))
+
 (defun positive-power-of-two-p (n)
   "Given an INTEGER N, return true if N is a power of 2, greater than 1."
-  (and (> n 1) (= 1 (logcount n))))
+  (and (> n 1) (power-of-two-p n)))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -232,16 +232,25 @@
     (is (plusp (length (parsed-program-executable-code prgm))))
     (is (plusp (length (parsed-program-executable-code (compiler-hook prgm chip)))))))
 
-(deftest test-positive-power-of-two-p ()
-  "Test that POSITIVE-POWER-OF-TWO-P does what it says on the tin."
+(deftest test-power-of-two-p ()
+  "Test that POWER-OF-TWO-P and POSITIVE-POWER-OF-TWO-P do what they say on the tin."
+  (is (not (quil::power-of-two-p -2)))
+  (is (not (quil::power-of-two-p -1)))
+  (is (not (quil::power-of-two-p 0)))
   (is (not (quil::positive-power-of-two-p -2)))
   (is (not (quil::positive-power-of-two-p -1)))
   (is (not (quil::positive-power-of-two-p 0)))
+
+  (is (quil::power-of-two-p 1))
+  (is (not (quil::positive-power-of-two-p 1)))
+
   (loop :for power-of-two = 2 :then (* 2 power-of-two)
         :while (<= power-of-two 1024)
         :do (progn
+              (is (quil::power-of-two-p power-of-two))
+              (is (not (quil::power-of-two-p (1+ power-of-two))))
               (is (quil::positive-power-of-two-p power-of-two))
-              (is (not (quil::positive-power-of-two-p (1- power-of-two)))))))
+              (is (not (quil::positive-power-of-two-p (1+ power-of-two)))))))
 
 (deftest test-check-permutation ()
   "Test that CHECK-PERMUTATION signals error iff input is not valid."


### PR DESCRIPTION
POWER-OF-TWO-P was renamed in de7367c72b23a236ef16e37d2fa8218ac3396119, which was merged shortly after this code.

I am not sure how to test this function (see #236), but can confirm I no longer get a style-warning when compiling.

