### PR TITLE
Rely on the dynamic linker for libtweedledum (#254)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ QUICKLISP_BOOTSTRAP_URL=https://beta.quicklisp.org/quicklisp.lisp
 UNAME_S=$(shell uname -s)
 ZMQ_REPO=https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/
 PREFIX ?= /usr/local
+TWEEDLEDUM ?= $(join $(realpath $(shell pwd)), /src/contrib/tweedledum)
 
 all: quilc
 
@@ -140,6 +141,7 @@ test-quilc:
 # You can specify a different c++17-compatible compiler via the CXX
 # variable. For example: make CXX=/usr/bin/clang++ test-tweedledum
 test-tweedledum:
+	LD_LIBRARY_PATH=$(TWEEDLEDUM):$(LD_LIBRARY_PATH) \
 	$(QUICKLISP) \
 		--eval "(ql:quickload :cl-quil/tweedledum-tests)" \
 		--eval "(asdf:test-system :cl-quil/tweedledum-tests)"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 COMMIT_HASH=$(shell git rev-parse --short HEAD)
 LISP_CACHE ?= $(HOME)/.cache/common-lisp
 RIGETTI_LISP_LIBRARY_HOME=../
-TWEEDLEDUM ?= $(join $(CURDIR), /src/contrib/tweedledum)
-LD_LIBRARY_PATH := $(TWEEDLEDUM):$(LD_LIBRARY_PATH)
 SBCL_BIN=sbcl
-SBCL=LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(SBCL_BIN) --noinform --no-userinit --no-sysinit --non-interactive
+SBCL=$(SBCL_BIN) --noinform --no-userinit --no-sysinit --non-interactive
 QUICKLISP_HOME=$(HOME)/quicklisp
 QUICKLISP_SETUP=$(QUICKLISP_HOME)/setup.lisp
 QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
@@ -16,13 +14,6 @@ QUICKLISP_BOOTSTRAP_URL=https://beta.quicklisp.org/quicklisp.lisp
 UNAME_S=$(shell uname -s)
 ZMQ_REPO=https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/
 PREFIX ?= /usr/local
-ifeq ($(UNAME_S),Linux)
-SOEXT := .so
-endif
-ifeq ($(UNAME_S),Darwin)
-SOEXT := .dylib
-endif
-LIBTWEEDLEDUM := $(TWEEDLEDUM)/libtweedledum$(SOEXT)
 
 all: quilc
 
@@ -75,7 +66,7 @@ endif
 ###############################################################################
 
 .PHONY: quilc
-quilc $(LIBTWEEDLEDUM): system-index.txt
+quilc: system-index.txt
 	$(SBCL) $(FOREST_SDK_FEATURE) \
 	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
 		--eval '(push :hunchentoot-no-ssl *features*)' \
@@ -117,12 +108,9 @@ docker-sdk-barebones: docker
 # INSTALL/UNINSTALL
 ###############################################################################
 
-.PHONY: install install-libtweedledum
-install: quilc install-libtweedledum
+.PHONY: install
+install: quilc
 	install quilc $(DESTDIR)$(PREFIX)/bin
-
-install-libtweedledum: $(LIBTWEEDLEDUM)
-	install $< $(DESTDIR)$(PREFIX)/lib
 
 .PHONY: uninstall
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT_HASH=$(shell git rev-parse --short HEAD)
 LISP_CACHE ?= $(HOME)/.cache/common-lisp
 RIGETTI_LISP_LIBRARY_HOME=../
-TWEEDLEDUM ?= $(join $(realpath $(shell pwd)), /src/contrib/tweedledum)
+TWEEDLEDUM ?= $(join $(CURDIR), /src/contrib/tweedledum)
 LD_LIBRARY_PATH := $(TWEEDLEDUM):$(LD_LIBRARY_PATH)
 SBCL_BIN=sbcl
 SBCL=LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(SBCL_BIN) --noinform --no-userinit --no-sysinit --non-interactive

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -193,6 +193,7 @@
   (disable-debugger))
 
 (defun entry-point (argv)
+  #-win32
   (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum)
   (handler-case
       (%entry-point argv)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -193,7 +193,7 @@
   (disable-debugger))
 
 (defun entry-point (argv)
-  (cffi:load-foreign-library (read-from-string "CL-QUIL.TWEEDLEDUM::LIBTWEEDLEDUM"))
+  (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum)
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/src/contrib/tweedledum/README.md
+++ b/src/contrib/tweedledum/README.md
@@ -116,7 +116,14 @@ $ git submodule init
 $ git submodule update --init
 ```
 
-You can then load the `cl-quil/tweedledum` package
+You must inform the dynamic linker of the path where the shared library,
+libtweedledum, will be placed once it is compiled (see below). For example,
+using the Bash shell,
+```
+export LD_LIBRARY_PATH=/path/to/quilc/src/contrib/tweedledum
+```
+
+Then, run sbcl and load the `cl-quil/tweedledum` package
 ```
 CL-USER> (ql:quickload :cl-quil/tweedledum)
 CL-USER> (cl-quil.tweedledum:synthesis-dbs '(0 1 3 2))

--- a/src/contrib/tweedledum/README.md
+++ b/src/contrib/tweedledum/README.md
@@ -120,7 +120,7 @@ You must inform the dynamic linker of the path where the shared library,
 libtweedledum, will be placed once it is compiled (see below). For example,
 using the Bash shell,
 ```
-export LD_LIBRARY_PATH=/path/to/quilc/src/contrib/tweedledum
+export LD_LIBRARY_PATH=/path/to/quilc/src/contrib/tweedledum:$LD_LIBRARY_PATH
 ```
 
 Then, run sbcl and load the `cl-quil/tweedledum` package

--- a/src/contrib/tweedledum/README.md
+++ b/src/contrib/tweedledum/README.md
@@ -116,14 +116,7 @@ $ git submodule init
 $ git submodule update --init
 ```
 
-You must inform the dynamic linker of the path where the shared library,
-libtweedledum, will be placed once it is compiled (see below). For example,
-using the Bash shell,
-```
-export LD_LIBRARY_PATH=/path/to/quilc/src/contrib/tweedledum:$LD_LIBRARY_PATH
-```
-
-Then, run sbcl and load the `cl-quil/tweedledum` package
+You can then load the `cl-quil/tweedledum` package
 ```
 CL-USER> (ql:quickload :cl-quil/tweedledum)
 CL-USER> (cl-quil.tweedledum:synthesis-dbs '(0 1 3 2))

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -9,17 +9,8 @@
 (in-package #:cl-quil.tweedledum)
 
 (cffi:define-foreign-library libtweedledum
-  (:darwin (:or #.(merge-pathnames "libtweedledum.dylib"
-                                   (or *compile-file-truename*
-                                       *load-truename*))
-                "libtweedledum.dylib"
-                "tweedledum.dylib"))
-  (:unix  (:or #.(merge-pathnames "libtweedledum.so"
-                                  (or *compile-file-truename*
-                                      *load-truename*))
-               "libtweedledum.so"
-               "tweedledum.so"))
-
+  (:darwin (:or "libtweedledum.dylib" "tweedledum.dylib"))
+  (:unix (:or "libtweedledum.so" "tweedledum.so"))
   (t (:default "libtweedledum")))
 
 (defvar *tweedledum-libs-loaded* nil

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -8,7 +8,8 @@
 
 (in-package #:cl-quil.tweedledum)
 
-(cffi:define-foreign-library libtweedledum
+(cffi:define-foreign-library
+    (libtweedledum :search-path "/usr/local/lib/rigetti/")
   (:darwin (:or #.(merge-pathnames "libtweedledum.dylib"
                                    (or *compile-file-truename*
                                        *load-truename*))


### PR DESCRIPTION
This is a simple way to fix the issue. Its drawback is that it requires that the user fiddles with LD_LIBRARY_PATH.

I tried different alternatives such as [1] `setf`-ing `(uiop:getenv "LD_LIBRARY_PATH")` from within the method `perform ((operation load-op) (component c->so))` and [2] trying to remove the hardcoded path from `sb-sys:*shared-objects*` before calling `save-lisp-and-die`, but this was the cleanest fix.

I've tested this patch using make test-tweedledum.