### PR TITLE
Quash compiler warnings

### DIFF
--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -36,6 +36,8 @@
   :test #'string=
   :documentation "The git hash of the quilc repo.")
 
+(declaim (special *logger*))
+
 (defun latest-sdk-version (&key (proxy nil))
   "Get the latest SDK quilc version, or NIL if unavailable."
   (handler-case

--- a/src/clifford/god-table.lisp
+++ b/src/clifford/god-table.lisp
@@ -163,7 +163,7 @@ allows to compute a minimal length sequence of generators to invert it."))
     ;; are 2 generator applications away from the identity, then 3,
     ;; etc. until we have reached all cliffords.
     (let ((explored 0)
-          (time (get-internal-real-time)))
+          #+#:debug(time (get-internal-real-time)))
       (loop :until (queue-empty-p q)
             :for next := (dequeue q)
             :do


### PR DESCRIPTION
- Don't define unused `TIME` variable in god-table.lisp
- Forward-declare `quilc::*logger*` in versions.lisp