### PR TITLE
Revert changes to gate modifier parsing

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -566,7 +566,7 @@ INPUT-STRING that triggered the condition."
             :finally (progn
                        (setf (application-operator app)
                              (apply-modifiers-to-operator
-                              (reverse processed-modifiers)
+                              processed-modifiers
                               (application-operator app)))
                        (return (values app rest-lines)))))))
 

--- a/tests/printer-test-files/gold-standard/plundered-gold.quil
+++ b/tests/printer-test-files/gold-standard/plundered-gold.quil
@@ -881,6 +881,19 @@ RESET
 HALT
 
 # Input
+# Disable fixed-point check
+#
+# The fixed-point check is disabled for this test because something in
+# the PARSE-QUIL -> PRINT-PARSED-PROGRAM cycle causes sequences of
+# CONTROLLED DAGGER or DAGGER CONTROLLED to permute, which makes
+# fixed-point check break. For example:
+#
+# CONTROLLED DAGGER Y 0 1
+# -> parse -> print ->
+# DAGGER CONTROLLED Y 0 1
+# -> parse -> print ->
+# CONTROLLED DAGGER Y 0 1
+#
 # Plundered from ../../good-test-files/good-modifiers.quil
 # various mixes of modifiers
 
@@ -915,9 +928,9 @@ CONTROLLED CONTROLLED CONTROLLED Y 0 1 2 3
 DAGGER Y 0
 Y 0
 DAGGER Y 0
-CONTROLLED DAGGER Y 0 1
+DAGGER CONTROLLED Y 0 1
 CONTROLLED DAGGER CONTROLLED Y 0 1 2
-CONTROLLED DAGGER CONTROLLED DAGGER Y 0 1 2
+DAGGER CONTROLLED DAGGER CONTROLLED Y 0 1 2
 CONTROLLED G 0 1
 DAGGER G 0
 


### PR DESCRIPTION
This a manual revert of the last commit from #316.

For context: https://github.com/rigetti/quilc/pull/316#discussion_r301745558