### PR TITLE
Test quilc endpoints

### DIFF
--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -64,15 +64,12 @@
       (error "Currently no more than two qubit randomized benchmarking is supported."))
     (let* ((cliffords (mapcar #'quil.clifford::clifford-from-quil gateset))
            (qubits-used (mapcar (a:compose
-                                 (a:curry #'reduce #'union)
-                                 #'cl-quil.clifford::extract-qubits-used
+                                 #'cl-quil:qubits-used
                                  #'cl-quil:parse-quil)
                                 gateset))
            (qubits-used-by-interleaver
              (when interleaver
-               (reduce #'union
-                       (cl-quil.clifford::extract-qubits-used
-                        (cl-quil:parse-quil interleaver)))))
+               (cl-quil:qubits-used (cl-quil:parse-quil interleaver))))
            (qubits (union qubits-used-by-interleaver (reduce #'union qubits-used)))
            (embedded-cliffords (loop :for clifford :in cliffords
                                      :for i :from 0
@@ -105,7 +102,7 @@
          (clifford-program (rpcq::|ConjugateByCliffordRequest-clifford| request))
          (pauli-indices (coerce (rpcq::|PauliTerm-indices| pauli) 'list))
          (pauli-terms (coerce (rpcq::|PauliTerm-symbols| pauli) 'list))
-         (clifford-indices (sort (reduce #'union (cl-quil.clifford::extract-qubits-used (cl-quil:parse-quil clifford-program))) #'<))
+         (clifford-indices (sort (cl-quil:qubits-used (cl-quil:parse-quil clifford-program)) #'<))
          (qubits (sort (union (copy-seq pauli-indices) (copy-seq clifford-indices)) #'<))
          (pauli (quil.clifford:pauli-from-string
                  (with-output-to-string (s)

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -152,6 +152,7 @@
 
 (declaim (special *program-name*))
 (defun start-rpc-server (&key
+                           (protocol "tcp")
                            (host "*")
                            (port 5555)
                            (logger (make-instance 'cl-syslog:rfc5424-logger
@@ -164,6 +165,6 @@
     (rpcq:dispatch-table-add-handler dt 'rewrite-arithmetic)
     (rpcq:dispatch-table-add-handler dt 'get-version-info)
     (rpcq:start-server :dispatch-table dt
-                       :listen-addresses (list (format nil "tcp://~a:~a" host port))
+                       :listen-addresses (list (format nil "~a://~a~@[:~a~]" protocol host port))
                        :logger logger
                        :timeout *time-limit*)))

--- a/app/src/web-server.lisp
+++ b/app/src/web-server.lisp
@@ -258,15 +258,12 @@ and replies with the JSON
       (error "Currently no more than two qubit randomized benchmarking is supported."))
     (let* ((cliffords (mapcar #'quil.clifford::clifford-from-quil gateset))
            (qubits-used (mapcar (a:compose
-                                 (a:curry #'reduce #'union)
-                                 #'cl-quil.clifford::extract-qubits-used
+                                 #'cl-quil:qubits-used
                                  #'cl-quil:parse-quil)
                                 gateset))
            (qubits-used-by-interleaver
              (when interleaver
-               (reduce #'union
-                       (cl-quil.clifford::extract-qubits-used
-                        (cl-quil:parse-quil interleaver)))))
+               (cl-quil:qubits-used (cl-quil:parse-quil interleaver))))
            (qubits (union qubits-used-by-interleaver (reduce #'union qubits-used)))
            (embedded-cliffords (loop :for clifford :in cliffords
                                      :for i :from 0
@@ -298,7 +295,7 @@ and replies with the JSON
          (clifford-program (gethash "clifford" json))
          (pauli-indices (first indices-and-terms))
          (pauli-terms (second indices-and-terms))
-         (clifford-indices (sort (reduce #'union (cl-quil.clifford::extract-qubits-used (cl-quil:parse-quil clifford-program))) #'<))
+         (clifford-indices (sort (cl-quil:qubits-used (cl-quil:parse-quil clifford-program)) #'<))
          (qubits (sort (union (copy-seq pauli-indices) (copy-seq clifford-indices)) #'<))
 	 (pauli (quil.clifford:pauli-from-string
 		 (with-output-to-string (s)

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -47,6 +47,25 @@
                (is (quil::matrix-equality mat1 mat2)))))
       (bt:destroy-thread server-thread))))
 
+(deftest test-native-quil-to-binary ()
+  (let* ((server-function (lambda ()
+                            (quilc::start-rpc-server)))
+         (server-thread (bt:make-thread server-function)))
+    (sleep 1)
+    (unwind-protect
+         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
+           (let* ((quil "H 0")
+                  (num-shots 10)
+                  (server-payload (make-instance 'rpcq::|BinaryExecutableRequest|
+                                                 :|quil| quil
+                                                 :|num_shots| num-shots))
+                  (server-response (rpcq:rpc-call client "native-quil-to-binary" server-payload)))
+             (is (string= quil (rpcq::|PyQuilExecutableResponse-program| server-response))
+                 (= num-shots (gethash "num_shots"
+                                       (rpcq::|PyQuilExecutableResponse-attributes| server-response))))))
+      (bt:destroy-thread server-thread))))
+
+
 ;; This test is copied wholesale from pyQuil's test_api.py, random
 ;; seed and all.
 (deftest test-generate-rb-sequence-endpoint ()

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -47,6 +47,8 @@
                (is (quil::matrix-equality mat1 mat2)))))
       (bt:destroy-thread server-thread))))
 
+;; This test is copied wholesale from pyQuil's test_api.py, random
+;; seed and all.
 (deftest test-generate-rb-sequence-endpoint ()
   (let* ((server-function (lambda ()
                             (quilc::start-rpc-server)))

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -4,120 +4,102 @@
 
 (in-package #:quilc-tests)
 
+(defmacro with-random-rpc-client ((client) &body body)
+  (let* ((protocol "inproc")
+         (host (format nil "~a" (uuid:make-v4-uuid)))
+         (endpoint (concatenate 'string protocol "://" host)))
+    `(let* ((server-function (lambda ()
+                              (quilc::start-rpc-server :protocol ,protocol
+                                                       :host ,host
+                                                       :port nil)))
+            (server-thread (bt:make-thread server-function)))
+       (sleep 1)
+       (unwind-protect
+            (rpcq:with-rpc-client (,client ,endpoint)
+              ,@body)
+         (bt:destroy-thread server-thread)))))
 
 (deftest test-easy-version-call ()
-  (let* ((server-thread (bt:make-thread #'quilc::start-rpc-server)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let ((hash (rpcq:rpc-call client "get-version-info")))
-             (is (typep hash 'hash-table))))
-      (bt:destroy-thread server-thread))))
+  (with-random-rpc-client (client)
+    (let ((hash (rpcq:rpc-call client "get-version-info")))
+      (is (typep hash 'hash-table)))))
 
 (deftest test-quil-roundtrip ()
-  (let* ((server-function (lambda ()
-                            (quilc::start-rpc-server)))
-         (server-thread (bt:make-thread server-function)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let* ((quil "H 0")
-                  (isa (a:plist-hash-table
+  (with-random-rpc-client (client)
+    (let* ((quil "H 0")
+           (isa (a:plist-hash-table
+                 (list
+                  "1Q" (a:plist-hash-table
                         (list
-                         "1Q" (a:plist-hash-table
-                               (list
-                                "0" (make-hash-table)))
-                         "2Q" (make-hash-table))))
-                  (specs (make-hash-table))
-                  (target-device (make-instance 'rpcq::|TargetDevice|
-                                                :|isa| isa
-                                                :|specs| specs))
-                  (server-payload (make-instance 'rpcq::|NativeQuilRequest|
-                                                 :|quil| quil
-                                                 :|target_device| target-device))
-                  (server-response (rpcq:rpc-call client "quil-to-native-quil" server-payload))
-                  (pp (quil::parse-quil quil))
-                  (cpp (quil::parse-quil (rpcq::|NativeQuilResponse-quil| server-response))))
-             (multiple-value-bind (mat1 mat2)
-                 (quil::matrix-rescale (quil::make-matrix-from-quil
-                                        (coerce (quil:parsed-program-executable-code pp) 'list))
-                                       (quil::make-matrix-from-quil
-                                        (coerce (quil:parsed-program-executable-code cpp) 'list)))
-               (setf mat1 (quil::scale-out-matrix-phases mat1 mat2))
-               (is (quil::matrix-equality mat1 mat2)))))
-      (bt:destroy-thread server-thread))))
+                         "0" (make-hash-table)))
+                  "2Q" (make-hash-table))))
+           (specs (make-hash-table))
+           (target-device (make-instance 'rpcq::|TargetDevice|
+                                         :|isa| isa
+                                         :|specs| specs))
+           (server-payload (make-instance 'rpcq::|NativeQuilRequest|
+                                          :|quil| quil
+                                          :|target_device| target-device))
+           (server-response (rpcq:rpc-call client "quil-to-native-quil" server-payload))
+           (pp (quil::parse-quil quil))
+           (cpp (quil::parse-quil (rpcq::|NativeQuilResponse-quil| server-response))))
+      (multiple-value-bind (mat1 mat2)
+          (quil::matrix-rescale (quil::make-matrix-from-quil
+                                 (coerce (quil:parsed-program-executable-code pp) 'list))
+                                (quil::make-matrix-from-quil
+                                 (coerce (quil:parsed-program-executable-code cpp) 'list)))
+        (setf mat1 (quil::scale-out-matrix-phases mat1 mat2))
+        (is (quil::matrix-equality mat1 mat2))))))
 
 (deftest test-native-quil-to-binary-endpoint ()
-  (let* ((server-function (lambda ()
-                            (quilc::start-rpc-server)))
-         (server-thread (bt:make-thread server-function)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let* ((quil "H 0")
-                  (num-shots 10)
-                  (server-payload (make-instance 'rpcq::|BinaryExecutableRequest|
-                                                 :|quil| quil
-                                                 :|num_shots| num-shots))
-                  (server-response (rpcq:rpc-call client "native-quil-to-binary" server-payload)))
-             (is (string= quil (rpcq::|PyQuilExecutableResponse-program| server-response))
-                 (= num-shots (gethash "num_shots"
-                                       (rpcq::|PyQuilExecutableResponse-attributes| server-response))))))
-      (bt:destroy-thread server-thread))))
+  (with-random-rpc-client (client)
+    (let* ((quil "H 0")
+           (num-shots 10)
+           (server-payload (make-instance 'rpcq::|BinaryExecutableRequest|
+                                          :|quil| quil
+                                          :|num_shots| num-shots))
+           (server-response (rpcq:rpc-call client "native-quil-to-binary" server-payload)))
+      (is (string= quil (rpcq::|PyQuilExecutableResponse-program| server-response))
+          (= num-shots (gethash "num_shots"
+                                (rpcq::|PyQuilExecutableResponse-attributes| server-response)))))))
 
 ;; This test is copied wholesale from pyQuil's test_api.py, random
 ;; seed and all.
 (deftest test-generate-rb-sequence-endpoint ()
-  (let* ((server-function (lambda ()
-                            (quilc::start-rpc-server)))
-         (server-thread (bt:make-thread server-function)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let* ((quil "PHASE(pi/2) 0
+  (with-random-rpc-client (client)
+    (let* ((quil "PHASE(pi/2) 0
 H 0")
-                  (gateset (list "PHASE(pi/2) 0" "H 0"))
-                  (server-payload (make-instance 'rpcq::|RandomizedBenchmarkingRequest|
-                                                 :|quil| quil
-                                                 :|depth| 2
-                                                 :|seed| 52
-                                                 :|qubits| 1
-                                                 :|gateset| gateset))
-                  (server-response (rpcq:rpc-call client "generate-rb-sequence" server-payload))
-                  (response (rpcq::|RandomizedBenchmarkingResponse-sequence| server-response)))
-             (loop :for a :across response :do
-               (is (equalp a #(0 0 1 0 1))))))
-      (bt:destroy-thread server-thread))))
+           (gateset (list "PHASE(pi/2) 0" "H 0"))
+           (server-payload (make-instance 'rpcq::|RandomizedBenchmarkingRequest|
+                                          :|quil| quil
+                                          :|depth| 2
+                                          :|seed| 52
+                                          :|qubits| 1
+                                          :|gateset| gateset))
+           (server-response (rpcq:rpc-call client "generate-rb-sequence" server-payload))
+           (response (rpcq::|RandomizedBenchmarkingResponse-sequence| server-response)))
+      (loop :for a :across response :do
+        (is (equalp a #(0 0 1 0 1)))))))
 
 (deftest test-conjugate-pauli-by-clifford-endpoint ()
-  (let* ((server-function (lambda ()
-                            (quilc::start-rpc-server)))
-         (server-thread (bt:make-thread server-function)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let* ((pauli (make-instance 'rpcq::|PauliTerm| :|indices| '(0) :|symbols| '("X")))
-                  (clifford "H 0")
-                  (request (make-instance 'rpcq::|ConjugateByCliffordRequest|
-                                          :|pauli| pauli
-                                          :|clifford| clifford))
-                  (response (rpcq:rpc-call client "conjugate-pauli-by-clifford" request)))
-             (is (zerop (rpcq::|ConjugateByCliffordResponse-phase| response)))
-             (is (string= "Z" (rpcq::|ConjugateByCliffordResponse-pauli| response)))))
-      (bt:destroy-thread server-thread))))
+  (with-random-rpc-client (client)
+    (let* ((pauli (make-instance 'rpcq::|PauliTerm| :|indices| '(0) :|symbols| '("X")))
+           (clifford "H 0")
+           (request (make-instance 'rpcq::|ConjugateByCliffordRequest|
+                                   :|pauli| pauli
+                                   :|clifford| clifford))
+           (response (rpcq:rpc-call client "conjugate-pauli-by-clifford" request)))
+      (is (zerop (rpcq::|ConjugateByCliffordResponse-phase| response)))
+      (is (string= "Z" (rpcq::|ConjugateByCliffordResponse-pauli| response))))))
 
 (deftest test-rewrite-arithmetic-endpoint ()
-  (let* ((server-function (lambda ()
-                            (quilc::start-rpc-server)))
-         (server-thread (bt:make-thread server-function)))
-    (sleep 1)
-    (unwind-protect
-         (rpcq:with-rpc-client (client "tcp://127.0.0.1:5555")
-           (let* ((quil "RX((2+1/2)*pi/7) 0")
-                  (request (make-instance 'rpcq::|RewriteArithmeticRequest|
-                                          :|quil| quil))
-                  (response (rpcq:rpc-call client "rewrite-arithmetic" request)))
-             (is (quil::matrix-equality
-                  (quil:parsed-program-to-logical-matrix (quil:parse-quil quil))
-                  (quil:parsed-program-to-logical-matrix (quil:parse-quil (rpcq::|RewriteArithmeticResponse-quil| response))))))))
-      (bt:destroy-thread server-thread)))
+  (with-random-rpc-client (client)
+    (let* ((quil "RX((2+1/2)*pi/7) 0")
+           (request (make-instance 'rpcq::|RewriteArithmeticRequest|
+                                   :|quil| quil))
+           (response (rpcq:rpc-call client "rewrite-arithmetic" request)))
+      (is (quil::matrix-equality
+           (quil:parsed-program-to-logical-matrix (quil:parse-quil quil))
+           (quil:parsed-program-to-logical-matrix
+            (quil:parse-quil (rpcq::|RewriteArithmeticResponse-quil| response))))))))
+

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -47,7 +47,7 @@
                (is (quil::matrix-equality mat1 mat2)))))
       (bt:destroy-thread server-thread))))
 
-(deftest test-generate-rb-sequence ()
+(deftest test-generate-rb-sequence-endpoint ()
   (declare (optimize (debug 3)))
   (let* ((server-function (lambda ()
                             (quilc::start-rpc-server)))

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -47,7 +47,7 @@
                (is (quil::matrix-equality mat1 mat2)))))
       (bt:destroy-thread server-thread))))
 
-(deftest test-native-quil-to-binary ()
+(deftest test-native-quil-to-binary-endpoint ()
   (let* ((server-function (lambda ()
                             (quilc::start-rpc-server)))
          (server-thread (bt:make-thread server-function)))

--- a/app/tests/rpcq-tests.lisp
+++ b/app/tests/rpcq-tests.lisp
@@ -48,7 +48,6 @@
       (bt:destroy-thread server-thread))))
 
 (deftest test-generate-rb-sequence-endpoint ()
-  (declare (optimize (debug 3)))
   (let* ((server-function (lambda ()
                             (quilc::start-rpc-server)))
          (server-thread (bt:make-thread server-function)))

--- a/quilc-tests.asd
+++ b/quilc-tests.asd
@@ -9,6 +9,7 @@
   :depends-on (#:quilc
                #:fiasco
                #:uiop
+               #:alexandria
                )
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call ':quilc-tests

--- a/quilc-tests.asd
+++ b/quilc-tests.asd
@@ -10,6 +10,7 @@
                #:fiasco
                #:uiop
                #:alexandria
+               #:uuid
                )
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call ':quilc-tests

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -381,6 +381,7 @@
    #:rewrite-arithmetic                 ; FUNCTION/TRANSFORMATION
    )
 
+  ;; compressor.lisp
   (:export
    #:compress-qubits
    #:relabel-rewiring

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -381,7 +381,7 @@
    #:rewrite-arithmetic                 ; FUNCTION/TRANSFORMATION
    )
 
-  ;; compressor.lisp
+  ;; analysis/compressor.lisp
   (:export
    #:compress-qubits
    #:relabel-rewiring

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -381,7 +381,7 @@
    #:rewrite-arithmetic                 ; FUNCTION/TRANSFORMATION
    )
 
-  ;; analysis/compressor.lisp
+  ;; analysis/compress-qubits.lisp
   (:export
    #:compress-qubits
    #:relabel-rewiring

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -381,6 +381,12 @@
    #:rewrite-arithmetic                 ; FUNCTION/TRANSFORMATION
    )
 
+  (:export
+   #:compress-qubits
+   #:relabel-rewiring
+   #:qubits-used
+   )
+
   ;; cl-quil.lisp
   (:export
    #:parse-quil                         ; FUNCTION


### PR DESCRIPTION
quilc endpoints are mostly untested, which allowed a bug to creep in (see #287).

The tests here could be better, if I knew more about cliffords etc.