### PR TITLE
Load "contribs" during in build-app.lisp + do not hardcode shared lib paths

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -193,6 +193,7 @@
   (disable-debugger))
 
 (defun entry-point (argv)
+  (cffi:load-foreign-library (read-from-string "CL-QUIL.TWEEDLEDUM::LIBTWEEDLEDUM"))
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -40,6 +40,8 @@
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
+    #-win32
+    (asdf:load-system "cl-quil/tweedledum")
     ;; TODO Something is broken here. If zap-info is left to do it's thing on
     ;; Windows, there is a weird error. This is a short-term fix.
     #-win32

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -76,6 +76,5 @@ GIVE-UP-COMPILATION if INSTR is not a permutation gate."
 
 ;; TODO Some error handling here
 (unless *tweedledum-libs-loaded*
-  (cffi:load-foreign-library 'libtweedledum)
   (push (constantly 'compile-perm-gate-with-tweedledum) cl-quil::*global-compilers*)
   (setf *tweedledum-libs-loaded* t))


### PR DESCRIPTION
Currently, to get access to the tweedledum compilation routine you must `(ql:quickload :cl-quil/tweedledum). We also want to load this during a `make quilc-sdk`, so it is available with `quilc < hella-big-permutation.quil`.

* [x] Load tweedledum in build-app.lisp
* [ ] Do not hardcode specific paths of shared libs