### PR TITLE
Adds compiler-rewrite-does-not-apply error condition

### DIFF
--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -38,13 +38,17 @@
   ()
   (:documentation "This is signaled when a compiler is technically applicable, but would act as an identity."))
 
+(define-condition compiler-rewrite-does-not-apply (compiler-does-not-apply)
+  ()
+  (:documentation "This is signaled when a rewriting rule cannot be applied to an instruction sequence."))
 
 
 (defun give-up-compilation (&key (because ':unknown))
   (ecase because
-    (:invalid-domain (error 'compiler-invalid-domain))
-    (:acts-trivially (error 'compiler-acts-trivially))
-    (:unknown        (error 'compiler-does-not-apply))))
+    (:invalid-domain         (error 'compiler-invalid-domain))
+    (:acts-trivially         (error 'compiler-acts-trivially))
+    (:rewrite-does-not-apply (error 'compiler-rewrite-does-not-apply))
+    (:unknown                (error 'compiler-does-not-apply))))
 
 
 ;;; Core routines governing how a chip-specification's compiler list is walked

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -47,7 +47,6 @@
   (ecase because
     (:invalid-domain         (error 'compiler-invalid-domain))
     (:acts-trivially         (error 'compiler-acts-trivially))
-    (:rewrite-does-not-apply (error 'compiler-rewrite-does-not-apply))
     (:unknown                (error 'compiler-does-not-apply))))
 
 

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -476,7 +476,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
   (check-type coord symbol)
   (check-type q1 symbol)
   (check-type q0 symbol)
-  
+
   (multiple-value-bind (body-prog decls docstring)
       (a:parse-body body :documentation t)
     `(progn
@@ -684,7 +684,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 
 (define-approximate-template nearest-CZ-circuit-of-depth-2 (coord q1 q0)
     (:requirements (:cz)
-     :predicate (double= 0d0 (third coord)))    
+     :predicate (double= 0d0 (third coord)))
   (list (build-gate "CZ" () q1 q0)
         (build-gate "RY" (list (first coord)) q1)
         (build-gate "RY" (list (second coord)) q0)
@@ -716,7 +716,7 @@ Both CENTER-CIRCUIT and the return value are lists of GATE-APPLICATIONs; A, D, a
       (match-matrix-to-an-e-basis-diagonalization
        (make-matrix-from-quil center-circuit :relabeling (standard-qubit-relabeler `(,q1 ,q0)))
        a d b)
-    
+
     (multiple-value-bind (b1 b0) (convert-su4-to-su2x2 ub)
       (multiple-value-bind (a1 a0) (convert-su4-to-su2x2 ua)
         (values
@@ -733,14 +733,14 @@ Both CENTER-CIRCUIT and the return value are lists of GATE-APPLICATIONs; A, D, a
 NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMATE-COMPILER* is NIL."
   (check-type instr gate-application)
   (check-type chip-spec (or null chip-specification))
-  
+
   (unless (= 2 (length (application-arguments instr)))
     (give-up-compilation))
-  
+
   ;; extract matrix, canonical decomposition
   (let* ((q1 (qubit-index (first (application-arguments instr))))
          (q0 (qubit-index (second (application-arguments instr))))
-         (m (or (gate-matrix instr) (give-up-compilation :because ':invalid-domain)))
+         (m (or (gate-matrix instr) (error 'compiler-invalid-domain)))
          (m (magicl:scale (expt (magicl:det m) -1/4) m)))
     (multiple-value-bind (a d b) (orthogonal-decomposition m)
       ;; now we manufacture a bunch of candidate circuits

--- a/src/compilers/optimal-2q.lisp
+++ b/src/compilers/optimal-2q.lisp
@@ -131,7 +131,7 @@ The optional argument INSTR is used to canonicalize the qubit indices of the ins
   ;; identity is *not* getting us closer.
   (when (gate-application-trivially-satisfies-2q-target-requirements
          instr (a:ensure-list target))
-    (give-up-compilation :because ':acts-trivially))
+    (error 'compiler-acts-trivially))
 
   ;; first, some utility definitions for 2Q templates that require numerical solvers
   (let ((m (gate-matrix instr)))

--- a/src/compressor/rewriting-rule-data-type.lisp
+++ b/src/compressor/rewriting-rule-data-type.lisp
@@ -14,7 +14,7 @@
 READABLE-NAME is a string used to identify the rewriting rule during debugging.
 
 COUNT is an integer that specifies the number of adjacent instructions the rule takes as input.
- 
+
 CONSUMER is a function that consumes a COMPRESSOR-CONTEXT followed by a list of instructions.  Its possible results are:
    * The error condition COMPILER-DOES-NOT-APPLY if the rule is inapplicable.
    * a LIST of instructions if the rule applies.
@@ -23,7 +23,7 @@ CONSUMER is a function that consumes a COMPRESSOR-CONTEXT followed by a list of 
   (count 1 :read-only t :type (and fixnum unsigned-byte))
   (consumer (lambda (context item)
               (declare (ignore context item))
-              (give-up-compilation))
+              (error 'compiler-rewrite-does-not-apply))
    :read-only t))
 
 (defmacro make-rewriting-rule (readable-name (context-var &rest bind-clauses) &body body)
@@ -108,12 +108,12 @@ BODY is a list of forms that, by the end, should construct a list of instruction
 ;;; dumb little macros for cond guards that we were repeating a million times
 
 (defmacro give-up-compilation-unless (test &body body)
-  "If TEST passes, proceed to execute BODY (and return the value of the final expression). If TEST fails, call GIVE-UP-COMPILATION."
+  "If TEST passes, proceed to execute BODY (and return the value of the final expression). If TEST fails, signal compiler-rewrite-does-not-apply."
   `(cond
      (,test
       ,@body)
      (t
-      (give-up-compilation))))
+      (error 'compiler-rewrite-does-not-apply))))
 
 (defmacro unpack-wf (instr context (psi qubits) &body body)
   "Extracts from CONTEXT the wavefunction component related to the instruction INSTR.  Upon success, bind PSI to the wavefunction contents, bind QUBITS to the qubit ordering convention of PSI, execute BODY, and return the result of the final expression.  Upon failure, call GIVE-UP-COMPILATION."

--- a/src/compressor/rewriting-rule-data-type.lisp
+++ b/src/compressor/rewriting-rule-data-type.lisp
@@ -23,7 +23,7 @@ CONSUMER is a function that consumes a COMPRESSOR-CONTEXT followed by a list of 
   (count 1 :read-only t :type (and fixnum unsigned-byte))
   (consumer (lambda (context item)
               (declare (ignore context item))
-              (give-up-compilation :because ':rewrite-does-not-apply))
+              (error 'compiler-rewrite-does-not-apply))
    :read-only t))
 
 (defmacro make-rewriting-rule (readable-name (context-var &rest bind-clauses) &body body)
@@ -107,19 +107,19 @@ BODY is a list of forms that, by the end, should construct a list of instruction
 
 ;;; dumb little macros for cond guards that we were repeating a million times
 
-(defmacro give-up-compilation-unless (test &body body)
+(defmacro give-up-rewriting-unless (test &body body)
   "If TEST passes, proceed to execute BODY (and return the value of the final expression). If TEST fails, signal compiler-rewrite-does-not-apply."
   `(cond
      (,test
       ,@body)
      (t
-      (give-up-compilation :because ':rewrite-does-not-apply))))
+      (error 'compiler-rewrite-does-not-apply))))
 
 (defmacro unpack-wf (instr context (psi qubits) &body body)
-  "Extracts from CONTEXT the wavefunction component related to the instruction INSTR.  Upon success, bind PSI to the wavefunction contents, bind QUBITS to the qubit ordering convention of PSI, execute BODY, and return the result of the final expression.  Upon failure, call GIVE-UP-COMPILATION."
+  "Extracts from CONTEXT the wavefunction component related to the instruction INSTR.  Upon success, bind PSI to the wavefunction contents, bind QUBITS to the qubit ordering convention of PSI, execute BODY, and return the result of the final expression.  Upon failure, signal COMPILER-REWRITE-DOES-NOT-APPLY"
   `(destructuring-bind (,psi ,qubits)
        (aqvm-extract-state (compressor-context-aqvm ,context)
                            (mapcar #'qubit-index (application-arguments ,instr)))
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (not (eql ':not-simulated ,psi))
        ,@body)))

--- a/src/compressor/rewriting-rule-data-type.lisp
+++ b/src/compressor/rewriting-rule-data-type.lisp
@@ -23,7 +23,7 @@ CONSUMER is a function that consumes a COMPRESSOR-CONTEXT followed by a list of 
   (count 1 :read-only t :type (and fixnum unsigned-byte))
   (consumer (lambda (context item)
               (declare (ignore context item))
-              (error 'compiler-rewrite-does-not-apply))
+              (give-up-compilation :because ':rewrite-does-not-apply))
    :read-only t))
 
 (defmacro make-rewriting-rule (readable-name (context-var &rest bind-clauses) &body body)
@@ -113,7 +113,7 @@ BODY is a list of forms that, by the end, should construct a list of instruction
      (,test
       ,@body)
      (t
-      (error 'compiler-rewrite-does-not-apply))))
+      (give-up-compilation :because ':rewrite-does-not-apply))))
 
 (defmacro unpack-wf (instr context (psi qubits) &body body)
   "Extracts from CONTEXT the wavefunction component related to the instruction INSTR.  Upon success, bind PSI to the wavefunction contents, bind QUBITS to the qubit ordering convention of PSI, execute BODY, and return the result of the final expression.  Upon failure, call GIVE-UP-COMPILATION."

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -391,7 +391,7 @@
                  ;; the control bit is on: 1100
                  ;; all the bits are nonzero, so we can't reduce: 1111
                  (otherwise
-                  (error 'compiler-rewrite-does-not-apply)))))))))))
+                  (give-up-compilation :because ':rewrite-does-not-apply)))))))))))
 
 (defun rewriting-rules-for-link-of-CPHASE-type ()
   "Generates a list of rewriting rules for simplifying expressions involving CPHASE and standard single-qubit operations."

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -15,7 +15,7 @@
         (("CZ" () p q) x)
         (("CZ" () r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (< (+ (ash 1 p) (ash 1 q))
             (+ (ash 1 r) (ash 1 s)))
        (list y x)))
@@ -25,7 +25,7 @@
         (("CPHASE" (_) p q) x)
         (("CPHASE" (_) r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (< (+ (ash 1 p) (ash 1 q))
             (+ (ash 1 r) (ash 1 s)))
        (list y x)))
@@ -36,7 +36,7 @@
 
      (unpack-wf instr context (psi qubit-indices)
        (let ((updated-wf (nondestructively-apply-instr-to-wf instr psi qubit-indices)))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (collinearp psi updated-wf)
            (list)))))))
 
@@ -56,7 +56,7 @@
         (_
          ((,roll-type (theta) _) x))
 
-      (give-up-compilation-unless
+      (give-up-rewriting-unless
           (and (typep theta 'double-float)
                (double= (/ theta (* 2 pi))
                         (round (/ theta (* 2 pi)))))
@@ -66,10 +66,10 @@
         (_
          ((,roll-type (theta) q) x))
 
-      (give-up-compilation-unless
+      (give-up-rewriting-unless
           (typep theta 'double-float)
         (let ((reduced-theta (- (mod (+ pi theta) (* 2 pi)) pi)))
-          (give-up-compilation-unless
+          (give-up-rewriting-unless
               (and (< pi (abs theta))
                    (< (abs reduced-theta) (abs theta)))
             (list (build-gate ,roll-type (list reduced-theta) q))))))
@@ -116,7 +116,7 @@
          ((,rollA (theta2) q) y)
          ((,rollB (theta3) q) z))
 
-      (give-up-compilation-unless
+      (give-up-rewriting-unless
           (and (typep theta1 'double-float)
                (double= (/ pi 2) (abs theta1))
                (typep theta2 'double-float)
@@ -146,7 +146,7 @@
         (("ISWAP" () p q) x)
         (("ISWAP" () r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "RZ" (list pi) p)
              (build-gate "RZ" (list pi) q))))
@@ -156,7 +156,7 @@
         (("RZ"    (theta) q)     x)
         (("ISWAP" ()      q1 q2) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (or (= q q1) (= q q2))
        (list (build-gate "ISWAP" ()           q1 q2)
              (build-gate "RZ"    (list theta) (if (= q q1) q2 q1)))))))
@@ -170,7 +170,7 @@
         (("PISWAP" (theta) p q) x)
         (("PISWAP" (phi)   r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "PISWAP" (list (param-+ theta phi)) p q))))
 
@@ -178,10 +178,10 @@
        (_
         (("PISWAP" (theta) p q) x))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (typep theta 'double-float)
        (let ((reduced-theta (mod theta (* 4 pi))))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (not (double= theta reduced-theta))
            (list (build-gate "PISWAP" (list reduced-theta) p q))))))
 
@@ -203,7 +203,7 @@
         (("RZ"     (theta) q)     x)
         (("PISWAP" (phi)   q1 q2) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (and (typep phi 'double-float)
               (double= 0d0 (mod (abs phi) pi))
               (or (= q q1) (= q q2)))
@@ -218,7 +218,7 @@
        (_
         (("PISWAP" (theta) p q) x))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (and (typep theta 'double-float)
               (double= (* pi (floor theta pi)) theta))
        (list (build-gate "ISWAP"  ()  p)
@@ -229,7 +229,7 @@
         (("ISWAP"  ()    p q) x)
         (("PISWAP" (phi) r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "PISWAP" (list (param-+ pi phi)) p q))))
 
@@ -238,7 +238,7 @@
         (("PISWAP" (theta) p q) x)
         (("ISWAP"  ()      r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "PISWAP" (list (param-+ theta pi)) p q))))))
 
@@ -260,7 +260,7 @@
         (("CNOT" () p q) x)
         (("CNOT" () r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list)))
 
@@ -289,7 +289,7 @@
         (("CZ" () p q) x)
         (("CZ" () r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list)))
 
@@ -298,7 +298,7 @@
         (("RZ" (_) q)    x)
         (("CZ" () q1 q2) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (or (= q q1) (= q q2))
        (list y x)))
 
@@ -307,7 +307,7 @@
         (("RX" (#.pi) q)     x)
         (("CZ" ()     q1 q2) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (or (= q q1) (= q q2))
        (list (build-gate "CZ" ()        q1 q2)
              (build-gate "RZ" (list pi) (if (= q q1) q2 q1))
@@ -324,7 +324,7 @@
                 (loop :for i :below (array-total-size psi)
                       :when (logbitp control-bit i)
                         :sum (expt (abs (aref psi i)) 2))))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (double= 0d0 (sqrt control-bit-weight))
            (list)))))
 
@@ -340,7 +340,7 @@
                 (loop :for i :below (array-total-size psi)
                       :when (logbitp control-bit i)
                         :sum (expt (abs (aref psi i)) 2))))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (double= 1d0 (sqrt control-bit-weight))
            (list (build-gate "RZ" (list pi) target))))))
 
@@ -362,7 +362,7 @@
            (dotimes (i (array-total-size psi))
              (incf (aref wf-components (position-type i))
                    (expt (abs (aref psi i)) 2)))
-           (give-up-compilation-unless
+           (give-up-rewriting-unless
                (not (double= 0d0 (aref wf-components 3)))
              (let ((wf-signature
                      (+ (if (double= 0d0 (aref wf-components 0))
@@ -391,7 +391,7 @@
                  ;; the control bit is on: 1100
                  ;; all the bits are nonzero, so we can't reduce: 1111
                  (otherwise
-                  (give-up-compilation :because ':rewrite-does-not-apply)))))))))))
+                  (error 'compiler-rewrite-does-not-apply)))))))))))
 
 (defun rewriting-rules-for-link-of-CPHASE-type ()
   "Generates a list of rewriting rules for simplifying expressions involving CPHASE and standard single-qubit operations."
@@ -401,7 +401,7 @@
         (("CPHASE" (theta) p q) x)
         (("CPHASE" (phi)   r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "CPHASE" (list (param-+ theta phi)) p q))))
 
@@ -409,7 +409,7 @@
        (_
         (("CPHASE" (theta) _ _) x))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (and (typep theta 'double-float)
               (double= 0d0 (mod theta (* 2 pi))))
        (list)))
@@ -418,7 +418,7 @@
        (_
         (("CPHASE" (theta) p q) x))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (and (typep theta 'double-float)
               (not (double= theta (mod theta (* 2 pi)))))
        (list (build-gate "CPHASE" (list (mod theta (* 2 pi))) p q))))
@@ -441,7 +441,7 @@
                 (loop :for i :below (array-total-size psi)
                       :when (logbitp control-bit i)
                         :sum (expt (abs (aref psi i)) 2))))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (double= 0d0 (sqrt control-bit-weight))
            (list)))))
 
@@ -457,7 +457,7 @@
                 (loop :for i :below (array-total-size psi)
                       :when (logbitp control-bit i)
                         :sum (expt (abs (aref psi i)) 2))))
-         (give-up-compilation-unless
+         (give-up-rewriting-unless
              (double= 1d0 (sqrt control-bit-weight))
            (list (build-gate "RZ" (list theta) target))))))
    (rewriting-rules-for-link-of-CZ-type)))
@@ -479,7 +479,7 @@
         (("CPHASE" (phi) p q) x)
         (("CZ"     ()    r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "CPHASE" (list (param-+ phi pi)) p q))))
 
@@ -489,7 +489,7 @@
         (("CZ"     ()    p q) x)
         (("CPHASE" (phi) r s) y))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (subsetp (list p q) (list r s))
        (list (build-gate "CPHASE" (list (param-+ phi pi)) p q))))
 
@@ -497,7 +497,7 @@
        (_
         (("CPHASE" (theta) p q) x))
 
-     (give-up-compilation-unless
+     (give-up-rewriting-unless
          (and (typep theta 'double-float)
               (double= 0d0 (mod (+ pi theta) (* 2 pi))))
        (list (build-gate "CZ" () p q))))))


### PR DESCRIPTION
Updates relevant call sites previously using the non-specific `GIVE-UP-COMPILATION` to directly signal the new condition when applicable. 

please see rigetti/quilc/issues/46