### PR TITLE
Respect final instrucion's wish to LINK-SUCCESSOR? in PROGRAM-CFG

### DIFF
--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -107,13 +107,15 @@
       (format stream "(~S)" (label-name (labeled obj))))
     (write-char #\Space stream)
     ;; instructions
-    (format stream "len:~D  " (length (basic-block-code obj)))
+    (format stream "len:~D " (length (basic-block-code obj)))
     ;; incoming and outgoing
     (format stream "in:~D out:" (length (incoming obj)))
-    (adt:match outgoing-edge (outgoing obj)
-      (terminating-edge (write-string "term" stream))
-      ((unconditional-edge _) (write-string "uncond" stream))
-      ((conditional-edge _ _ _) (write-string "cond" stream)))))
+    (if (not (slot-boundp obj 'outgoing))
+        (write-string "unbound" stream)
+        (adt:match outgoing-edge (outgoing obj)
+          (terminating-edge (write-string "term" stream))
+          ((unconditional-edge _) (write-string "uncond" stream))
+          ((conditional-edge _ _ _) (write-string "cond" stream))))))
 
 (defun make-block-from-label (label)
   "Make a new block from the label LABEL."
@@ -540,41 +542,38 @@ Return the following values:
 (defun program-cfg (pp &key (dce nil) (simplify nil))
   "Compute the control flow graph for the parsed program PP. Dead code in the CFG is eliminated if DCE is true (default: NIL). Measures are appended before HALT instructions if ADD-MEASURES is set to a CHIP-SPECIFICATION."
   (let* ((code (parsed-program-executable-code pp))
-         (entry (make-instance 'basic-block :name (gensym "ENTRY-BLK-")))
+         (entry (make-instance 'basic-block :name (gensym "ENTRY-BLK-") :outgoing terminating-edge))
          (cfg (make-instance 'cfg :entry-point entry
                                   :blocks (list entry))))
-    (loop :with current-block := (entry-point cfg)
-          :with finished-block := nil
-          :with link-successor? := nil
-          :for i :from 0
-          :for instr :across code
-          :do (progn
-                ;; Start a new block if necessary, and link it to its
-                ;; predecessor.
-                (when (null current-block)
-                  (setf current-block (make-instance 'basic-block)))
+    (flet ((next (current-block)
+             (or current-block (make-instance 'basic-block))))
+      (loop :with finished-block := nil
+            :with link-successor? := nil
+            :for instr :across code
+            :for current-block := (entry-point cfg) :then (next current-block)
+            :do (progn
+                  ;; Process the instruction.
+                  (multiple-value-setq (current-block finished-block link-successor?)
+                    (process-instruction cfg current-block instr))
 
-                ;; We processed a block before, and it needs to be
-                ;; linked to the current one.
-                (when link-successor?
-                  (assert (not (null finished-block)))
-                  (let ((edge (funcall link-successor? current-block)))
-                    (link-blocks finished-block edge)))
+                  (when link-successor?
+                    ;; Start a new block, and link it to its predecessor.
+                    (assert (null current-block))
+                    (assert (not (null finished-block)))
+                    (setf current-block (next current-block))
+                    (let ((edge (funcall link-successor? current-block)))
+                      (link-blocks finished-block edge)))
 
-                ;; Process the instruction.
-                (multiple-value-setq (current-block finished-block link-successor?)
-                  (process-instruction cfg current-block instr))
-
-                ;; Add the finished block if necessary.
-                (unless (null finished-block)
-                  (add-block-to-cfg finished-block cfg)))
-          :finally (progn
-                     ;; If we have a CURRENT-BLOCK that evidently
-                     ;; wasn't finished, we ought to add it to the
-                     ;; CFG, remembering to link it to the exit point.
-                     (unless (null current-block)
-                       (link-blocks current-block terminating-edge)
-                       (add-block-to-cfg current-block cfg))))
+                  ;; Add the finished block if necessary.
+                  (unless (null finished-block)
+                    (add-block-to-cfg finished-block cfg)))
+            :finally (progn
+                       ;; If we have a CURRENT-BLOCK that evidently
+                       ;; wasn't finished, we ought to add it to the
+                       ;; CFG, remembering to link it to the exit point.
+                       (unless (null current-block)
+                         (link-blocks current-block terminating-edge)
+                         (add-block-to-cfg current-block cfg)))))
 
     ;; Remove dead code when desired.
     (when dce
@@ -603,11 +602,12 @@ Return the following values:
     (loop :for x :across (basic-block-code blk) :do
       (print-instruction x s)
       (format s "\\l"))
-    (adt:match outgoing-edge (outgoing blk)
-      ((conditional-edge instr _ _)
-       (format s "\\nConditioned on ~a" (print-instruction instr nil))
-       (format s "\\l"))
-      (_ nil))))
+    (when (slot-boundp blk 'outgoing)
+      (adt:match outgoing-edge (outgoing blk)
+        ((conditional-edge instr _ _)
+         (format s "\\nConditioned on ~a" (print-instruction instr nil))
+         (format s "\\l"))
+        (_ nil)))))
 
 
 (defun generate-graphviz (cfg &optional (stream *standard-output*))
@@ -624,19 +624,20 @@ Return the following values:
 
   ;; All links
   (dolist (from-blk (cfg-blocks cfg))
-    (adt:match outgoing-edge (outgoing from-blk)
-      (terminating-edge nil)
-      ((unconditional-edge target)
-       (format stream "~A -> ~A;~%"
-               (underscorize (symbol-name (basic-block-name from-blk)))
-               (underscorize (symbol-name (basic-block-name target)))))
-      ((conditional-edge _ true-target false-target)
-       (format stream "~A -> ~A [label = \"1\", fontname = \"times-italic\"];~%"
-               (underscorize (symbol-name (basic-block-name from-blk)))
-               (underscorize (symbol-name (basic-block-name true-target))))
-       (format stream "~A -> ~A [label = \"0\", fontname = \"times-italic\"];~%"
-               (underscorize (symbol-name (basic-block-name from-blk)))
-               (underscorize (symbol-name (basic-block-name false-target)))))))
+    (when (slot-boundp from-blk 'outgoing)
+      (adt:match outgoing-edge (outgoing from-blk)
+        (terminating-edge nil)
+        ((unconditional-edge target)
+         (format stream "~A -> ~A;~%"
+                 (underscorize (symbol-name (basic-block-name from-blk)))
+                 (underscorize (symbol-name (basic-block-name target)))))
+        ((conditional-edge _ true-target false-target)
+         (format stream "~A -> ~A [label = \"1\", fontname = \"times-italic\"];~%"
+                 (underscorize (symbol-name (basic-block-name from-blk)))
+                 (underscorize (symbol-name (basic-block-name true-target))))
+         (format stream "~A -> ~A [label = \"0\", fontname = \"times-italic\"];~%"
+                 (underscorize (symbol-name (basic-block-name from-blk)))
+                 (underscorize (symbol-name (basic-block-name false-target))))))))
 
   ;; Footer
   (format stream "}~%")

--- a/tests/cfg-tests.lisp
+++ b/tests/cfg-tests.lisp
@@ -186,3 +186,11 @@
     ;; Originally this program has an unnecessary jump-when loop with 3 blocks when it could be completely removed,
     ;; as well as a trail of blocks to the end. This 8 block program should now be a 3 block program (at most).
     (is (>= 3 (length blocks-result)))))
+
+(deftest test-program-terminated-by-conditional-jump ()
+  "Verify that quil programs ending with a JUMP-WHEN or JUMP-UNLESS do not signal an UNBOUND-SLOT error.
+
+This is a regression test for https://github.com/rigetti/quilc/issues/244"
+  (dolist (jump-instr '("JUMP-WHEN" "JUMP-UNLESS"))
+    (let ((p (quil::parse-quil-into-raw-program (format nil "DECLARE ro BIT~%LABEL @START~%~A @START ro[0]" jump-instr))))
+      (not-signals error (quil::program-cfg p :dce t :simplify t)))))


### PR DESCRIPTION
## Original commit message

When processing a JUMP-UNLESS or JUMP-WHEN instruction, PROCESS-INSTRUCTION will return a non-nil LINK-SUCCESSOR?, requesting the just-finished block to be linked to it's successor. Previously, if the conditional jump instruction was the final instruction in the program, successor linkage would not happen and the finished block's OUTGOING slot would be unbound. The compiler would later choke on said block, resulting in an UNBOUND-SLOT error.

With this change, ensure that successor linkage always happens, if requested, after PROCESS-INSTRUCTION returns.

Additionally, fix PRINT-OBJECT and the various routines for generating graphviz output to check for SLOT-BOUNDP before attempting to access the block's OUTGOING slot.


Fixes #244

## Additional comments

Note that this commit only focuses on fixing the "slot-unbound" error reported in #244. As @ecpeterson noted in the issue comments, there may be another bug in the compiled output (JUMP to undefined label), but I will address that in a separate PR when/if I'm able to determine that it's a genuine bug.

This is one approach to fixing the "slot-unbound" error reported in #244. I'm starting with this approach because it's the most localized change I could think of that would be least likely to break other things, but it may not be the "best" fix. Here are a couple of (untested) alternatives that come to mind. Feedback welcome.

1. Always canonicalize the instruction sequence at the start of compiler processing by slapping a HALT onto the end if one isn't there already. With this approach, no changes to PROGRAM-CFG would be required, because the program could never end in a conditional jump, so there would always be some succeeding block/instruction to process and link to. Note that the compiler already appends a HALT to every program, but does so near the end of processing, rather than at the start, in RECONSTITUTE-BASIC-BLOCK. I am not sure what the knock-on effects of such a change would be on the rest of the compiler, but usually adding an invariant helps more than it hurts. Or maybe it'll blow up in my face :).

2. This one is more speculative, but I think just initializing every BASIC-BLOCK's OUTGOING edge to TERMINATING-EDGE would fix this particular bug since the last BASIC-BLOCK containing the final jump instruction would then not need linkage because there is no succeeding block. But again, I'm unsure what this implies for the rest of the compiler. At a minimum, I'd have check all the places it's currently pattern matching on the OUTGOING slot and see what's affected.

If either of the above two alternatives sound more appealing (or some other option I haven't considered) I'm happy to test it out and report back.