### PR TITLE
Portability improvements

### DIFF
--- a/app/tests/package.lisp
+++ b/app/tests/package.lisp
@@ -7,4 +7,5 @@
   
   ;; suite.lisp
   (:export
-   #:run-quilc-tests))
+   #:run-quilc-tests)
+  (:shadowing-import-from #:cl-quil #:pi))

--- a/benchmarking/package.lisp
+++ b/benchmarking/package.lisp
@@ -10,4 +10,5 @@
 
   ;; suite.lisp
   (:export
-   #:run-benchmarks))
+   #:run-benchmarks)
+  (:shadowing-import-from #:cl-quil #:pi))

--- a/benchmarking/rewiring-analysis.lisp
+++ b/benchmarking/rewiring-analysis.lisp
@@ -134,13 +134,12 @@
             (read-quil-file prog-source))))
 
        (by-assignment (prog-source chip assn)
-         #+sbcl (sb-ext:gc :full t)
          (handler-bind
              ((simple-error
-                (lambda (e)
-                  (when break-on-error
-                    (break "~a" e))
-                  (return-from by-assignment (list nil nil 1)))))
+               (lambda (e)
+                 (when break-on-error
+                   (break "~a" e))
+                 (return-from by-assignment (list nil nil 1)))))
            (funcall assn (lambda ()
                            (rest (multiple-value-list (compiler-hook (get-prog prog-source) chip)))))))
 
@@ -191,7 +190,9 @@
                      (list (make-instance 'application-force-rewiring :target target)))))
 
 (defun generate-random-rewiring-prog (n-qubits state)
-  (let ((*random-state* (sb-ext:seed-random-state state)))
+  (let ((*random-state* #+sbcl (sb-ext:seed-random-state state)
+                        #+ecl  (make-random-state state)
+                        #-(or sbcl ecl) (error "don't know how to seed random state")))
     (make-rewiring-prog (quil::generate-random-rewiring n-qubits))))
 
 (defun measure-rewiring-swap-search (assn &rest args
@@ -212,7 +213,9 @@
 
 (defvar *basic-swap-search-assn*
     (make-assignments
-        ((*random-state* (sb-ext:seed-random-state 1))
+        ((*random-state* #+sbcl (sb-ext:seed-random-state 1)
+                         #+ecl  (make-random-state 1)
+                         #-(or sbcl ecl) (error "don't know how to seed random state"))
          (quil::*compressor-passes* 0))
         (quil::*addresser-swap-search-type*
          quil::*addresser-move-to-rewiring-swap-search-type*)
@@ -223,7 +226,9 @@
 
 (defvar *2q-tiers-assn*
   (make-assignments
-      ((*random-state* (sb-ext:seed-random-state 1))
+      ((*random-state* #+sbcl (sb-ext:seed-random-state 1)
+                       #+ecl  (make-random-state 1)
+                       #-(or sbcl ecl) (error "don't know how to seed random state"))
        (quil::*compressor-passes* 0))
       (quil::*initial-rewiring-default-type*
        quil::*addresser-swap-search-type*
@@ -243,7 +248,9 @@
 
 (defvar *swap-search-assn*
   (make-assignments
-      ((*random-state* (sb-ext:seed-random-state 1))
+      ((*random-state* #+sbcl (sb-ext:seed-random-state 1)
+                       #+ecl  (make-random-state 1)
+                       #-(or sbcl ecl) (error "don't know how to seed random state"))
        (quil::*compressor-passes* 0))
       (quil::*initial-rewiring-default-type*
        quil::*addresser-swap-search-type*
@@ -260,7 +267,9 @@
 
 (defvar *initial-rewiring-assn*
   (make-assignments
-      ((*random-state* (sb-ext:seed-random-state 1))
+      ((*random-state* #+sbcl (sb-ext:seed-random-state 1)
+                       #+ecl  (make-random-state 1)
+                       #-(or sbcl ecl) (error "don't know how to seed random state"))
        (quil::*compressor-passes* 0)
        (quil::*addresser-swap-search-type* :greedy-qubit))
       (quil::*initial-rewiring-default-type*)
@@ -272,7 +281,9 @@
 
 (defvar *depth-vs-swaps-assn*
   (make-assignments
-      ((*random-state* (sb-ext:seed-random-state 1))
+      ((*random-state* #+sbcl (sb-ext:seed-random-state 1)
+                       #+ecl  (make-random-state 1)
+                       #-(or sbcl ecl) (error "don't know how to seed random state"))
        (quil::*compressor-passes* 0))
       (quil::*initial-rewiring-default-type*
        quil::*addresser-swap-search-type*

--- a/src/addresser/cost-function.lisp
+++ b/src/addresser/cost-function.lisp
@@ -100,7 +100,7 @@
                     ;; find a position for the other qubit
                     (setf p1
                           (loop :with min-p    := nil
-                                :with min-dist := sb-ext:double-float-positive-infinity
+                                :with min-dist := double-float-positive-infinity
                                 :for p :below (rewiring-length rewiring)
                                 :unless (apply-rewiring-p2l rewiring p)
                                   :do (let ((new-dist (aref qq-distances p0 p)))

--- a/src/addresser/initial-rewiring.lisp
+++ b/src/addresser/initial-rewiring.lisp
@@ -246,7 +246,7 @@ appear in the same connected component of the qpu"
              (loop
                :with l-multiplier := (aref l2l-multiplier qubit)
                :with best := nil
-               :with best-cost := most-positive-long-float
+               :with best-cost := most-positive-double-float
 
                :for physical-target :in cc
                :for cost

--- a/src/addresser/outgoing-schedule.lisp
+++ b/src/addresser/outgoing-schedule.lisp
@@ -19,7 +19,7 @@
     :initarg :chip-spec
     :reader chip-schedule-spec)
    (lschedule
-    :type 'logical-scheduler
+    :type logical-scheduler
     :initform (make-lscheduler)
     :reader chip-schedule-data)))
 

--- a/src/analysis/rewrite-arithmetic.lisp
+++ b/src/analysis/rewrite-arithmetic.lisp
@@ -119,7 +119,8 @@ expressions, as elements of a single new memory descriptor.
          ;; just a single name (i.e., more than just __P). It adds
          ;; little bit of complexity in favor of a bit of additional
          ;; extensibility.
-         (recalculation-table (make-hash-table :test 'memory-ref=))
+         (recalculation-table (make-hash-table :test 'memory-ref=
+                                               :hash-function 'memory-ref-hash))
          (old-memory-descriptors (parsed-program-memory-definitions parsed-prog))
          (new-memory-descriptors old-memory-descriptors)
          ;; This isn't necessarily guaranteed to be unique, but the

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -54,9 +54,6 @@ WARNING: The default will work for instances of \"idiomatic\" classes that aren'
   #-sbcl
   (logxor (sxhash (memory-ref-name m)) (sxhash (memory-ref-position m))))
 
-;; Used to make a memory reference - keyed hashmap in analysis/rewrite-arithmetic.lisp
-(sb-ext:define-hash-table-test memory-ref= memory-ref-hash)
-
 (defmethod print-object ((mref memory-ref) stream)
   (print-unreadable-object (mref stream :type t :identity nil)
     (format stream "~A[~D]~:[~;*~]"

--- a/src/clifford/clifford.lisp
+++ b/src/clifford/clifford.lisp
@@ -250,10 +250,10 @@ NOTE: THERE IS NO CHECKING OF THE VALIDITY OF THE MAP. ANTICOMMUTATIVITY IS NOT 
   (if pre-allocate
       (make-hash-table :test 'clifford=
                        :hash-function 'clifford-hash
-                       #+sbcl :synchronized #+sbcl synchronized
+                       #+(or sbcl ecl) :synchronized #+(or sbcl ecl) synchronized
                        :size (count-clifford pre-allocate))
       (make-hash-table :test 'clifford=
-                       #+sbcl :synchronized #+sbcl synchronized
+                       #+(or sbcl ecl) :synchronized #+(or sbcl ecl) synchronized
                        :hash-function 'clifford-hash)))
 
 (defmethod print-object ((c clifford) stream)

--- a/src/clifford/god-table.lisp
+++ b/src/clifford/god-table.lisp
@@ -112,8 +112,9 @@ and J-th (target) qubit."
   (make-hash-table :test 'gateset=
                    :hash-function 'gateset-hash
                    ;; We need to synchronize because this table will
-                   ;; be used as a cache from the server.
-                   :synchronized t))
+                   ;; be used as a cache from the server. LW and CCL
+                   ;; support that by default.
+                   #+(or sbcl ecl) :synchronized #+(or sbcl ecl) t))
 
 (defclass god-table ()
   ((mapping :initarg :mapping :reader mapping)

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -752,7 +752,7 @@ This specific routine is the start of a giant dispatch mechanism. Its role is to
   (let* ((output nil)
          (n-qubits (chip-spec-n-qubits chip-specification))
          (governors (make-list (length (chip-specification-objects chip-specification))))
-         (global-governor (make-instance 'governed-queue))
+         (global-governor (make-governed-queue))
          (context (set-up-compressor-context :qubit-count n-qubits
                                              :simulate (and *enable-state-prep-compression* protoquil)
                                              :chip-specification chip-specification)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -421,7 +421,9 @@
   ;; relabeling.lisp
   (:export
    #:standard-qubit-relabeler           ; FUNCTION
-   ))
+   )
+  (:shadow
+   #:pi))
 
 (defpackage #:cl-quil.clifford
   (:nicknames #:quil.clifford)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -421,8 +421,7 @@
   ;; relabeling.lisp
   (:export
    #:standard-qubit-relabeler           ; FUNCTION
-   )
-  )
+   ))
 
 (defpackage #:cl-quil.clifford
   (:nicknames #:quil.clifford)

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -95,9 +95,9 @@
    (return (tok :PARAMETER (param $1))))
   ((eager "{{STRING}}")
    (return (tok :STRING (read-from-string $@))))
-  ((eager #.(string #\DAGGER))
+  ((eager #.(string #-ccl #\DAGGER #+ccl #\u+2020))
    (return (tok ':DAGGER)))
-  ((eager #.(string #\HELM_SYMBOL))
+  ((eager #.(string #-ccl #\HELM_SYMBOL #+ccl #\u+2388))
    (return (tok ':CONTROLLED)))
   ("INCLUDE|DEFCIRCUIT|DEFGATE|MEASURE|LABEL|WAIT|NOP|HALT|RESET|JUMP\\-WHEN|JUMP\\-UNLESS|JUMP|PRAGMA|NOT|AND|IOR|MOVE|EXCHANGE|SHARING|DECLARE|OFFSET|XOR|NEG|LOAD|STORE|CONVERT|ADD|SUB|MUL|DIV|EQ|GT|GE|LT|LE|CONTROLLED|DAGGER|AS|MATRIX|PERMUTATION"
    (return (tok (intern $@ :keyword))))

--- a/src/resource.lisp
+++ b/src/resource.lisp
@@ -32,9 +32,10 @@
                   (defun ,name ,args ,@body)
                   (declaim (notinline ,name))))))
 
-  (define-inlineable integer-bits-equal (bits1 bits2)
-      (bit-set bit-set -> boolean)
-    (= bits1 bits2))
+  (eval-when (:compile-toplevel :load-toplevel :execute)
+    (define-inlineable integer-bits-equal (bits1 bits2)
+        (bit-set bit-set -> boolean)
+      (= bits1 bits2)))
   (define-inlineable infinite-integer-set-p (bits)
       (bit-set -> boolean)
     (minusp bits))

--- a/src/resource.lisp
+++ b/src/resource.lisp
@@ -108,6 +108,9 @@ classical memory regions. "
     (qubits +empty+ :type bit-set :read-only t)
     (memory-regions nil :read-only t))  ; Either an alist mapping region names to bit sets, or the sentinel value T
 
+  (defmethod make-load-form ((object resource-collection) &optional env)
+    (make-load-form-saving-slots object :environment env))
+
   (defun resource= (rc1 rc2)
     "Returns true if resource collections RC1 and RC2 contain the same qubit and region resources."
     (and (integer-bits-equal (resource-collection-qubits rc1)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -40,7 +40,11 @@
        (sb-ext:atomic-incf ,counter-name)
        #+lispworks
        (system:atomic-incf ,counter-name)
-       #-(or sbcl lispworks)
+       #+ecl
+       (mp:atomic-incf ,counter-name)
+       #+ccl
+       (ccl::atomic-incf ,counter-name)
+       #-(or ccl ecl sbcl lispworks)
        (incf ,counter-name))))
 
 (defun first-column-operator= (mat1 mat2)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -146,3 +146,5 @@ Return two values:
     #+ecl ext:double-float-positive-infinity
     #+sbcl sb-ext:double-float-positive-infinity
     #-(or ccl ecl sbcl) (error "double-float-positive-infinity not available."))
+
+(alexandria:define-constant pi #.(coerce cl:pi 'double-float))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -136,3 +136,9 @@ Return two values:
 (defun positive-power-of-two-p (n)
   "Given an INTEGER N, return true if N is a power of 2, greater than 1."
   (and (> n 1) (power-of-two-p n)))
+
+(alexandria:define-constant double-float-positive-infinity
+    #+ccl ccl::double-float-positive-infinity
+    #+ecl ext:double-float-positive-infinity
+    #+sbcl sb-ext:double-float-positive-infinity
+    #-(or ccl ecl sbcl) (error "double-float-positive-infinity not available."))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -164,7 +164,8 @@
     (is (quil::memory-ref= a0 a0!))
     (is (not (quil::memory-ref= a0 a1)))
     (is (not (quil::memory-ref= a0 b0)))
-    (let ((T-A-B-L-E (make-hash-table :test 'quil::memory-ref=)))
+    (let ((T-A-B-L-E (make-hash-table :test 'quil::memory-ref=
+                                      :hash-function 'quil::memory-ref-hash)))
       (setf (gethash a0  T-A-B-L-E) t
             (gethash a0* T-A-B-L-E) t
             (gethash a0! T-A-B-L-E) t

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -7,4 +7,5 @@
 
   ;; suite.lisp
   (:export
-   #:run-cl-quil-tests))
+   #:run-cl-quil-tests)
+  (:shadowing-import-from #:cl-quil #:pi))


### PR DESCRIPTION
With these commits cl-quil loads without problems on ECL[1]. Some fixes are made to improve CCL support, but it still doesn't load cl-quil because of how ADT creates structuers (it uses uninterned symbols and make-load-form-saving-slots on CCL doesn't use slot offsets but names).

[1] Branch is not merged yet, but it introduces improvements to make-load-form-saving-slots and adds custom equivalence predicate capabilities to make-hash-table.

https://gitlab.com/embeddable-common-lisp/ecl/merge_requests/152