### PR TITLE
rewrite-arithmetic-for-isn matches all quil types

### DIFF
--- a/src/analysis/rewrite-arithmetic.lisp
+++ b/src/analysis/rewrite-arithmetic.lisp
@@ -48,6 +48,9 @@ NOTE: This function does *not* cause side effects.")
   (:method ((isn instruction) mref-name index)
     (values isn '() index))
 
+  (:method ((isn jump-target) mref-name index)
+    (values isn '() index))
+
   (:method ((isn application) mref-name index)
     (check-type mref-name string)
     (check-type index unsigned-byte)


### PR DESCRIPTION
Previously this would error if `isn` was anything but an `instruction` or `application`. This closes #266.