### PR TITLE
Ignore some pedagogical code that may refer to retired symbols

### DIFF
--- a/src/compilers/cs-compile.lisp
+++ b/src/compilers/cs-compile.lisp
@@ -18,7 +18,7 @@
 
 ;; zips up a compatible pair of lists of UCRs into a single such list by
 ;; letting each list act on a block factor
-#+pedagogical-purposes-only
+#+#:pedagogical-purposes-only
 (defun ucr-zipper (string0 string1 control-qubit)
   (mapcar
        (lambda (left right)
@@ -45,7 +45,7 @@
        string0
        string1))
 
-#+pedagogical-purposes-only
+#+#:pedagogical-purposes-only
 (defun cs-compiler (instr)
   "Performs Cosine-Sine Compilation on an instruction, emitting a list of UCR instructions that describe an equivalent circuit."
   (when (zerop (length (application-arguments instr)))

--- a/src/compilers/cs-compile.lisp
+++ b/src/compilers/cs-compile.lisp
@@ -18,6 +18,7 @@
 
 ;; zips up a compatible pair of lists of UCRs into a single such list by
 ;; letting each list act on a block factor
+#+pedagogical-purposes-only
 (defun ucr-zipper (string0 string1 control-qubit)
   (mapcar
        (lambda (left right)
@@ -44,6 +45,7 @@
        string0
        string1))
 
+#+pedagogical-purposes-only
 (defun cs-compiler (instr)
   "Performs Cosine-Sine Compilation on an instruction, emitting a list of UCR instructions that describe an equivalent circuit."
   (when (zerop (length (application-arguments instr)))

--- a/src/compilers/ucr-explode.lisp
+++ b/src/compilers/ucr-explode.lisp
@@ -289,6 +289,7 @@
                                    (- (aref operating-vector j))))
                  (coerce operating-vector 'list))))))
 
+#+pedagogical-purposes-only
 (defun ucr-explode-instr (instr)
   "Turn any UCR pseudo-instruction into an equivalent list of Quil instructions over the gate set RY, RZ, CNOT.  Leave all others alone."
   (unless (typep instr 'UCR-application)

--- a/src/compilers/ucr-explode.lisp
+++ b/src/compilers/ucr-explode.lisp
@@ -289,7 +289,7 @@
                                    (- (aref operating-vector j))))
                  (coerce operating-vector 'list))))))
 
-#+pedagogical-purposes-only
+#+#:pedagogical-purposes-only
 (defun ucr-explode-instr (instr)
   "Turn any UCR pseudo-instruction into an equivalent list of Quil instructions over the gate set RY, RZ, CNOT.  Leave all others alone."
   (unless (typep instr 'UCR-application)


### PR DESCRIPTION
Closes #282 