### PR TITLE
Remove singleton metaclass for NOP, HALT, RESET, and WAIT

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -326,6 +326,11 @@ as a permutation."
 (defclass no-operation (instruction)
   ()
   (:documentation "The \"do-nothing\" instruction.")
+  ;; The singleton-class is disabled rather than removed here (and elsewhere) as a reminder that
+  ;; this is a quick fix. Ideally, we'd like to find a way to preserve the singleton nature of these
+  ;; AST classes, but still work with rewiring comments and the guts of logical-scheduler. See
+  ;; https://github.com/rigetti/quilc/issues/270 for more context.
+  #+#:appleby-sufficiently-classy
   (:metaclass singleton-class))
 
 (defmethod arguments ((instruction no-operation)) #())
@@ -358,6 +363,7 @@ numbers. It must start with a string.")
 (defclass halt (instruction)
   ()
   (:documentation "An instruction to immediately halt all execution.")
+  #+#:appleby-sufficiently-classy
   (:metaclass singleton-class))
 
 (defmethod arguments ((instruction halt)) #())
@@ -366,6 +372,7 @@ numbers. It must start with a string.")
 (defclass reset (instruction)
   ()
   (:documentation "An instruction to reset all qubits to the |0>-state.")
+  #+#:appleby-sufficiently-classy
   (:metaclass singleton-class))
 
 (defmethod arguments ((instruction reset)) #())
@@ -384,6 +391,7 @@ as the reset is formally equivalent to measuring the qubit and then conditionall
 (defclass wait (instruction)
   ()
   (:documentation "An instruction to wait for some signal from a classical processor.")
+  #+#:appleby-sufficiently-classy
   (:metaclass singleton-class))
 
 (defmethod arguments ((instruction wait)) #())

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -134,8 +134,7 @@
               "    RESET qq"
               "RESET"))
          (code (parsed-program-executable-code p)))
-    (is (equalp (aref code 0)
-                (make-instance 'reset)))
+    (is (typep (aref code 0) 'reset))
     (is (equalp (reset-qubit-target (aref code 1))
                 (qubit 5)))))
 

--- a/tests/printer-tests.lisp
+++ b/tests/printer-tests.lisp
@@ -15,22 +15,11 @@
   (with-output-to-string (s)
     (funcall printer (funcall parser input) s)))
 
-(defun reset-comment-table-hack ()
-  "Reset the CL-QUIL::**COMMENTS** hash table.
-
-  Resetting the **COMMENTS** table might be required for any test that wants to validate the output
-  of PRINT-PARSED-PROGRAM for programs that contain HALT, NOP, RESET, or other instructions that are
-  represented by singleton classes. This is because the **COMMENTS** hash table is keyed on object
-  identity, so if any prior tests have attached rewiring comments to any singleton instructions,
-  they will persist and be printed by PRINT-PARSED-PROGRAM."
-  (setf quil::**comments** (quil::make-comment-table)))
-
 (defun update-print-parsed-program-golden-files (&key skip-prompt)
   "Call UPDATE-PRINT-PARSED-PROGRAM-GOLDEN-FILES on all the files in *PRINTER-TEST-FILES-DIRECTORY*.
 
 See the documentation string for UPDATE-PRINT-PARSED-PROGRAM-GOLDEN-FILES for more info and an
 admonition against carelessness."
-  (reset-comment-table-hack)
   (update-golden-file-output-sections
    (uiop:directory-files *printer-test-files-directory* #P"*.quil")
    #'parse-and-print-quil-to-string
@@ -44,8 +33,6 @@ admonition against carelessness."
   ;; above, to update the output sections of the golden files. If you do so, however, be sure to
   ;; examine the diffs of the old vs new output *carefully* to ensure all the changes are intended
   ;; or expected. Golden files are precious, and their sanctity must be preserved. Thank you.
-
-  (reset-comment-table-hack)
 
   (let ((golden-files (uiop:directory-files *printer-test-files-directory* #P"*.quil")))
     (is (not (null golden-files)))


### PR DESCRIPTION
- Drop singleton metaclass for the above instructions
- Remove RESET-COMMENT-TABLE-HACK, which is no longer needed.
- Update a parser test that broke as a result of this change.

Fixes #270

The self-flagellating feature expressions are to serve as a reminder that, in a better world, referential transparency would be preserved.