### PR TITLE
Boondoggle package-local nickname for alexandria

### DIFF
--- a/boondoggle/src/package.lisp
+++ b/boondoggle/src/package.lisp
@@ -3,4 +3,5 @@
 ;;;; Author: Eric Peterson
 
 (defpackage #:boondoggle
-  (:use #:cl))
+  (:use #:cl)
+  (:local-nicknames (:a :alexandria)))


### PR DESCRIPTION
Boondoggle refers to "alexandria" as "a", but the local nickname was not set up.