### PR TITLE
Configure docker env var for CXX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM rigetti/rpcq
 
 ARG build_target
 
+ENV CXX="clang++-7"
+
 # install build dependencies
 COPY Makefile /src/quilc/Makefile
 WORKDIR /src/quilc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM rigetti/rpcq
 
 ARG build_target
 
-ENV CXX="clang++-7"
-
 # install build dependencies
 COPY Makefile /src/quilc/Makefile
 WORKDIR /src/quilc
@@ -12,7 +10,7 @@ RUN make dump-version-info install-test-deps
 # build the quilc app
 ADD . /src/quilc
 WORKDIR /src/quilc
-RUN git clean -fdx && make ${build_target}
+RUN git clean -fdx && CXX=clang++-7 make ${build_target}
 
 EXPOSE 5555
 EXPOSE 6000


### PR DESCRIPTION
The new default `g++` is not available in the docker builds, or at least it is too old. The docker builds do have `clang++-7` however, so configure them to use that.