### PR TITLE
Package local nickname for alexandria

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -105,7 +105,7 @@
            (coerce #(#\Newline #\#) 'string))))
 
 (defun lookup-isa-descriptor-for-name (isa)
-  (alexandria:switch (isa :test #'string=)
+  (a:switch (isa :test #'string=)
     ("8Q" (quil::build-8Q-chip))
     ("20Q" (quil::build-skew-rectangular-chip 0 4 5))
     ("16QMUX" (quil::build-16QMUX-chip))
@@ -117,7 +117,7 @@
          (error "ISA descriptor does not name a known template or an extant file.")))))
 
 (defun log-level-string-to-symbol (log-level)
-  (alexandria:eswitch (log-level :test #'string=)
+  (a:eswitch (log-level :test #'string=)
     ("debug" :debug)
     ("info" :info)
     ("notice" :notice)

--- a/app/src/package.lisp
+++ b/app/src/package.lisp
@@ -6,4 +6,4 @@
 
 (defpackage #:quilc
   (:use #:cl)
-  (:package-local-nicknames (:alexandria :a)))
+  (:local-nicknames (:a :alexandria)))

--- a/app/src/package.lisp
+++ b/app/src/package.lisp
@@ -5,4 +5,5 @@
 (in-package #:cl-user)
 
 (defpackage #:quilc
-  (:use #:cl))
+  (:use #:cl)
+  (:package-local-nicknames (:alexandria :a)))

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -6,7 +6,7 @@
 
 
 (defun get-version-info ()
-  (alexandria:alist-hash-table
+  (a:alist-hash-table
    `(("quilc"   . ,+QUILC-VERSION+)
      ("githash" . ,+GIT-HASH+))))
 
@@ -22,9 +22,9 @@
   (check-type request rpcq::|NativeQuilRequest|)
   (let* ((quil-program (quil::parse-quil-into-raw-program (rpcq::|NativeQuilRequest-quil| request)))
          (target-device (rpcq::|NativeQuilRequest-target_device| request))
-         (qpu-hash (alexandria:plist-hash-table (list "isa" (rpcq::|TargetDevice-isa| target-device)
-                                                      "specs" (rpcq::|TargetDevice-specs| target-device))
-                                                :test #'equal))
+         (qpu-hash (a:plist-hash-table (list "isa" (rpcq::|TargetDevice-isa| target-device)
+                                             "specs" (rpcq::|TargetDevice-specs| target-device))
+                                       :test #'equal))
          (chip-specification (cl-quil::qpu-hash-table-to-chip-specification qpu-hash))
          (dictionary (process-program quil-program chip-specification))
          (metadata (make-instance 'rpcq::|NativeQuilMetadata|
@@ -44,7 +44,7 @@
   (check-type request rpcq::|BinaryExecutableRequest|)
   (make-instance 'rpcq::|PyQuilExecutableResponse|
                  :|program| (rpcq::|BinaryExecutableRequest-quil| request)
-                 :|attributes| (alexandria:plist-hash-table
+                 :|attributes| (a:plist-hash-table
                                 `("num_shots" ,(rpcq::|BinaryExecutableRequest-num_shots| request)))))
 
 (defun generate-rb-sequence (request)
@@ -63,8 +63,8 @@
     (when (> n 2)
       (error "Currently no more than two qubit randomized benchmarking is supported."))
     (let* ((cliffords (mapcar #'quil.clifford::clifford-from-quil gateset))
-           (qubits-used (mapcar (alexandria:compose
-                                 (alexandria:curry #'reduce #'union)
+           (qubits-used (mapcar (a:compose
+                                 (a:curry #'reduce #'union)
                                  #'cl-quil.clifford::extract-qubits-used
                                  #'cl-quil:parse-quil)
                                 gateset))
@@ -120,7 +120,7 @@
     (make-instance 'rpcq::|ConjugateByCliffordResponse|
                    :|phase| (quil.clifford::phase-factor pauli-out)
                    :|pauli| (apply #'concatenate 'string
-                                   (mapcar (alexandria:compose #'symbol-name #'quil.clifford::base4-to-sym)
+                                   (mapcar (a:compose #'symbol-name #'quil.clifford::base4-to-sym)
                                            (quil.clifford::base4-list pauli-out))))))
 
 (defun rewrite-arithmetic (request)
@@ -142,7 +142,7 @@
                        (with-output-to-string (s)
                          (quil::print-parsed-program rewritten-program s))
                        :|original_memory_descriptors|
-                       (alexandria:alist-hash-table
+                       (a:alist-hash-table
                         (mapcar (lambda (memory-defn)
                                   (cons (quil::memory-descriptor-name memory-defn)
                                         (make-instance 'rpcq::|ParameterSpec|

--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -26,12 +26,12 @@
             "unknown"
             output)))))
 
-(alexandria:define-constant +QUILC-VERSION+
+(a:define-constant +QUILC-VERSION+
     (system-version '#:quilc)
   :test #'string=
   :documentation "The version of the quilc application.")
 
-(alexandria:define-constant +GIT-HASH+
+(a:define-constant +GIT-HASH+
     (git-hash '#:quilc)
   :test #'string=
   :documentation "The git hash of the quilc repo.")

--- a/app/src/web-server.lisp
+++ b/app/src/web-server.lisp
@@ -59,7 +59,7 @@
   (load-time-value
    (with-output-to-string (s)
      (yason:encode
-      (alexandria:plist-hash-table
+      (a:plist-hash-table
        (list "error_type" "quilc_error"
              "status" "invalid endpoint"))
       s))
@@ -68,7 +68,7 @@
 (defmethod tbnl:acceptor-status-message ((acceptor vhost) (http-status-code (eql #.tbnl:+http-internal-server-error+)) &key error &allow-other-keys)
   (with-output-to-string (s)
     (yason:encode
-     (alexandria:plist-hash-table
+     (a:plist-hash-table
       (list "error_type" "quilc_error"
             "status" error))
      s)))
@@ -182,7 +182,7 @@ If ALLOW-EMPTY-PAYLOADS is true, then an empty payload resolves to the same thin
                        api-key user-id)
     (with-timeout
         (with-output-to-string (s)
-          (yason:encode (alexandria:alist-hash-table
+          (yason:encode (a:alist-hash-table
                          `(("quilc"   . ,+QUILC-VERSION+)
                            ("githash" . ,+GIT-HASH+)))
                         s)))))
@@ -231,10 +231,10 @@ and replies with the JSON
                  recalculation-table)
         (with-output-to-string (s)
           (yason:encode
-           (alexandria:plist-hash-table (list "quil" (with-output-to-string (s)
-                                                       (quil::print-parsed-program rewritten-program s))
-                                              "original_memory_descriptors" reformatted-omd
-                                              "recalculation_table" reformatted-rt))
+           (a:plist-hash-table (list "quil" (with-output-to-string (s)
+                                              (quil::print-parsed-program rewritten-program s))
+                                     "original_memory_descriptors" reformatted-omd
+                                     "recalculation_table" reformatted-rt))
            s))))))
 
 (defun rb-post (data json api-key user-id)
@@ -257,8 +257,8 @@ and replies with the JSON
     (when (> n 2)
       (error "Currently no more than two qubit randomized benchmarking is supported."))
     (let* ((cliffords (mapcar #'quil.clifford::clifford-from-quil gateset))
-           (qubits-used (mapcar (alexandria:compose
-                                 (alexandria:curry #'reduce #'union)
+           (qubits-used (mapcar (a:compose
+                                 (a:curry #'reduce #'union)
                                  #'cl-quil.clifford::extract-qubits-used
                                  #'cl-quil:parse-quil)
                                 gateset))
@@ -313,7 +313,7 @@ and replies with the JSON
     (with-output-to-string (s)
       (yason:encode (list (quil.clifford::phase-factor pauli-out)
                           (apply #'concatenate 'string
-                                 (mapcar (alexandria:compose #'symbol-name #'quil.clifford::base4-to-sym)
+                                 (mapcar (a:compose #'symbol-name #'quil.clifford::base4-to-sym)
                                          (quil.clifford::base4-list pauli-out))))
                     s))))
 

--- a/app/tests/package.lisp
+++ b/app/tests/package.lisp
@@ -8,4 +8,5 @@
   ;; suite.lisp
   (:export
    #:run-quilc-tests)
+  (:local-nicknames (:a :alexandria))
   (:shadowing-import-from #:cl-quil #:pi))

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -22,9 +22,9 @@
     (unwind-protect
          (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
            (let* ((quil "H 0")
-                  (isa (alexandria:plist-hash-table
+                  (isa (a:plist-hash-table
                         (list
-                         "1Q" (alexandria:plist-hash-table
+                         "1Q" (a:plist-hash-table
                                (list
                                 "0" (make-hash-table)))
                          "2Q" (make-hash-table))))

--- a/app/tests/utils.lisp
+++ b/app/tests/utils.lisp
@@ -15,7 +15,7 @@ e.g.
   (testfunc 3 4)) ;; => 12
 "
   (let* ((names (mapcar #'first defs))
-         (gnames (mapcar (alexandria:compose #'gensym #'symbol-name) names)))
+         (gnames (mapcar (a:compose #'gensym #'symbol-name) names)))
     `(let (,@(loop :for name :in names
                    :for gname :in gnames
                    :collect `(,gname (fdefinition ',name))))

--- a/benchmarking/qaoa-tests/generate-program.lisp
+++ b/benchmarking/qaoa-tests/generate-program.lisp
@@ -69,7 +69,7 @@ NOTE: This copies the list first, and so is safe to apply to &REST lists."
                                       &rest rest)
   "Generates a QAOA program which maps perfectly onto the QPU described by CHIP-SPECIFICATION and which occupies QUBIT-COUNT many qubits.  (Should result in a trivial scheduling problem for the NAIVE rewiring method.)  Pass along any keyword arguments to QAOA-PROGRAM-FROM-GRAPH."
   (let* ((live-ccs (chip-spec-live-qubit-cc chip-specification))
-         (biggest-cc (alexandria:extremum live-ccs #'> :key #'length))
+         (biggest-cc (a:extremum live-ccs #'> :key #'length))
          (program-qubits nil)
          (program-links nil))
     
@@ -81,12 +81,12 @@ NOTE: This copies the list first, and so is safe to apply to &REST lists."
             ()
             "Must request at least one qubit.")
     
-    (push (alexandria:random-elt biggest-cc)
+    (push (a:random-elt biggest-cc)
           program-qubits)
     
     ;; collect qubits to find a connected subgraph of chip-specification of size qubit-count
     (loop :with nearby-qubits := (chip-spec-adj-qubits chip-specification (first program-qubits))
-          :for next-qubit := (alexandria:random-elt nearby-qubits)
+          :for next-qubit := (a:random-elt nearby-qubits)
           :do (push next-qubit program-qubits)
               (setf nearby-qubits
                     (set-difference (union nearby-qubits
@@ -142,6 +142,6 @@ NOTE: SELF-CONNECTIVITY must lie in the region [0, 1). For values very close to 
                  qubit-connections)
            (incf qubit-bound)))))
     (apply 'qaoa-program-from-graph
-           (alexandria:iota qubit-count)
+           (a:iota qubit-count)
            qubit-connections
            rest)))

--- a/benchmarking/qaoa-tests/qaoa-bench.lisp
+++ b/benchmarking/qaoa-tests/qaoa-bench.lisp
@@ -22,8 +22,8 @@
         nil))))
 
 (defun print-stats (name numbers)
-  (let ((mean (alexandria:mean numbers))
-        (sdev (alexandria:standard-deviation numbers)))
+  (let ((mean (a:mean numbers))
+        (sdev (a:standard-deviation numbers)))
     (format t "~&~A: ~F (~F)~%" name mean sdev)))
 
 (load (asdf:system-relative-pathname

--- a/boondoggle/src/consumers.lisp
+++ b/boondoggle/src/consumers.lisp
@@ -47,7 +47,7 @@
             (classical-addresses
               (get-consumer-registers consumer parsed-program))
             (qvm-payload (yason:encode
-                          (alexandria:plist-hash-table
+                          (a:plist-hash-table
                            (list "type" "multishot"
                                  "addresses" classical-addresses
                                  "trials" (consumer-local-qvm-trials consumer)

--- a/quilc.asd
+++ b/quilc.asd
@@ -22,6 +22,7 @@
                #:rpcq                 ; to replace HUNCHENTOOT and B-T
                #:drakma
                #:trivial-features     ; for portable *features*
+               #:alexandria
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:quilc-tests)))
   :around-compile (lambda (compile)

--- a/src/addresser/astar-rewiring-search.lisp
+++ b/src/addresser/astar-rewiring-search.lisp
@@ -210,7 +210,7 @@ for each el in seq."
     (map nil (lambda (el &aux (value (funcall key el)))
                (setf (gethash value hist) (1+ (or (gethash value hist) 0))))
          seq)
-    (sort (alexandria:hash-table-alist hist) #'> :key #'car)))
+    (sort (a:hash-table-alist hist) #'> :key #'car)))
 
 (defun search-rewiring (chip-spec initial-rewiring initial-qubit-times heuristic-fn done-fn
                         &key (max-iterations most-positive-fixnum))

--- a/src/addresser/initial-rewiring.lisp
+++ b/src/addresser/initial-rewiring.lisp
@@ -180,10 +180,10 @@ is found, then it will return *INITIAL-REWIRING-DEFAULT-TYPE*."
   "Rewires physical qubits not in CC to logical qubits that are not in
 NEEDED."
   (loop :for qi-non-cc
-          :in (set-difference (alexandria:iota (chip-spec-n-qubits chip-spec))
+          :in (set-difference (a:iota (chip-spec-n-qubits chip-spec))
                               cc)
         :for qi-non-needed
-          :in (set-difference (alexandria:iota (chip-spec-n-qubits chip-spec))
+          :in (set-difference (a:iota (chip-spec-n-qubits chip-spec))
                               needed) :do
           (setf (aref (rewiring-p2l rewiring) qi-non-cc) qi-non-needed
                 (aref (rewiring-l2p rewiring) qi-non-needed) qi-non-cc))
@@ -195,7 +195,7 @@ appear in the same connected component of the qpu"
   (let* ((n-qubits (chip-spec-n-qubits chip-spec))
          (connected-components (chip-spec-live-qubit-cc chip-spec))
          (indices (containing-indices connected-components))
-         (cc (alexandria:extremum connected-components #'> :key #'length))
+         (cc (a:extremum connected-components #'> :key #'length))
          (needed (prog-used-qubits parsed-prog)))
     (assert (or (endp needed)
                 (<= (apply #'max needed) n-qubits))

--- a/src/addresser/logical-schedule.lisp
+++ b/src/addresser/logical-schedule.lisp
@@ -440,7 +440,7 @@ use RESOURCE."
        (push new-inst (gethash hi-inst earlier-instrs))
        (push hi-inst (gethash new-inst later-instrs))
        ;; connect before
-       (alexandria:removef first-instrs hi-inst)
+       (a:removef first-instrs hi-inst)
        (push new-inst first-instrs))
       (t
        ;; connect before
@@ -598,7 +598,7 @@ mapping instructions to their tags. "
                               ;; because INSTR will only be within our
                               ;; native gate set, which will never
                               ;; have gate modifiers.
-                              (alexandria:switch ((application-operator-name instr) :test #'string=)
+                              (a:switch ((application-operator-name instr) :test #'string=)
                                 ;; special handling for the 1Q gates
                                 ("RX"
                                  (gethash "f1QRB" specs-hash))
@@ -630,4 +630,4 @@ mapping instructions to their tags. "
             :finally (return (exp (- (sqrt (- (log fidelity))))))))))
 
 (defun lscheduler-all-instructions (lschedule)
-  (alexandria:hash-table-keys (nth-value 1 (lscheduler-walk-graph lschedule))))
+  (a:hash-table-keys (nth-value 1 (lscheduler-walk-graph lschedule))))

--- a/src/addresser/outgoing-schedule.lisp
+++ b/src/addresser/outgoing-schedule.lisp
@@ -38,7 +38,7 @@ permutation record duration."
         (permutation-record-duration (vnth 0 (hardware-object-permutation-gates
                                               (chip-spec-nth-link chip-spec link-index)))))))
   (flet ((get-it (chip-spec isn)
-           (alexandria:if-let ((obj (nth-value 2 (lookup-hardware-address chip-spec isn))))
+           (a:if-let ((obj (nth-value 2 (lookup-hardware-address chip-spec isn))))
              (funcall (hardware-object-native-instructions obj) isn)
              nil)))
     (declare (inline get-it))
@@ -93,7 +93,7 @@ BEFORE-INST to make use of RESOURCE."
 
 (defun chip-schedule-resource-end-time (schedule resource)
   "Return the time at which RESOURCE becomes free permanently within SCHEDULE."
-  (alexandria:if-let (inst (chip-schedule-last-meeting schedule resource))
+  (a:if-let (inst (chip-schedule-last-meeting schedule resource))
     (chip-schedule-end-time schedule inst)
     0))
 
@@ -108,7 +108,7 @@ BEFORE-INST to make use of RESOURCE."
   "Find the first time a qubit is available, for each qubit in the schedule."
   (map 'vector
        (lambda (idx) (chip-schedule-resource-end-time schedule (make-qubit-resource idx)))
-       (alexandria:iota (chip-spec-n-qubits (chip-schedule-spec schedule)))))
+       (a:iota (chip-spec-n-qubits (chip-schedule-spec schedule)))))
 
 (defun chip-schedule-duration (chip-sched)
   "Find the total duration of a chip schedule."
@@ -136,4 +136,4 @@ BEFORE-INST to make use of RESOURCE."
           :do (remhash inst needed))
         (assert (zerop (hash-table-count needed)) ()
                 "Qubit ~a did not have a single line in ~a. Missing ~a"
-                qubit chip-sched (alexandria:hash-table-keys needed))))))
+                qubit chip-sched (a:hash-table-keys needed))))))

--- a/src/addresser/path-heuristic.lisp
+++ b/src/addresser/path-heuristic.lisp
@@ -44,13 +44,13 @@ respectively."
                (decf (aref link-values link-index) weight-off)))))
 
 (defun select-swap-by-values (chip-spec link-values rewirings-tried rewiring)
-  (alexandria:extremum
+  (a:extremum
    (delete-if
     (lambda (link-index)
       (destructuring-bind (q0 q1) (coerce (chip-spec-qubits-on-link chip-spec link-index) 'list)
         (with-update-rewiring rewiring q0 q1
           (member rewiring rewirings-tried :test #'equalp))))
-    (alexandria:iota (length link-values)))
+    (a:iota (length link-values)))
    #'>
    :key (lambda (idx) (aref link-values idx))))
 
@@ -97,9 +97,9 @@ rewiring."
 
                   (unless p1
                     ;; find a position for the other qubit
-                    (setf p1 (alexandria:extremum
+                    (setf p1 (a:extremum
                               (delete-if (lambda (p) (apply-rewiring-p2l rewiring p))
-                                         (alexandria:iota (rewiring-length rewiring)))
+                                         (a:iota (rewiring-length rewiring)))
                               #'<
                               :key (lambda (p) (aref qq-distances p0 p))))
                     (rewiring-assign rewiring q1 p1))

--- a/src/addresser/temporal-addresser.lisp
+++ b/src/addresser/temporal-addresser.lisp
@@ -178,7 +178,7 @@ following swaps. Perform translations under ENVIRONS."
                            (topmost-link
                             (chip-spec-adj-links chip-spec topmost-link))
                            (t
-                            (alexandria:iota n-links)))))
+                            (a:iota n-links)))))
                    (dolist (link-index links-to-search)
                      (let ((topmost-link (or topmost-link link-index)))
                        ;; apply this link
@@ -327,7 +327,7 @@ Optional arguments:
          ;; precompute SWAP distances between separated qubits
          (qq-distances (precompute-qubit-qubit-distances chip-spec))
          ;; the connected component where newly-assigned qubits will live
-         (qubit-cc (alexandria:extremum (chip-spec-live-qubit-cc chip-spec) #'> :key #'length))
+         (qubit-cc (a:extremum (chip-spec-live-qubit-cc chip-spec) #'> :key #'length))
          ;; initialize a bunch of empty 1Q queues, INDEXED BY LOGICAL ADDRESS
          (1q-queues (make-array n-qubits :initial-element (list)))
          ;; finally, initialize a scheduler to write into
@@ -731,7 +731,7 @@ Optional arguments:
            "Finds the best location for an unassigned logical under the given future schedule."
            (assert (not (apply-rewiring-l2p working-l2p logical)) (logical)
                    "Qubit ~a already assigned" logical)
-           (alexandria:extremum
+           (a:extremum
             (remove-if (lambda (p)
                          (or (apply-rewiring-p2l working-l2p p)
                              (chip-spec-qubit-dead? chip-spec p)))
@@ -793,7 +793,7 @@ Optional arguments:
                  :for candidate-instr :in 2q-instrs-partially-assigned
                  :for ((q0 q1) (pos0 pos1)) := (assign-gate candidate-instr gates-in-waiting)
                  :when (and pos0 pos1)
-                   :do (alexandria:when-let*
+                   :do (a:when-let*
                            ((candidate-link-line
                              (nth-value 1 (lookup-hardware-address-by-qubits chip-spec (list pos0 pos1))))
                             (candidate-horizon

--- a/src/analysis/expand-circuits.lisp
+++ b/src/analysis/expand-circuits.lisp
@@ -182,7 +182,7 @@ explicitly allowed by setting *ALLOW-UNRESOLVED-APPLICATIONS* to T."
                                  (evaluate-delayed-expression p)
                                  p))
                     params)
-          (assert (notany (alexandria:conjoin #'is-param #'delayed-expression-p) params))
+          (assert (notany (a:conjoin #'is-param #'delayed-expression-p) params))
           (assert (notany #'is-formal args))
           (if (not remake)
               instr

--- a/src/analysis/fusion.lisp
+++ b/src/analysis/fusion.lisp
@@ -191,7 +191,7 @@ This function is non-destructive."
       ;; nodes.
       (map nil #'chase-node (trailers pg))
       ;; Return the nodes.
-      (alexandria:hash-table-keys nodes))))
+      (a:hash-table-keys nodes))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Fusion ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -295,12 +295,12 @@ forcing \"Y\" to be the middle link."
            ;;Mark that we've seen it and don't want to see it again.
            (setf (gethash node seen) t)
            ;; Fuse forward.
-           (alexandria:when-let
+           (a:when-let
                ((new-node (attempt-trivial-fusion #'fuse-node-forward node seen final )))
              (setf node new-node))
 
            ;; Fuse backward.
-           (alexandria:when-let
+           (a:when-let
                ((new-node (attempt-trivial-fusion #'fuse-node-backward node seen final )))
              (setf node new-node))
 
@@ -432,7 +432,7 @@ The list will actually be a list of lists, where each sublist commutes and can b
 
 (defun program-grid-to-gate-sequence (pg)
   "Convert a PROGRAM-GRID PG back into a list of gates."
-  (mapcan (alexandria:curry #'mapcar #'grid-node-tag) (sort-program-grid pg)))
+  (mapcan (a:curry #'mapcar #'grid-node-tag) (sort-program-grid pg)))
 
 (defun fuse-gate-sequence (gate-sequence)
   "Given a list of gates GATE-SEQUENCE containing *only* fuseable gates, perform gate fusion, returning a new list of gates that is purportedly mathematically equivalent."

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -29,7 +29,7 @@
       (setf file (merge-pathnames file originating-dir)))
     (unless (uiop:file-exists-p file)
       (error "Could not include ~S because it does not exist." file))
-    (let ((incl-pp (parse-quil-into-raw-program (alexandria:read-file-into-string file))))
+    (let ((incl-pp (parse-quil-into-raw-program (a:read-file-into-string file))))
       (setf (parsed-program-gate-definitions pp)
             (append (parsed-program-gate-definitions pp)
                     (parsed-program-gate-definitions incl-pp)))

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -36,10 +36,10 @@
            ;; Verify correct arguments
            (let ((args (application-arguments app)))
              ;; Check that all arguments are qubits
-             (assert-and-print-instruction (every (alexandria:disjoin #'qubit-p
-                                                                      (if *in-circuit-body*
-                                                                          #'is-formal
-                                                                          (constantly nil)))
+             (assert-and-print-instruction (every (a:disjoin #'qubit-p
+                                                             (if *in-circuit-body*
+                                                                 #'is-formal
+                                                                 (constantly nil)))
                                                   args)
                                            ()
                                            "All arguments must be qubits. Check type of args: ~S." args)

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -256,7 +256,7 @@ as a permutation."
                     :name name
                     :parameters parameters
                     :entries entries)
-      (alexandria:if-let ((perm (permutation-from-gate-entries entries)))
+      (a:if-let ((perm (permutation-from-gate-entries entries)))
         (make-instance 'permutation-gate-definition
                        :name name
                        :permutation perm)
@@ -338,7 +338,7 @@ numbers. It must start with a string.")
                (not (endp words))))
   (assert (stringp (first words))
           ((first words)))
-  (assert (every (alexandria:disjoin #'stringp #'integerp) words)
+  (assert (every (a:disjoin #'stringp #'integerp) words)
           (words))
   (check-type freeform (or null string))
   (specialize-pragma
@@ -446,10 +446,10 @@ Each addressing mode will be a vector of symbols:
     "A map between a class name (symbol) and the vector of types.")
 
   (defun make-typed-name (name types)
-    (alexandria:format-symbol (symbol-package name)
-                              "~A-~{~A~^/~}"
-                              name
-                              types))
+    (a:format-symbol (symbol-package name)
+                     "~A-~{~A~^/~}"
+                     name
+                     types))
 
   (defun valid-type-symbol-p (s)
     (member s '(
@@ -595,7 +595,7 @@ Each addressing mode will be a vector of symbols:
 (defmacro define-classical-instruction (name mnemonic &body body)
   (check-type mnemonic string)
   (multiple-value-bind (types decls docstring)
-      (alexandria:parse-body body :documentation t)
+      (a:parse-body body :documentation t)
     ;; Declarations are not allowed.
     (assert (null decls))
     ;; An empty body, or a body with non-lists aren't allowed.
@@ -966,7 +966,7 @@ N.B. This slot shoould not be accessed directly! Consider using GATE-APPLICATION
   ;; See the actual definition of this in gates.lisp.
   (:documentation "Return a gate-like object represented in the application APP.")
   (:method :around ((app gate-application))
-    (alexandria:if-let ((gate (%get-gate-application-gate app)))
+    (a:if-let ((gate (%get-gate-application-gate app)))
       gate
       (%set-gate-application-gate (call-next-method) app))))
 
@@ -1301,7 +1301,7 @@ For example,
     (flet ((print-one-line (instr)
              (write-string prefix stream)
              (print-instruction instr stream)
-             (alexandria:when-let ((c (comment instr)))
+             (a:when-let ((c (comment instr)))
                (format stream "~40T# ~a" c))
              (terpri stream)))
       (map nil #'print-one-line seq))))
@@ -1316,7 +1316,7 @@ For example,
     (when (memory-descriptor-sharing-parent memory-defn)
       (format s " SHARING ~a"
               (memory-descriptor-sharing-parent memory-defn))
-      (alexandria:when-let (x (memory-descriptor-sharing-offset-alist memory-defn))
+      (a:when-let (x (memory-descriptor-sharing-offset-alist memory-defn))
         (format s " OFFSET")
         (loop :for (type . count) :in x
               :do (format s " ~a ~a" count (quil-type-string type)))))

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -641,7 +641,7 @@ Return the following values:
 
 (defun output-cfg (quil out-file &key parallel dce simplify)
   (let ((pp (parse-quil-into-raw-program (if (pathnamep quil)
-                                             (alexandria:read-file-into-string quil)
+                                             (a:read-file-into-string quil)
                                              quil))))
     (setf pp (transform 'process-includes pp (if (pathnamep quil) quil nil)))
     (output-cfg-from-program pp out-file :parallel parallel :dce dce :simplify simplify)))

--- a/src/chip-reader.lisp
+++ b/src/chip-reader.lisp
@@ -160,7 +160,7 @@
                          (t (error "Unknown link type in QPU descriptor on link ~a: ~a."
                                    (list q0 q1) string))))
                      (target-parser (hash-value)
-                       (mapcar #'individual-target-parser (alexandria:ensure-list hash-value))))
+                       (mapcar #'individual-target-parser (a:ensure-list hash-value))))
               (let ((link (build-link q0 q1
                                       (if (gethash "type" link-hash)
                                           (target-parser (gethash "type" link-hash))
@@ -184,7 +184,7 @@
     (loop :for i :from 0
           :for qubit :across (vnth 0 (chip-specification-objects chip-spec))
           :do ;; load the qubit specs info
-              (alexandria:when-let ((spec (gethash (list i) (gethash "1Q" specs-hash))))
+              (a:when-let ((spec (gethash (list i) (gethash "1Q" specs-hash))))
                 (setf (gethash "specs" (hardware-object-misc-data qubit))
                       spec))))
   (when (gethash "2Q" specs-hash)
@@ -207,7 +207,7 @@
     (install-generic-compilers chip-spec (list ':cz))
     ;; now load the layers out of the .qpu hash
     (load-isa-layer chip-spec isa-hash)
-    (alexandria:when-let ((specs-hash (gethash "specs" hash-table)))
+    (a:when-let ((specs-hash (gethash "specs" hash-table)))
       (load-specs-layer chip-spec specs-hash))
     ;; and return the chip-specification that we've built
     chip-spec))

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -198,7 +198,7 @@ used to specify CHIP-SPEC."
 (defun lookup-hardware-address-by-qubits (chip-spec args)
   (unless (chip-specification-lookup-cache chip-spec)
     (warm-chip-spec-lookup-cache chip-spec))
-  (alexandria:when-let ((hash-value (gethash args (chip-specification-lookup-cache chip-spec))))
+  (a:when-let ((hash-value (gethash args (chip-specification-lookup-cache chip-spec))))
     (destructuring-bind (index obj) hash-value
       (values (1- (length args)) index obj))))
 
@@ -222,7 +222,7 @@ used to specify CHIP-SPEC."
   (check-type qubit0 unsigned-byte)
   (check-type qubit1 unsigned-byte)
   (assert (/= qubit0 qubit1))
-  (setf type (alexandria:ensure-list type))
+  (setf type (a:ensure-list type))
   (let* ((misc-data (make-hash-table :test #'equal))
          (obj (make-hardware-object
                :order 1
@@ -445,32 +445,32 @@ used to specify CHIP-SPEC."
 (defun architecture-has-ucr-compiler-p (architecture)
   (or (optimal-2q-target-meets-requirements architecture ':cz)
       (optimal-2q-target-meets-requirements architecture ':iswap)
-      (find ':cnot (alexandria:ensure-list architecture))))
+      (find ':cnot (a:ensure-list architecture))))
 
 ;;; routines for populating the fields of a CHIP-SPECIFICATION object (and
 ;;; maintaining the appropriate interrelations).
 (defvar *global-compilers*
   (list (lambda (chip-spec arch)
           (declare (ignore arch))
-          (alexandria:curry #'swap-to-native-swaps chip-spec))
+          (a:curry #'swap-to-native-swaps chip-spec))
         (lambda (chip-spec arch)
           (when (optimal-2q-target-meets-requirements arch ':cz)
-            (alexandria:curry #'cnot-to-native-cnots chip-spec)))
+            (a:curry #'cnot-to-native-cnots chip-spec)))
         (lambda (chip-spec arch)
           (when (optimal-2q-target-meets-requirements arch ':cz)
-            (alexandria:curry #'cz-to-native-czs chip-spec)))
+            (a:curry #'cz-to-native-czs chip-spec)))
         (lambda (chip-spec arch)
           (when (optimal-2q-target-meets-requirements arch ':iswap)
-            (alexandria:curry #'ISWAP-to-native-ISWAPs chip-spec)))
+            (a:curry #'ISWAP-to-native-ISWAPs chip-spec)))
         (lambda (chip-spec arch)
           (when (optimal-2q-target-meets-requirements arch ':cphase)
-            (alexandria:curry #'CPHASE-to-native-CPHASEs chip-spec)))
+            (a:curry #'CPHASE-to-native-CPHASEs chip-spec)))
         (lambda (chip-spec arch)
           (when (optimal-2q-target-meets-requirements arch ':piswap)
-            (alexandria:curry #'PISWAP-to-native-PISWAPs chip-spec)))
+            (a:curry #'PISWAP-to-native-PISWAPs chip-spec)))
         (lambda (chip-spec arch)
-          (when (find ':cnot (alexandria:ensure-list arch))
-            (alexandria:curry #'CNOT-to-native-CNOTs chip-spec)))
+          (when (find ':cnot (a:ensure-list arch))
+            (a:curry #'CNOT-to-native-CNOTs chip-spec)))
         ;; We make this unconditional. We could later conditionalize it if
         ;; we happen to have better CCNOT translations for specific target
         ;; gate sets.
@@ -486,7 +486,7 @@ used to specify CHIP-SPEC."
             (lambda (instr) (ucr-compiler instr :target ':iswap))))
         (lambda (chip-spec arch)
           (declare (ignore chip-spec))
-          (when (find ':cnot (alexandria:ensure-list arch))
+          (when (find ':cnot (a:ensure-list arch))
             (lambda (instr) (ucr-compiler instr :target ':cnot))))
         (constantly #'state-prep-compiler)
         (constantly #'recognize-ucr)
@@ -506,7 +506,7 @@ Compilers are listed in descending precedence.")
   (let ((ret (make-adjustable-vector)))
     (setf (chip-specification-generic-compilers chip-spec) ret)
     (dolist (get-compiler *global-compilers*)
-      (alexandria:when-let ((compiler (funcall get-compiler chip-spec architecture)))
+      (a:when-let ((compiler (funcall get-compiler chip-spec architecture)))
         (vector-push-extend compiler ret)))))
 
 
@@ -604,9 +604,9 @@ Compilers are listed in descending precedence.")
 
 (defun build-16QMUX-chip ()
   (qpu-hash-table-to-chip-specification
-   (alexandria:plist-hash-table
-    (list "isa" (alexandria:plist-hash-table
-                 (list "1Q" (alexandria:plist-hash-table
+   (a:plist-hash-table
+    (list "isa" (a:plist-hash-table
+                 (list "1Q" (a:plist-hash-table
                              (list "0" (make-hash-table)
                                    "1" (make-hash-table)
                                    "2" (make-hash-table)
@@ -624,7 +624,7 @@ Compilers are listed in descending precedence.")
                                    "16" (make-hash-table)
                                    "17" (make-hash-table))
                              :test #'equal)
-                       "2Q" (alexandria:plist-hash-table
+                       "2Q" (a:plist-hash-table
                              (list "0-1" (make-hash-table)
                                    "1-2" (make-hash-table)
                                    "2-3" (make-hash-table)

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -23,5 +23,5 @@
                (uiop:file-exists-p filespec))
           (filespec)
           "FILESPEC must be a path to a file that exists")
-  (parse-quil (alexandria:read-file-into-string filespec)
+  (parse-quil (a:read-file-into-string filespec)
               :originating-file (first (directory filespec))))

--- a/src/classical-memory.lisp
+++ b/src/classical-memory.lisp
@@ -4,7 +4,7 @@
 
 (in-package #:cl-quil)
 
-(define-condition quil-memory-model-error (alexandria:simple-parse-error)
+(define-condition quil-memory-model-error (a:simple-parse-error)
   ()
   (:documentation "An error regarding the classical memory declarations."))
 
@@ -21,7 +21,7 @@
 
 (defun string-to-quil-type (name)
   "Convert a Quil string name of a data type to our internal representation."
-  (alexandria:switch (name :test #'string=)
+  (a:switch (name :test #'string=)
     ("BIT"     quil-bit)
     ("OCTET"   quil-octet)
     ("INTEGER" quil-integer)

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -41,7 +41,7 @@
            (loop :for generator :in cliffords
                  :collect (let ((inverse (reconstruct (group-inv generator) god-table)))
                             (cons generator inverse))))
-         (min-identity-decomposition (alexandria:extremum identity-decompositions #'< :key #'length)))
+         (min-identity-decomposition (a:extremum identity-decompositions #'< :key #'length)))
     (push inverse seq)
     (loop :for s :in seq
           :collect (if (clifford-identity-p s)
@@ -197,7 +197,7 @@
   "If the parsed circuit PARSED-QUIL a clifford circuit, return the CLIFFORD corresponding to it. Otherwise return NIL. This will generate a clifford that acts on the number of qubits in the program, rather than a number of qubits that is the difference between the maximum and minimum index."
   (let* ((cliffords (extract-cliffords parsed-quil))
          (qubit-targets (extract-qubits-used parsed-quil))
-	 (qubits (sort (remove-duplicates (alexandria:flatten qubit-targets)) #'<))
+	 (qubits (sort (remove-duplicates (a:flatten qubit-targets)) #'<))
 	 (num-qubits (length qubits)))
     (reduce #'group-mul (loop :for clifford :in (reverse cliffords)
 			   :for target :in (reverse qubit-targets)

--- a/src/clifford/clifford.lisp
+++ b/src/clifford/clifford.lisp
@@ -197,7 +197,7 @@ NOTE: THERE IS NO CHECKING OF THE VALIDITY OF THE MAP. ANTICOMMUTATIVITY IS NOT 
                           ()
                           "The symbol ~S is not a Pauli basis element" from)
                   ;; Get the max dimension
-                  (alexandria:maxf num-qubits (dimension from-name) (dimension to-name))
+                  (a:maxf num-qubits (dimension from-name) (dimension to-name))
                   ;; Record the map.
                   (push (cons from-name to-name)
                         maps)))

--- a/src/clifford/god-table.lisp
+++ b/src/clifford/god-table.lisp
@@ -331,7 +331,7 @@ invert C when applied in the correct (reversed) order.
           :for i :from 0
           :do (dotimes (jdx (gethash i sample-idxs 0))
                 (vector-push hash-key results)))
-    (coerce (alexandria:shuffle results) 'list)))
+    (coerce (a:shuffle results) 'list)))
 
 (defun default-gateset (num-qubits &optional (cnot-edges :complete))
   "Generate a list of generators of single qubit Hadamard and Phase

--- a/src/clifford/pauli.lisp
+++ b/src/clifford/pauli.lisp
@@ -7,7 +7,7 @@
 ;;; This file implements an efficient representation of the Pauli
 ;;; group.
 
-(alexandria:define-constant +paulis+
+(a:define-constant +paulis+
     #(I X Z Y)
   :test #'equalp
   :documentation "The Pauli group symbols.")
@@ -137,7 +137,7 @@ If STREAM is T, print to standard output. Otherwise print to STREAM."
           (apply
            #'concatenate
            'string
-           (mapcar (alexandria:compose #'symbol-name #'base4-to-sym)
+           (mapcar (a:compose #'symbol-name #'base4-to-sym)
                    (base4-list p)))))
 
 (defmethod print-object ((p pauli) stream)
@@ -175,7 +175,7 @@ phase factor)."
            (i (string= (elt r 1) "i"))
            (o (elt r 2))
            (p (+ (if i 1 0) (if n 2 0)))
-           (l (mapcar (alexandria:compose
+           (l (mapcar (a:compose
                        #'intern
                        (lambda (x) (coerce (list x) 'string)))
                       (coerce o 'list))))
@@ -184,16 +184,16 @@ phase factor)."
 )                                       ; EVAL-WHEN
 
 
-(alexandria:define-constant +I+ (pauli-from-symbols '(I))
+(a:define-constant +I+ (pauli-from-symbols '(I))
   :test #'pauli=)
 
-(alexandria:define-constant +X+ (pauli-from-symbols '(X))
+(a:define-constant +X+ (pauli-from-symbols '(X))
   :test #'pauli=)
 
-(alexandria:define-constant +Y+ (pauli-from-symbols '(Y))
+(a:define-constant +Y+ (pauli-from-symbols '(Y))
   :test #'pauli=)
 
-(alexandria:define-constant +Z+ (pauli-from-symbols '(Z))
+(a:define-constant +Z+ (pauli-from-symbols '(Z))
   :test #'pauli=)
 
 (defun pauli-identity (n &optional (p 0))

--- a/src/clifford/stabilizer.lisp
+++ b/src/clifford/stabilizer.lisp
@@ -217,8 +217,8 @@ but the symbols may be uninterned or named differently.
          (num-variables (* 2 num-qubits))
          (variables (loop :for i :below num-variables
                           :collect (if (evenp i)
-                                       (alexandria:format-symbol nil "X~D" (floor i 2))
-                                       (alexandria:format-symbol nil "Z~D" (floor i 2)))))
+                                       (a:format-symbol nil "X~D" (floor i 2))
+                                       (a:format-symbol nil "Z~D" (floor i 2)))))
          (phase-factor nil)
          (new-variables (make-array num-variables :initial-element nil)))
     ;; We will be mapping over all Paulis operating on a single
@@ -299,7 +299,7 @@ but the symbols may be uninterned or named differently.
          (i      (gensym "I-"))
          (tab    (gensym "TAB-"))
          (qubits (loop :for i :below num-qubits
-                       :collect (alexandria:format-symbol nil "Q~D" i))))
+                       :collect (a:format-symbol nil "Q~D" i))))
     (multiple-value-bind (variables phase-kickback new-variables)
         (clifford-stabilizer-action c)
       ;; Most of this lambda can be understood by understanding the
@@ -444,7 +444,7 @@ but the symbols may be uninterned or named differently.
         :for isn :in code
         :do
            (format t "~D: ~A" i isn)
-           (alexandria:destructuring-ecase isn
+           (a:destructuring-ecase isn
              ((H q)       (tableau-apply-h tab q))
              ((PHASE q)   (tableau-apply-phase tab q))
              ((CNOT p q)  (tableau-apply-cnot tab p q))

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -56,8 +56,8 @@
 
 (defun optimal-2q-target-meets-requirements (target requirements)
   "Tests whether REQUIREMENTS of type OPTIMAL-2Q-TARGET, thought of as the two-qubit instructions necessary to instantiate a two-qubit decomposition template, is covered by TARGET of type OPTIMAL-2Q-TARGET, thought of as the available two-qubit instructions on the device."
-  (let ((targetl       (alexandria:ensure-list target))
-        (requirementsl (alexandria:ensure-list requirements)))
+  (let ((targetl       (a:ensure-list target))
+        (requirementsl (a:ensure-list requirements)))
     (when (member ':cphase targetl) (push ':cz targetl))
     (when (member ':piswap targetl) (push ':iswap targetl))
     (when (member ':cnot targetl) (push ':cz targetl))
@@ -125,7 +125,7 @@
 ;; REM: according to arXiv:0308033, their only special property is:
 ;;     e e^T = -(sigma_y (x) sigma_y) .
 ;; there are several such matrices; this one is just easy to write down.
-(alexandria:define-constant
+(a:define-constant
     +e-basis+
     (let* ((sqrt2 (/ (sqrt 2) 2))
            (-sqrt2 (- sqrt2))
@@ -139,7 +139,7 @@
   :test #'matrix-equality
   :documentation "This is an element of SU(4) that has two properties: (1) e-basis e-basis^T = - sigma_y^((x) 2) and (2) e-basis^dag SU(2)^((x) 2) e-basis = SO(4).")
 
-(alexandria:define-constant
+(a:define-constant
     +edag-basis+
     (let* ((sqrt2 (/ (sqrt 2) 2))
            (-sqrt2 (- sqrt2))
@@ -162,7 +162,7 @@
 ;; special-orthogonal, we have to correct this behavior manually.
 (defun find-real-spanning-set (vectors)
   "VECTORS is a list of complex vectors in C^n (which, here, are of type LIST).  When possible, computes a set of vectors with real coefficients that span the same complex subspace of C^n as VECTORS."
-  (assert (alexandria:proper-list-p vectors))
+  (assert (a:proper-list-p vectors))
   (let* ((coeff-matrix (magicl:make-complex-matrix
                         (length (first vectors))
                         (* 2 (length vectors))
@@ -478,7 +478,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
   (check-type q0 symbol)
   
   (multiple-value-bind (body-prog decls docstring)
-      (alexandria:parse-body body :documentation t)
+      (a:parse-body body :documentation t)
     `(progn
        (defun ,name (,coord ,q1 ,q0)
          ,@(when docstring (list docstring))
@@ -506,8 +506,8 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 (defmacro define-searching-approximate-template (name (coord q1 q0 parameter-array) (&key predicate requirements parameter-count) &body parametric-circuit)
   "Defines an approximate template that uses an inexact (and possibly imperfect) search algorithm (e.g., a Nelder-Mead solver).  In addition to the documentation of DEFINE-APPROXIMATE-TEMPLATE, this macro takes the extra value PARAMETER-COUNT which controls how many variables the searcher will optimize over."
   (multiple-value-bind (body-prog decls docstring)
-      (alexandria:parse-body parametric-circuit :documentation t)
-    (alexandria:with-gensyms (a d b in goodness template-values)
+      (a:parse-body parametric-circuit :documentation t)
+    (a:with-gensyms (a d b in goodness template-values)
       `(define-approximate-template ,name (,coord ,q1 ,q0)
            (:requirements ,requirements
             :predicate ,predicate)
@@ -769,7 +769,7 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
           ((endp candidate-pairs)
            (give-up-compilation))
           (t
-           (destructuring-bind (fidelity . circuit) (alexandria:extremum candidate-pairs #'> :key #'car)
+           (destructuring-bind (fidelity . circuit) (a:extremum candidate-pairs #'> :key #'car)
              (unless (or *enable-approximate-compilation*
                          (double= 1d0 fidelity))
                (give-up-compilation))

--- a/src/compilers/optimal-2q.lisp
+++ b/src/compilers/optimal-2q.lisp
@@ -130,7 +130,7 @@ The optional argument INSTR is used to canonicalize the qubit indices of the ins
   ;; that compilers should in general get us closer to our target, and
   ;; identity is *not* getting us closer.
   (when (gate-application-trivially-satisfies-2q-target-requirements
-         instr (alexandria:ensure-list target))
+         instr (a:ensure-list target))
     (give-up-compilation :because ':acts-trivially))
 
   ;; first, some utility definitions for 2Q templates that require numerical solvers

--- a/src/compilers/ucr-explode.lisp
+++ b/src/compilers/ucr-explode.lisp
@@ -46,9 +46,9 @@
   (let* ((temp-gate (copy-instance gate)))
     (setf (application-arguments temp-gate)
           (mapcar #'qubit
-                  (alexandria:iota (length (application-arguments gate))
-                                   :start (1- (length (application-arguments gate)))
-                                   :step -1)))
+                  (a:iota (length (application-arguments gate))
+                          :start (1- (length (application-arguments gate)))
+                          :step -1)))
     (make-matrix-from-quil
      (append
       (when (eql ':up (ucr-application-chirality temp-gate))
@@ -59,7 +59,7 @@
       (when (eql ':down (ucr-application-chirality temp-gate))
         (list
          (build-gate "CNOT" () (second (application-arguments temp-gate))
-                               (first (application-arguments temp-gate)))))))))
+                     (first (application-arguments temp-gate)))))))))
 
 
 ;;; now some local utility functions
@@ -183,8 +183,8 @@
                (make-instance 'ucr-application
                               :chirality chirality
                               :roll-type roll
-                              :parameters (alexandria:ensure-list params)
-                              :arguments (alexandria:ensure-list args)))
+                              :parameters (a:ensure-list params)
+                              :arguments (a:ensure-list args)))
              (ucr (roll params args)
                (ucr* nil roll params args))
              (chiroll (chirality params)

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -204,10 +204,10 @@ other's."
   (unless node
     (return-from print-node-list nil))
   (format t "~30a <-- ~30a --> ~30a~%"
-          (alexandria:when-let ((prev (peephole-rewriter-node-prev node)))
+          (a:when-let ((prev (peephole-rewriter-node-prev node)))
             (peephole-rewriter-node-instr prev))
           (peephole-rewriter-node-instr node)
-          (alexandria:when-let ((next (peephole-rewriter-node-next node)))
+          (a:when-let ((next (peephole-rewriter-node-next node)))
             (peephole-rewriter-node-instr next)))
   (print-node-list (peephole-rewriter-node-next node)))
 
@@ -235,7 +235,7 @@ other's."
            ;; make sure we have enough terms, then apply the rule's consumer
            (with-simple-restart (try-next-compiler "Ignore this error and try the next rewrite rule in the list.")
              (handler-case
-                 (alexandria:when-let*
+                 (a:when-let*
                      ((relevant-nodes-for-inspection
                        (and (>= (length nodes-for-inspection) (rewriting-rule-count rule))
                             ;; TODO: consider calculating this subseq only once.
@@ -293,7 +293,7 @@ other's."
                  (let ((obj (nth-value 2 (lookup-hardware-address-by-qubits chip-specification qubit-complex))))
                    ;; if we can, then we want to loop over the object's rewrite rules.
                    ;; if we can't, we fall through and do nothing.
-                   (alexandria:when-let
+                   (a:when-let
                        ((rewrite-rules
                          (cond
                            ;; if we found a new hardware object, then use its rules
@@ -405,7 +405,7 @@ other's."
          ;; produce a sequence of native instructions that have the same effect
          ;; as the matrix representation of INSTRUCTIONS
          (decompile-instructions-into-full-unitary ()
-           (alexandria:when-let ((matrix (make-matrix-from-quil
+           (a:when-let ((matrix (make-matrix-from-quil
                                           instructions
                                           :relabeling (standard-qubit-relabeler qubits-on-obj))))
              (expand-to-native-instructions
@@ -521,7 +521,7 @@ other's."
                    collinear with the target wavefunction.")))
 
          (check-quil-is-near-as-matrices ()
-           (alexandria:when-let ((stretched-matrix (make-matrix-from-quil instructions)))
+           (a:when-let ((stretched-matrix (make-matrix-from-quil instructions)))
              (let* ((n (ilog2 (magicl:matrix-rows stretched-matrix)))
                     (reduced-matrix
                      (kron-matrix-up (make-matrix-from-quil reduced-instructions)
@@ -781,7 +781,7 @@ This specific routine is the start of a giant dispatch mechanism. Its role is to
                             global-governor
                             (nth address (nth order governors))))
                       (old-state (governed-queue-state governed-queue)))
-                 (alexandria:eswitch ((list old-state new-state) :test #'equal)
+                 (a:eswitch ((list old-state new-state) :test #'equal)
                    ;;
                    ;; QUEUEING --> PASSING(B)
                    ;;

--- a/src/compressor/wavefunctions.lisp
+++ b/src/compressor/wavefunctions.lisp
@@ -180,7 +180,7 @@ If DESTRUCTIVE-UPDATE is T, we will update AQVM's internal structure to correlat
 
 (defun nondestructively-apply-instrs-to-wf (instrs wf qc)
   "Given a wavefunction WF, represented as an array of complex doubles, together with a list QC of qubit indices describing what the components of the wavefunction represent, applies the sequence of instructions INSTRS and returns the resulting wavefunction (with the same qubit ordering).  Does not modify any of its inputs."
-  (alexandria:when-let ((wf (copy-seq wf)))
+  (a:when-let ((wf (copy-seq wf)))
     (assert (= (length wf) (expt 2 (length qc))))
     (dolist (instr instrs wf)
       (let ((new-wf (nondestructively-apply-instr-to-wf instr wf qc)))

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -62,7 +62,7 @@ GIVE-UP-COMPILATION if INSTR is not a permutation gate."
                 (relabler (lambda (q)
                             (setf (quil::qubit-index q)
                                   (quil::qubit-index (nth (quil::qubit-index q) qubits))))))
-           (map nil (alexandria:rcurry #'quil::%relabel-qubits relabler) code)
+           (map nil (a:rcurry #'quil::%relabel-qubits relabler) code)
            (coerce code 'list)))
         (t
          (quil::give-up-compilation))))))

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -3,6 +3,7 @@
 (defpackage #:cl-quil.tweedledum
   (:use #:common-lisp
         #:cffi)
+  (:local-nicknames (:a :alexandria))
   (:export #:synthesis-dbs))
 
 (in-package #:cl-quil.tweedledum)

--- a/src/define-pragma.lisp
+++ b/src/define-pragma.lisp
@@ -28,7 +28,7 @@
   (intern (symbol-name slot-name) :keyword))
 
 (defun pdef-accessor-name (slot-name)
-  (alexandria:format-symbol (symbol-package slot-name) "PRAGMA-~A" slot-name))
+  (a:format-symbol (symbol-package slot-name) "PRAGMA-~A" slot-name))
 
 (defun format-complex-list (list)
   (format nil "(~{~A~^ ~})"
@@ -156,7 +156,7 @@ contains no duplicates."
     (flet ((error-form (message)
              `(error ,(format nil "Malformed pragma ~A -- ~A"
                               name message))))
-      (alexandria:with-gensyms (class words freeform-string)
+      (a:with-gensyms (class words freeform-string)
         `(defmethod check-pragma-arguments ((,class (eql ',pragma-class))
                                            ,words ,freeform-string)
            (unless (,operator ,value (length ,words))
@@ -169,7 +169,7 @@ contains no duplicates."
                            ,(error-form "freeform string provided"))))))))
 
 (defun pdef-pragma-specalized-initargs-form (pdef)
-  (alexandria:with-gensyms (class words freeform-string)
+  (a:with-gensyms (class words freeform-string)
     (let ((pragma-class (pdef-class-name pdef))
           (code (pdef-initialization-code pdef))
           (lambda-list (pdef-word-lambda-list pdef))
@@ -207,7 +207,7 @@ contains no duplicates."
   (let ((class-name (pdef-class-name pdef))
         (code (pdef-display-string-code pdef)))
     (when code
-      (alexandria:with-gensyms (pragma)
+      (a:with-gensyms (pragma)
         `(defmethod pragma-display-string ((,pragma ,class-name))
            (let ,(mapcar (lambda (slot)
                            `(,slot (,(pdef-accessor-name slot) ,pragma)))

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -14,7 +14,7 @@
 
 (defmacro tolerate-unknown-gate (&body body)
   "Evaluate BODY. If a gate wasn't found, just reurn NIL."
-  `(alexandria:ignore-some-conditions (gate-not-found) ,@body))
+  `(a:ignore-some-conditions (gate-not-found) ,@body))
 
 (defgeneric lookup-gate-in-environment (gate environs)
   (:documentation "Looks up a definition of the instruction GATE inside of the environment ENVIRONS. Results in an object compatible with GATE-MATRIX if a definition is found. Signal the error GATE-NOT-FOUND if it wasn't found."))
@@ -35,10 +35,10 @@
       (error 'gate-not-found :name gate)))
 
 (defmethod lookup-gate-in-environment ((gate string) (environs parsed-program))
-  (alexandria:if-let ((gate-defn (find gate
-                                       (parsed-program-gate-definitions environs)
-                                       :test #'string=
-                                       :key #'gate-definition-name)))
+  (a:if-let ((gate-defn (find gate
+                              (parsed-program-gate-definitions environs)
+                              :test #'string=
+                              :key #'gate-definition-name)))
     gate-defn
     (lookup-gate-in-environment gate nil)))
 

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -209,7 +209,7 @@
     (let* ((permutation (permutation-gate-permutation target))
            (size (length permutation)))
       (make-instance 'permutation-gate
-                     :permutation (append (alexandria:iota size)
+                     :permutation (append (a:iota size)
                                           (mapcar (lambda (j) (+ j size)) permutation))))))
 
 ;;; Daggered Gates
@@ -249,9 +249,9 @@
     ((named-operator _)
      (lambda (gate) gate))
     ((controlled-operator od)
-     (alexandria:compose #'control-gate (operator-description-gate-lifter od)))
+     (a:compose #'control-gate (operator-description-gate-lifter od)))
     ((dagger-operator od)
-     (alexandria:compose #'dagger-gate (operator-description-gate-lifter od)))))
+     (a:compose #'dagger-gate (operator-description-gate-lifter od)))))
 
 (defmethod gate-application-gate ((app gate-application))
   (funcall (operator-description-gate-lifter (application-operator app))
@@ -265,7 +265,7 @@
     (let ((table (make-hash-table :test 'equal))
           (gate-defs (parsed-program-gate-definitions
                       (parse-quil-into-raw-program
-                       (alexandria:read-file-into-string
+                       (a:read-file-into-string
                         (asdf:system-relative-pathname
                          "cl-quil" "src/quil/stdgates.quil"))))))
       (dolist (gate-def gate-defs table)
@@ -280,7 +280,7 @@
 
 (defun lookup-standard-gate (gate-name)
   "Lookup the gate named by GATE-NAME in the collection of *standard* Quil gates. Return NIL if non-standard."
-  (check-type gate-name alexandria:string-designator)
+  (check-type gate-name a:string-designator)
   (values (gethash (string gate-name) **default-gate-definitions**)))
 
 
@@ -294,7 +294,7 @@
 (defgeneric gate-definition-to-gate (gate-def)
   (:documentation "Convert a parsed Quil gate definition to a usable, executable gate.")
   (:method :around ((gate-def gate-definition))
-    (alexandria:if-let ((gate (%gate-definition-cached-gate gate-def)))
+    (a:if-let ((gate (%gate-definition-cached-gate gate-def)))
       gate
       (setf (%gate-definition-cached-gate gate-def) (call-next-method)))))
 
@@ -335,7 +335,7 @@
   "Constructs the matrix representation associated to an instruction list consisting of gates. Suitable for testing the output of compilation routines."
   (check-type m magicl:matrix)
   (check-type instr application)
-  (alexandria:when-let ((defn (gate-matrix instr)))
+  (a:when-let ((defn (gate-matrix instr)))
     (let* ((mat-size (ilog2 (magicl:matrix-rows m)))
            (size (max mat-size
                       (apply #'max
@@ -348,7 +348,7 @@
            (m (if (< mat-size size)
                   (kq-gate-on-lines m
                                     size
-                                    (alexandria:iota mat-size :start (1- mat-size) :step -1))
+                                    (a:iota mat-size :start (1- mat-size) :step -1))
                   m)))
       (magicl:multiply-complex-matrices mat m))))
 
@@ -435,7 +435,7 @@ as matrices."
         (unless (endp new-qubits)
           (setf u (kq-gate-on-lines u
                                     (+ (length qubits) (length new-qubits))
-                                    (alexandria:iota (length qubits)
+                                    (a:iota (length qubits)
                                                      :start (1- (length qubits))
                                                      :step -1)))
           (setf qubits (append new-qubits qubits)))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -240,7 +240,7 @@ as needed so that they are the same size."
         matrix
         (kq-gate-on-lines matrix
                           n
-                          (alexandria:iota m :start (1- m) :step -1)))))
+                          (a:iota m :start (1- m) :step -1)))))
 
 (defun matrix-trace (m)
   (assert (= (magicl:matrix-rows m) (magicl:matrix-cols m)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -30,7 +30,9 @@
         #:parse-float
         #:abstract-classes
         #:singleton-classes
-        #:cl-quil.resource)
+        #:cl-quil.resource
+        #:alexandria)
+  (:local-nicknames (:a :alexandria))
   ;; options.lisp
   (:export
    #:*allow-unresolved-applications*    ; VARIABLE

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -4,6 +4,7 @@
 
 (defpackage #:cl-quil.resource
   (:use #:cl)
+  (:local-nicknames (:a :alexandria))
   (:export
    #:make-resource-collection           ; FUNCTION
    #:make-qubit-resource                ; FUNCTION
@@ -30,8 +31,7 @@
         #:parse-float
         #:abstract-classes
         #:singleton-classes
-        #:cl-quil.resource
-        #:alexandria)
+        #:cl-quil.resource)
   (:local-nicknames (:a :alexandria))
   ;; options.lisp
   (:export
@@ -431,6 +431,7 @@
   (:nicknames #:quil.clifford)
   (:use #:cl
         #:cl-permutation)
+  (:local-nicknames (:a :alexandria))
 
   ;; clifford/ module
   (:export

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -244,7 +244,7 @@ INPUT-STRING that triggered the condition."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Parser ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-condition quil-parse-error (alexandria:simple-parse-error)
+(define-condition quil-parse-error (a:simple-parse-error)
   ()
   (:documentation "Representation of an error parsing Quil."))
 

--- a/src/resource.lisp
+++ b/src/resource.lisp
@@ -120,7 +120,7 @@ classical memory regions. "
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (alexandria:define-constant +impossibly-full-resource+
+  (a:define-constant +impossibly-full-resource+
       (make-resource-collection
        :qubits +full+
        :memory-regions t)
@@ -378,7 +378,7 @@ DEFAULT-VALUE is used. "
 (defconstant +range-lower-bound+ most-negative-fixnum)
 (defconstant +range-upper-bound+ most-positive-fixnum)
 
-(alexandria:define-constant +full-range+
+(a:define-constant +full-range+
     (list (cons +range-lower-bound+ +range-upper-bound+))
   :test 'equal
   :documentation "The largest possible range.")
@@ -395,7 +395,7 @@ RANGES."
     ((endp ranges)
      nil)
     ((>= (interval-hi range) (first-interval-lo ranges))
-     (alexandria:maxf (interval-hi range) (first-interval-hi ranges)))))
+     (a:maxf (interval-hi range) (first-interval-hi ranges)))))
 
 (defun range-union (r1 r2)
   (nconc

--- a/src/transformable-mixin.lisp
+++ b/src/transformable-mixin.lisp
@@ -29,7 +29,7 @@
   (assert (null options) (options)
           "No options are supported at this time.")
   (multiple-value-bind (predecessors decls doc)
-      (alexandria:parse-body (append docs-and-predecessors '(nil)) :documentation t)
+      (a:parse-body (append docs-and-predecessors '(nil)) :documentation t)
     (assert (null decls) (docs-and-predecessors)
             "DEFINE-TRANSFORM can't have any declarations. Found ~S." decls)
     (assert (every #'symbolp predecessors) (docs-and-predecessors)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -110,7 +110,7 @@ Return two values:
                   (push item current-segment))
                  (t
                   (let ((satisfied (funcall predicate item)))
-                    (when (alexandria:xor satisfied current-satisfaction)
+                    (when (a:xor satisfied current-satisfaction)
                       ;; We have differing satisfactions.
                       (finish-segment)
                       (setf current-satisfaction satisfied))
@@ -127,7 +127,7 @@ Return two values:
          (finish-segment)
          (values (nreverse segments)
                  ;; I'm not even gonna comment this.
-                 (alexandria:xor current-satisfaction (evenp num-segments))))))))
+                 (a:xor current-satisfaction (evenp num-segments))))))))
 
 (defun ilog2 (x)
   "Compute integer logarithm of X to the base 2."
@@ -141,10 +141,10 @@ Return two values:
   "Given an INTEGER N, return true if N is a power of 2, greater than 1."
   (and (> n 1) (power-of-two-p n)))
 
-(alexandria:define-constant double-float-positive-infinity
+(a:define-constant double-float-positive-infinity
     #+ccl ccl::double-float-positive-infinity
     #+ecl ext:double-float-positive-infinity
     #+sbcl sb-ext:double-float-positive-infinity
     #-(or ccl ecl sbcl) (error "double-float-positive-infinity not available."))
 
-(alexandria:define-constant pi #.(coerce cl:pi 'double-float))
+(a:define-constant pi #.(coerce cl:pi 'double-float))

--- a/tests/analysis-tests.lisp
+++ b/tests/analysis-tests.lisp
@@ -12,7 +12,7 @@
               (sort (copy-seq a) #'<)
               (sort (copy-seq b) #'<))))
 
-(alexandria:define-constant +identity-defgate+ "
+(a:define-constant +identity-defgate+ "
 DEFGATE I:
     1, 0, 0, 0
     0, 1, 0, 0
@@ -302,13 +302,13 @@ B(b) 0 1
           :accessor dummy-node-value)))
 
 (defun dummy-node (x)
-  (make-instance 'dummy-node :value (alexandria:ensure-list x)))
+  (make-instance 'dummy-node :value (a:ensure-list x)))
 
 (defmethod quil::fuse-objects ((a dummy-node) (b dummy-node))
   (make-instance 'dummy-node
                  :value (append
-                         (alexandria:ensure-list (dummy-node-value a))
-                         (alexandria:ensure-list (dummy-node-value b)))))
+                         (a:ensure-list (dummy-node-value a))
+                         (a:ensure-list (dummy-node-value b)))))
 
 (deftest test-fuse-dummy-objects ()
   "Test that FUSE-OBJECTS behaves properly in MERGE-GRID-NODES."
@@ -335,7 +335,7 @@ B(b) 0 1
              (is (= 1 (length (quil::roots output-pg))))
              (let ((root (first (quil::roots output-pg))))
                (is (quil::root-node-p root))
-               (is (every (alexandria:curry #'eq root) (quil::trailers output-pg)))
+               (is (every (a:curry #'eq root) (quil::trailers output-pg)))
                (is (every #'null (quil::grid-node-back root)))
                (is (every #'null (quil::grid-node-forward root)))
                (is (equalp (mapcar #'first proto-nodes)

--- a/tests/approximation-tests.lisp
+++ b/tests/approximation-tests.lisp
@@ -7,15 +7,15 @@
 
 (deftest test-approximate-compilation ()
   (let* ((chip (quil::build-nq-linear-chip 3 :architecture ':cz))
-         (fidelity-hash (alexandria:plist-hash-table (list "fCZ"   0.50d0
-                                                           "f1QRB" 0.99d0)
-                                                     :test #'equalp))
+         (fidelity-hash (a:plist-hash-table (list "fCZ" 0.50d0
+                                                  "f1QRB" 0.99d0)
+                                            :test #'equalp))
          (pp (quil::parse-quil "CPHASE(pi/4) 0 1"))
          (m-in (quil::make-matrix-from-quil (coerce (quil::parsed-program-executable-code pp) 'list)))
          cpp m-out)
     (loop
-       :for obj :across (quil::vnth 1 (quil::chip-specification-objects chip))
-       :do (setf (gethash "specs" (quil::hardware-object-misc-data obj)) fidelity-hash))
+      :for obj :across (quil::vnth 1 (quil::chip-specification-objects chip))
+      :do (setf (gethash "specs" (quil::hardware-object-misc-data obj)) fidelity-hash))
     (let ((quil::*enable-approximate-compilation* t))
       (setf cpp (quil::compiler-hook pp chip)))
     ;; check: results are approximately correct

--- a/tests/clifford-tests.lisp
+++ b/tests/clifford-tests.lisp
@@ -193,7 +193,7 @@
             (setf (gethash rep equivalence-classes)
                   (cons key (gethash rep equivalence-classes))))))
     ;;Check that all 2Q classes contain two elements
-    (dolist (class (alexandria:hash-table-values equivalence-classes))
+    (dolist (class (a:hash-table-values equivalence-classes))
       (is (= 2 (length class))))))
 
 (defparameter *chp-test-files-directory*
@@ -218,7 +218,7 @@
         :repeat 500
         :do
            (let ((tab (cl-quil.clifford::make-tableau-zero-state 6))
-                 (qubits (alexandria:iota 6) #+igh(alexandria:shuffle '(0 1 2 3 4 5))))
+                 (qubits (a:iota 6) #+igh(a:shuffle '(0 1 2 3 4 5))))
              (cl-quil.clifford::tableau-apply-h    tab 0)
              (cl-quil.clifford::tableau-apply-cnot tab 0 1)
              (cl-quil.clifford::tableau-apply-cnot tab 1 2)

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -89,7 +89,7 @@
                  (processed-quil (funcall (cl-quil::approximate-2q-compiler-for target-type (build-8Q-chip))
                                           (build-anonymous-gate ref-mat 1 0)))
                  (mat (cl-quil::make-matrix-from-quil processed-quil))
-                 (big-gates (mapcar (alexandria:compose
+                 (big-gates (mapcar (a:compose
                                      #'quil::operator-description-name
                                      #'application-operator)
                                     (remove-if (lambda (i) (= 1 (length (application-arguments i))))
@@ -154,7 +154,7 @@
               :test #'equalp))))
 
 (defun link-nativep (chip-spec)
-  (reduce #'alexandria:disjoin
+  (reduce #'a:disjoin
           (quil::chip-spec-links chip-spec)
           :initial-value (constantly t)
           :key #'quil::hardware-object-native-instructions))

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -165,7 +165,7 @@ RX(pi) 2
         (format *debug-io* "      Working on architecture ~a.~%" architecture)
         (let* ((num-qubits 4)
                (v (quil::random-special-unitary (expt 2 num-qubits)))
-               (args (shuffle-list (alexandria:iota num-qubits :start (1- num-qubits) :step -1)))
+               (args (shuffle-list (a:iota num-qubits :start (1- num-qubits) :step -1)))
                (parsed-prog (make-instance
                              'quil::parsed-program
                              :executable-code (make-array 1

--- a/tests/defcircuit-tests.lisp
+++ b/tests/defcircuit-tests.lisp
@@ -244,8 +244,8 @@
               "DAGGER BELL"))
          (code (quil:parsed-program-executable-code p)))
     (destructuring-bind (instr-cnot instr-h)
-        (mapcar (alexandria:compose #'quil::operator-description-string
-                                    #'quil:application-operator)
+        (mapcar (a:compose #'quil::operator-description-string
+                           #'quil:application-operator)
                 (coerce code 'list))
       (is (string= "DAGGER CNOT" instr-cnot))
       (is (string= "DAGGER H" instr-h)))))
@@ -263,8 +263,8 @@
     ;; Note that here the order of operations is reversed yet again,
     ;; so that the H 0 instruction is back on top.
     (destructuring-bind (instr-h instr-cnot)
-        (mapcar (alexandria:compose #'quil::operator-description-string
-                                    #'quil:application-operator)
+        (mapcar (a:compose #'quil::operator-description-string
+                           #'quil:application-operator)
                 (coerce code 'list))
       (is (string= "H" instr-h))
       (is (string= "CNOT" instr-cnot)))))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -92,7 +92,7 @@
                  (unless (= j (1- (expt 2 qubit-count)))
                    (format s ", ")))
                (format s "~%"))
-             (format s "TEST ~{~d ~}" (alexandria:iota qubit-count))))
+             (format s "TEST ~{~d ~}" (a:iota qubit-count))))
          (parsed-prog (quil::parse-quil-into-raw-program program-string)))
     (setf parsed-prog (quil::transform 'quil::resolve-applications parsed-prog))
     (is (quil::matrix-equality (magicl:make-identity-matrix (expt 2 qubit-count))
@@ -272,7 +272,7 @@
   (signals simple-error (quil::check-permutation '(0 1 2 5 3)))
   ;; Valid permutations. Grows as n!, so don't get too crazy here.
   (dotimes (n 6)
-    (alexandria:map-permutations
+    (a:map-permutations
      (lambda (permutation)
        (not-signals simple-error (quil::check-permutation permutation)))
-     (alexandria:iota n))))
+     (a:iota n))))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -3,7 +3,8 @@
 ;;;; Author: Robert Smith
 
 (fiasco:define-test-package #:cl-quil-tests
-    (:use #:cl-quil #:cl-quil.clifford)
+  (:local-nicknames (:a :alexandria))
+  (:use #:cl-quil #:cl-quil.clifford)
 
   ;; suite.lisp
   (:export

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -148,8 +148,8 @@
     (destructuring-bind (instr-dagger^1
                          instr-dagger^2
                          instr-dagger^3)
-        (mapcar (alexandria:compose #'quil::operator-description-string
-                                    #'quil:application-operator)
+        (mapcar (a:compose #'quil::operator-description-string
+                           #'quil:application-operator)
                 (coerce code 'list))
       (is (string= "DAGGER H" instr-dagger^1))
       (is (string= "H" instr-dagger^2))

--- a/tests/resource-tests.lisp
+++ b/tests/resource-tests.lisp
@@ -75,7 +75,7 @@
 
 
 (deftest test-resource-difference ()
-  (let ((universe (make-qubit-resources (alexandria:iota 30))))
+  (let ((universe (make-qubit-resources (a:iota 30))))
     (loop
       :repeat 20
       :for l := (loop :repeat 20 :collect (random 30))
@@ -114,7 +114,7 @@
     (loop :repeat (1+ (random 10))
           :for size := (random 10)
           :for lo := (random (- 50 size))
-          :collect (quil::make-resource-range (format nil "~d" (alexandria:random-elt range-names)) lo (+ lo size))))))
+          :collect (quil::make-resource-range (format nil "~d" (a:random-elt range-names)) lo (+ lo size))))))
 
 (deftest test-resource-identities ()
   (let* ((names (list "a" "b" "c"))

--- a/tests/translator-tests.lisp
+++ b/tests/translator-tests.lisp
@@ -84,7 +84,7 @@
 (deftest test-ucr-recognition ()
   (dolist (roll-type (list "RY" "RZ"))
     (let* ((qubit-count 4)
-           (argument-list (random-permutation (mapcar #'qubit (alexandria:iota qubit-count))))
+           (argument-list (random-permutation (mapcar #'qubit (a:iota qubit-count))))
            (angle-list (mapcar (lambda (x)
                                  (declare (ignore x))
                                  (constant (random (* 2 pi))))
@@ -96,7 +96,7 @@
            (ucr-matrix (quil::make-matrix-from-quil (list ucr-instruction)))
            (anonymous-instr (make-instance 'quil::gate-application
                                            :operator #.(named-operator "ANONYMOUS-UCR")
-                                           :arguments (mapcar #'qubit (nreverse (alexandria:iota qubit-count)))
+                                           :arguments (mapcar #'qubit (nreverse (a:iota qubit-count)))
                                            :gate ucr-matrix))
            (recognized-instruction (quil::recognize-ucr anonymous-instr))
            (recognized-matrix (quil::make-matrix-from-quil recognized-instruction)))


### PR DESCRIPTION
For the sake of reasonable line-length when currying and more!

I will add the same to `quilc.asd` etc. and replace `(alexandria:` with `(a:` if y'all concur.