### PR TITLE
Publish test-compiler-hook stats

### DIFF
--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -66,6 +66,19 @@
 ;;; helper functions for algebraically-reduce-instructions, including the doubly-linked
 ;;; list structure peephole-rewriter-node which is used for rewinding the peephole rewriter
 
+(defun calculate-instructions-2q-depth (instructions)
+  (let ((lschedule (make-lscheduler)))
+    (append-instructions-to-lschedule lschedule instructions)
+    (or (lscheduler-walk-graph lschedule
+                               :base-value 0
+                               :bump-value (lambda (instr value)
+                                             (if (and (typep instr 'gate-application)
+                                                      (< 1 (length (application-arguments instr))))
+                                                 (1+ value)
+                                                 value))
+                               :test-values #'max)
+        0)))
+
 (defun calculate-instructions-duration (instructions chip-specification)
   "Calculates the runtime of a sequence of native INSTRUCTIONS on a chip with architecture governed by CHIP-SPECIFICATION (and with assumed perfect parallelization across resources)."
   (let ((lschedule (make-lscheduler)))

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -99,11 +99,15 @@ JUMP @a")))
          (proc-prog
            (quil::compiler-hook (quil::transform 'quil::compress-qubits
                                                  (cl-quil::read-quil-file file))
-                                (quil::build-nQ-linear-chip 5 :architecture architecture))))
+                                (quil::build-nQ-linear-chip 5 :architecture architecture)
+                                :protoquil t)))
     (is (quil::matrix-equals-dwim (quil::parsed-program-to-logical-matrix orig-prog)
-                                  (quil::parsed-program-to-logical-matrix proc-prog)))))
+                                  (quil::parsed-program-to-logical-matrix proc-prog)))
+    (list
+     (quil::calculate-instructions-2q-depth (coerce (quil::parsed-program-executable-code proc-prog)
+                                                    'list)))))
 
-(deftest test-compiler-hook ()
+(deftest test-compiler-hook (&key print-stats)
   "Test whether the compiler hook preserves semantic equivalence for
 some test programs."
   (finish-output *debug-io*)
@@ -114,7 +118,9 @@ some test programs."
         (format *debug-io* "      Testing file ~a:" (pathname-name file))
         (dolist (architecture (list ':cz ':iswap ':cphase ':piswap ':cnot))
           (format *debug-io* " ~a" architecture)
-          (compare-compiled file architecture))
+          (let ((stats (compare-compiled file architecture)))
+            (when print-stats
+              (format *debug-io* "~a" stats))))
         (terpri *debug-io*)))))
 
 (deftest test-compression-bug-QUILC-152 ()


### PR DESCRIPTION
Working on a compilation subroutine and you aren't sure how it's affecting output quality for example programs? Try running `cl-quil-tests::test-compiler-hook` with `print-stats` turned on!