### PR TITLE
Convert EXHAUST-STACK in COMPILATION-HOOK from tail-recursion to an explicit LOOP

### DIFF
--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -337,10 +337,8 @@ Returns a value list: (processed-program, of type parsed-program
 
          ;; this is the main loop that pushes through the CFG
          (exhaust-stack ()
-           (unless (endp block-stack)
-             (destructuring-bind (blk registrant) (pop block-stack)
-               (process-block blk registrant))
-             (exhaust-stack))))
+           (loop :until (endp block-stack) :do
+             (apply #'process-block (pop block-stack)))))
 
       ;; kick off the traversal
       (exhaust-stack)


### PR DESCRIPTION
Refactor OUTER-INSTRUCTION-LOOP in ALGEBRAICALLY-REDUCE-INSTRUCTIONS and EXHAUST-STACK in COMPILATION-HOOK from tail-recursive calls to explicit LOOPs.

I started working on this to try and get the test suite passing on ECL. However, it looks like there might be more places that need converting (e.g. OPTIMAL-2Q-COMPILER, EXPAND-TO-NATIVE-INSTRUCTIONS, possibly others) so I'm posting here to see if folks want to try and continue down this path of selectively converting tail-recursive functions into LOOPs wherever possible, or if we want to try another tack. If there are only a handful of these tail-recursive functions and this seems like a reasonable approach, then I can try refactoring EXPAND-TO-NATIVE-INSTRUCTIONS next. On the other hand, if we expect there are many such tail-recursive functions (or, indeed, non-tail recursions that will be harder to convert to LOOPs), then maybe some other approach makes more sense.

Note that in the case of OUTER-INSTRUCTION-LOOP, changing it to an explicit LOOP also avoids a stack overflow on SBCL for me when compiling with `(optimize debug)`, e.g. via `C-u C-c C-c` in SLIME.

EXHAUST-STACK was minding it's own business, but I happened to notice it while working on a different PR the other day and it was trivial to convert it to a LOOP, so I threw it in for good measure.

Here are the individual commit messages. These commits get riskier as you go. The first three commits seem relatively safe. The last one I am less sure of, both because I'm basically doing a mechanical refactoring with only a high-level understanding of what ALGEBRAICALLY-REDUCE-INSTRUCTIONS is doing, and because it's debatable whether this final refactoring helps or hurts readability. I left it as the last commit so it's easy to drop if nobody likes it.

**Cleanup whitespace in compilation-methods.lisp**

**Convert EXHAUST-STACK in COMPILER-HOOK to an explicit LOOP**

**Convert OUTER-INSTRUCTION-LOOP to an explicit LOOP**

Convert the locally defined function OUTER-INSTRUCTION-LOOP in ALGEBRAICALLY-REDUCE-INSTRUCTIONS from tail calls to an explicit loop.

When compiling with (optimize debug) on SBCL, certain tests (I'm looking at *you* TEST-ABSOLUTE-UNIT-CNOT-COMPILATION) would previously result in stack overflow on my machine, presumably because SBCL disables tail-call optimization when compiling with max debug settings. After this change, no stack overflow occurs.

This commit represents a minimal translation from tail calls to an explicit loop, changing as little as possible in the process in order to decrease the likelihood of introducing bugs.

**Further refactoring of OUTER-INSTRUCTION-LOOP**

Add an additional named inner LOOP and scrunch more of the bindings and control logic of OUTER-INSTRUCTION-LOOP into the inner LOOP's loop control clauses. This allows to get rid of some of the RETURN and RETURN-FROM forms, and to do away with the explicit outer BLOCK.