### PR TITLE
fixing tests to adhere to previous PR for fix/clifford_ket

### DIFF
--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -130,7 +130,7 @@
         ((quil::double~ phase #C(0 1)) "i")
         ((quil::double~ phase #C(0 -1)) "-i")
         ;; This phase is invalid, but don't error so the test suite can continue.
-        (t nil)))
+        (t (error "Invalid phase number: ~A~%" phase))))
 
 (defun string-to-phase (phase-str)
   "Returns the phase corresponding to a string form of a fourth root of unity, given by PHASE-STR, NIL otherwise."
@@ -139,7 +139,7 @@
         ((string= phase-str "i") #C(0 1))
         ((string= phase-str "-i") #C(0 -1))
         ;; This phase string is invalid, but don't error so the test suite can continue.
-        (t nil)))
+        (t (error "Invalid phase string: ~A~%" phase-str))))
 
 (defun pauli-matrix-p (p)
   "Returns two strings. The first is a string representation of the phase of P, assuming P is a Pauli matrix, which will be a fourth root of unity. The second return value is a string representation of P as a tensor product of single qubit Pauli operators. If P is not a Pauli operator, then the second value will be NIL."
@@ -159,7 +159,7 @@
       ((not (valid-pauli-dim m n)) NIL)
       ((= m n 2)
        (if (not (null pauli))
-           (values (phase-to-string phase) pauli)
+           (handler-bind ((error #'(lambda (x) (declare (ignore x)) nil))) (values (phase-to-string phase) pauli))
            NIL))
       ((or (factor-I p) (factor-Z p))
        (multiple-value-bind (coeff next-pauli)

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -129,7 +129,8 @@
         ((quil::double~ phase -1) "-")
         ((quil::double~ phase #C(0 1)) "i")
         ((quil::double~ phase #C(0 -1)) "-i")
-        (t (error "Invalid phase number: ~A~%" phase))))
+        ;; This phase is invalid, but don't error so the test suite can continue.
+        (t nil)))
 
 (defun string-to-phase (phase-str)
   "Returns the phase corresponding to a string form of a fourth root of unity, given by PHASE-STR, NIL otherwise."
@@ -137,7 +138,8 @@
         ((string= phase-str "-") -1)
         ((string= phase-str "i") #C(0 1))
         ((string= phase-str "-i") #C(0 -1))
-        (t (error "Invalid phase string: ~A~%" phase-str))))
+        ;; This phase string is invalid, but don't error so the test suite can continue.
+        (t nil)))
 
 (defun pauli-matrix-p (p)
   "Returns two strings. The first is a string representation of the phase of P, assuming P is a Pauli matrix, which will be a fourth root of unity. The second return value is a string representation of P as a tensor product of single qubit Pauli operators. If P is not a Pauli operator, then the second value will be NIL."

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -129,7 +129,6 @@
         ((quil::double~ phase -1) "-")
         ((quil::double~ phase #C(0 1)) "i")
         ((quil::double~ phase #C(0 -1)) "-i")
-        ;; This phase is invalid, but don't error so the test suite can continue.
         (t (error "Invalid phase number: ~A~%" phase))))
 
 (defun string-to-phase (phase-str)
@@ -138,7 +137,6 @@
         ((string= phase-str "-") -1)
         ((string= phase-str "i") #C(0 1))
         ((string= phase-str "-i") #C(0 -1))
-        ;; This phase string is invalid, but don't error so the test suite can continue.
         (t (error "Invalid phase string: ~A~%" phase-str))))
 
 (defun pauli-matrix-p (p)
@@ -159,7 +157,7 @@
       ((not (valid-pauli-dim m n)) NIL)
       ((= m n 2)
        (if (not (null pauli))
-           (handler-bind ((error #'(lambda (x) (declare (ignore x)) nil))) (values (phase-to-string phase) pauli))
+           (handler-case (values (phase-to-string phase) pauli) (error () nil))
            NIL))
       ((or (factor-I p) (factor-Z p))
        (multiple-value-bind (coeff next-pauli)

--- a/tests/benchmarking-procedures-tests.lisp
+++ b/tests/benchmarking-procedures-tests.lisp
@@ -143,17 +143,17 @@
 	(XZ (cl-quil.clifford:pauli-from-string "XZ"))
 	(-YY (cl-quil.clifford:pauli-from-string "-YY"))
 	(XX (cl-quil.clifford:pauli-from-string "XX"))
-	(CNOT01H0-quil (format nil "~{~a~%~}" (list "CNOT 1 0" "H 0")))
-	(CNOT01H0 (cl-quil.clifford:clifford-from-quil CNOT01H0-quil))
-	(H0CNOT01-quil (format nil "~{~a~%~}" (list "H 0" "CNOT 1 0")))
-	(H0CNOT01 (cl-quil.clifford:clifford-from-quil H0CNOT01-quil)))
+	(CN0T10H0-quil (format nil "~{~a~%~}" (list "CNOT 1 0" "H 0")))
+	(CN0T10H0 (cl-quil.clifford:clifford-from-quil CN0T10H0-quil))
+	(H0CNOT10-quil (format nil "~{~a~%~}" (list "H 0" "CNOT 1 0")))
+	(H0CNOT10 (cl-quil.clifford:clifford-from-quil H0CNOT10-quil)))
     (loop
        :for pauli-in :in `(,IZ ,ZI ,ZZ)
        :for pauli-out :in `(,XZ ,XI ,IZ)
-       :do (is (cl-quil.clifford:pauli= pauli-out (cl-quil.clifford:apply-clifford CNOT01H0 pauli-in))))
+       :do (is (cl-quil.clifford:pauli= pauli-out (cl-quil.clifford:apply-clifford CN0T10H0 pauli-in))))
         (loop
        :for pauli-in :in `(,IZ ,ZI ,ZZ)
        :for pauli-out :in `(,ZZ ,XX ,-YY)
-       :do (is (cl-quil.clifford:pauli= pauli-out (cl-quil.clifford:apply-clifford H0CNOT01 pauli-in))))))
+       :do (is (cl-quil.clifford:pauli= pauli-out (cl-quil.clifford:apply-clifford H0CNOT10 pauli-in))))))
     
 

--- a/tests/benchmarking-procedures-tests.lisp
+++ b/tests/benchmarking-procedures-tests.lisp
@@ -53,7 +53,7 @@
   (let ((cliff-id1 (list (cl-quil.clifford:clifford-identity 1)))
         (cliff-id2 (list (cl-quil.clifford:clifford-identity 2))))
     (is (equalp (serialize-clifford-sequence cliff-id1) (list (list "X" "Z"))))
-    (is (equalp (serialize-clifford-sequence cliff-id2) (list (list "XI" "ZI" "IX" "IZ"))))))
+    (is (equalp (serialize-clifford-sequence cliff-id2) (list (list "IX" "IZ" "XI" "ZI"))))))
 
 (defun matrix-equalp (a b)
   (let ((ma (magicl:matrix-rows a))
@@ -127,7 +127,7 @@
     (is (plusp diff))))
 
 (deftest test-clifford-from-quil ()
-  (let ((clifford-quil (format nil "~{~a~%~}" (list "CNOT 0 1" "H 5" "CNOT 0 5" "X 3" "Y 1"))))
+  (let ((clifford-quil (format nil "~{~a~%~}" (list "CNOT 1 0" "H 5" "CNOT 5 0" "X 3" "Y 1"))))
     (is (not (null (cl-quil.clifford:clifford-from-quil clifford-quil)))))
   ;; Check to make sure the indices are being parsed correctly (big endian)
   (let ((clifford-quil "CZ 0 5"))
@@ -143,9 +143,9 @@
 	(XZ (cl-quil.clifford:pauli-from-string "XZ"))
 	(-YY (cl-quil.clifford:pauli-from-string "-YY"))
 	(XX (cl-quil.clifford:pauli-from-string "XX"))
-	(CNOT01H0-quil (format nil "~{~a~%~}" (list "CNOT 0 1" "H 0")))
+	(CNOT01H0-quil (format nil "~{~a~%~}" (list "CNOT 1 0" "H 0")))
 	(CNOT01H0 (cl-quil.clifford:clifford-from-quil CNOT01H0-quil))
-	(H0CNOT01-quil (format nil "~{~a~%~}" (list "H 0" "CNOT 0 1")))
+	(H0CNOT01-quil (format nil "~{~a~%~}" (list "H 0" "CNOT 1 0")))
 	(H0CNOT01 (cl-quil.clifford:clifford-from-quil H0CNOT01-quil)))
     (loop
        :for pauli-in :in `(,IZ ,ZI ,ZZ)


### PR DESCRIPTION
Eliminated errors from `phase-to-string` and `string-to-phase` so that the test suite could continue and reject invalid pauli matrices on its own, and changed the qubit ordering convention in `test-clifford-from-quil` to be consistent with the clifford/paulis' new computational basis argument convention.

Fixes #299 