### PR TITLE
fix: read 1Q specs correctly

### DIFF
--- a/src/chip-reader.lisp
+++ b/src/chip-reader.lisp
@@ -86,6 +86,14 @@
     (integer-list
      key)))
 
+(defun expand-isa-key (key)
+  (cond
+    ((and (stringp key)
+          (cl-ppcre:scan "^(\\d)+(-(\\d)+)*$" key))
+     (expand-key-to-integer-list key))
+    (t
+     key)))
+
 (defun dead-qubit-hash-table ()
   (yason:parse "{\"dead\": true}"))
 
@@ -97,18 +105,17 @@
     ;; Get the maximally indexed qubit, so we can bound the indexes of
     ;; the qubits we need to add.
     (let ((max-qubit-index
-            (loop :for k :being :the :hash-keys :of 1q-layer
-                  :maximize (parse-integer k :radix 10 :junk-allowed nil))))
+            (loop :for (k) :being :the :hash-keys :of 1q-layer
+                  :maximize k)))
       ;; Now, go through the hash table, filling in anything
       ;; missing. We can go :BELOW and not :TO with DOTIMES since we
       ;; know the last index exists.
       (dotimes (q max-qubit-index isa-hash)
-        (let ((qkey (prin1-to-string q)))
-          (multiple-value-bind (qubit-hash exists?)
-              (gethash qkey 1q-layer)
-            (declare (ignore qubit-hash))
-            (unless exists?
-              (setf (gethash qkey 1q-layer) (dead-qubit-hash-table)))))))))
+        (multiple-value-bind (qubit-hash exists?)
+            (gethash (list q) 1q-layer)
+          (declare (ignore qubit-hash))
+          (unless exists?
+            (setf (gethash (list q) 1q-layer) (dead-qubit-hash-table))))))))
 
 (defun parse-binding (gate-datum)
   "Parses an entry in the \"gates\" field of an ISA object descriptor."
@@ -128,6 +135,8 @@
 (defun parse-gate-information (gate-datum)
   (let (args)
     (a:when-let ((fidelity (gethash "fidelity" gate-datum)))
+      (when (double= -1d0 fidelity)
+        (setf fidelity +near-perfect-fidelity+))
       (setf args (list* ':fidelity fidelity args)))
     (a:when-let ((duration (gethash "duration" gate-datum)))
       (setf args (list* ':duration duration args)))
@@ -155,7 +164,7 @@
           (make-array qubit-count :initial-element nil))
     ;; for each logical qubit descriptor...
     (dohash ((key qubit-hash) (gethash "1Q" isa-hash))
-      (destructuring-bind (i) (expand-key-to-integer-list key)
+      (destructuring-bind (i) key
         (assert (< i qubit-count)
                 nil
                 "ISA contains a 1Q descriptor of index ~a, but there are only ~a qubit(s) altogether."
@@ -184,7 +193,7 @@
     ;; for each logical link descriptor...
     (when (gethash "2Q" isa-hash)
       (dohash ((key link-hash) (gethash "2Q" isa-hash))
-        (destructuring-bind (q0 q1) (expand-key-to-integer-list key)
+        (destructuring-bind (q0 q1) key
           ;; check that the link is ordered
           (assert (< q0 q1)
                   nil
@@ -239,7 +248,6 @@
 
 (defun load-specs-layer (chip-spec specs-hash)
   "Loads the \"specs\" layer into a chip-specification object."
-  (declare (optimize (debug 3)))
   (when (gethash "1Q" specs-hash)
     (loop :for i :from 0
           :for qubit :across (chip-spec-qubits chip-spec)
@@ -254,25 +262,20 @@
                       (setf (gethash binding gate-info)
                             (copy-gate-record record :fidelity fidelity)))))
                 (a:when-let ((fidelity (gethash "f1QRB" spec)))
-                  (dolist (binding (list (make-gate-binding :operator (named-operator "RX")
-                                                            :parameters '(#.(/ pi 2))
-                                                            :arguments '(_))
-                                         (make-gate-binding :operator (named-operator "RX")
-                                                            :parameters '(#.(/ pi -2))
-                                                            :arguments '(_))
-                                         (make-gate-binding :operator (named-operator "RX")
-                                                            :parameters '(#.pi)
-                                                            :arguments '(_))
-                                         (make-gate-binding :operator (named-operator "RX")
-                                                            :parameters '(#.(- pi))
-                                                            :arguments '(_))))
-                    (a:when-let ((record (gethash binding gate-info)))
+                  ;; NOTE: Forest thinks that "-1" is a special fidelity value
+                  ;;       that indicates a particular error in measurement.
+                  (when (double= -1d0 fidelity)
+                    (setf fidelity +near-perfect-fidelity+))
+                  (dohash ((binding record) gate-info)
+                    (when (and (gate-binding-p binding)
+                               (equalp (named-operator "RX") (gate-binding-operator binding))
+                               (not (double= 0d0 (first (gate-binding-parameters binding)))))
                       (setf (gethash binding gate-info)
                             (copy-gate-record record :fidelity fidelity))))))))
   (when (gethash "2Q" specs-hash)
     (loop :for key :being :the :hash-keys :of (gethash "2Q" specs-hash)
             :using (hash-value spec)
-          :for (q0 q1) := (expand-key-to-integer-list key)
+          :for (q0 q1) := key
           :for link := (lookup-hardware-object-by-qubits chip-spec (list q0 q1))
           :for gate-info := (and link (hardware-object-gate-information link))
           :when gate-info
@@ -293,21 +296,74 @@
                     (destructuring-bind (name params) args
                       (stash-fidelity name params)))))))
 
+;; NOTE: This function (and its call sites) are an unfortunate anachronism of
+;; CL-QUIL / quilc development. QPU specifications were originally sent over
+;; the wire (or read in from disk) as JSON dictionaries, which have the
+;; restriction that the can only be keyed on strings. Internally, it would have
+;; been more convenient to have them keyed on lists of numbers, and so we decided
+;; on the convention that the string "n1" (with n1 a number) deserialize to the
+;; list (n1), the string "n1-n2" deserialize to the list (n1 n2), and so on. we
+;; managed this at right at the deserialization layer by providing an
+;; :object-key-fn key to yason:parse.
+;;
+;; later, we migrated to RPCQ, which does support sending dictionaries keyed on
+;; non-strings over the wire, but we didn't initially make use of it: the client
+;; still serialized the QPU specification through JSON, then sent the JSON string
+;; along to the deserialized by the above means. later, someone half-assed the
+;; RPCQ message |TargetDevice|, which broke the "isa" and "specs" top-level keys
+;; from a QPU specification into RPCQ slots, but then marked their contents as
+;; :any -> :any dictionaries and stored the non-JSON-serialized dictionaries
+;; there, which were keyed on single-qubit unwrapped integers and qubit-qubit
+;; pairs of integers (breaking consistently with the deser layer above).
+;;
+;; this type mismatch caused bugs, which we awkwardly patched over for a while,
+;; until we ultimately found ourselves in a position without a backwards
+;; compatible solution. the situation is improving: quilc's HTTP endpoint is
+;; sunsetting, and with it the JSON payloads are likely to disappear too (though
+;; one must still consider their CLI usage), and so we need only consider the
+;; client's awkward behavior with the RPCQ payloads. for now, we are going to
+;; isolate this awkward behavior into this single function, which converts all
+;; of the possible options above into integer lists, and adhere rigidly to the
+;; use of integer vectors within the CL-QUIL codebase.
+;;
+;;        -ecp
+(defun sanitize-qpu-hash-layer (layer)
+  (flet ((walk-sublayer (sublayer)
+           (let ((new-sublayer (make-hash-table :test #'equalp)))
+             (dohash ((key val) sublayer new-sublayer)
+               (etypecase key
+                 (string
+                  (setf key (sort (expand-key-to-integer-list key) #'<)))
+                 (integer
+                  (setf key (list key)))
+                 (vector
+                  (setf key (sort (coerce key 'list) #'<)))
+                 (list
+                  (setf key (sort (copy-seq key) #'<))))
+               (setf (gethash key new-sublayer) val)))))
+    (let ((new-layer (make-hash-table :test #'equalp)))
+      (a:when-let ((sublayer (gethash "1Q" layer)))
+        (setf (gethash "1Q" new-layer) (walk-sublayer sublayer)))
+      (a:when-let ((sublayer (gethash "2Q" layer)))
+        (setf (gethash "2Q" new-layer) (walk-sublayer sublayer)))
+      new-layer)))
+
 (defun qpu-hash-table-to-chip-specification (hash-table)
   "Converts a QPU specification HASH-TABLE, to a chip-specification object.  Requires an \"isa\" layer."
   (check-type hash-table hash-table)
-  (let ((isa-hash (or (gethash "isa" hash-table)
-                      (error 'missing-isa-layer-error)))
-        (chip-spec (make-chip-specification
-                    :objects (make-array 2 :initial-contents (list (make-adjustable-vector)
-                                                                   (make-adjustable-vector)))
-                    :generic-rewriting-rules (coerce (global-rewriting-rules) 'vector))))
+  (let* ((isa-hash (or (gethash "isa" hash-table)
+                       (error 'missing-isa-layer-error)))
+         (isa-hash (sanitize-qpu-hash-layer isa-hash))
+         (chip-spec (make-chip-specification
+                     :objects (make-array 2 :initial-contents (list (make-adjustable-vector)
+                                                                    (make-adjustable-vector)))
+                     :generic-rewriting-rules (coerce (global-rewriting-rules) 'vector))))
     ;; set up the self-referential compilers
     (install-generic-compilers chip-spec (list ':cz))
     ;; now load the layers out of the .qpu hash
     (load-isa-layer chip-spec isa-hash)
     (a:when-let ((specs-hash (gethash "specs" hash-table)))
-      (load-specs-layer chip-spec specs-hash))
+      (load-specs-layer chip-spec (sanitize-qpu-hash-layer specs-hash)))
     ;; and return the chip-specification that we've built
     (warm-hardware-objects chip-spec)))
 

--- a/src/chip-reader.lisp
+++ b/src/chip-reader.lisp
@@ -127,8 +127,8 @@
 (defun parse-gate-information (gate-datum)
   (let (args)
     (a:when-let ((fidelity (gethash "fidelity" gate-datum)))
-      (when (double= -1d0 fidelity)
-        (setf fidelity +near-perfect-fidelity+))
+      (when (double= fidelity +forest-error-sentinel+)
+        (setf fidelity +totally-awful-fidelity+))
       (setf args (list* ':fidelity fidelity args)))
     (a:when-let ((duration (gethash "duration" gate-datum)))
       (setf args (list* ':duration duration args)))
@@ -254,10 +254,8 @@
                       (setf (gethash binding gate-info)
                             (copy-gate-record record :fidelity fidelity)))))
                 (a:when-let ((fidelity (gethash "f1QRB" spec)))
-                  ;; NOTE: Forest thinks that "-1" is a special fidelity value
-                  ;;       that indicates a particular error in measurement.
-                  (when (double= -1d0 fidelity)
-                    (setf fidelity +near-perfect-fidelity+))
+                  (when (double= fidelity +forest-error-sentinel+)
+                    (setf fidelity +totally-awful-fidelity+))
                   (dohash ((binding record) gate-info)
                     (when (and (gate-binding-p binding)
                                (equalp (named-operator "RX") (gate-binding-operator binding))

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -332,10 +332,10 @@ used to specify CHIP-SPEC."
         (setf (gethash (make-measure-binding :qubit q
                                              :target '_)
                        (hardware-object-gate-information obj))
-              (make-gate-record :duration 2000))
+              (make-gate-record :duration 2000 :fidelity 0.90d0))
         (setf (gethash (make-measure-binding :qubit '_)
                        (hardware-object-gate-information obj))
-              (make-gate-record :duration 2000)))
+              (make-gate-record :duration 2000 :fidelity 0.90d0)))
       (when (member ':RZ type)
         (stash-gate-record "RZ" '(_) (list q) 1/100 +near-perfect-fidelity+))
       (when (member ':X/2 type)

--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -11,6 +11,13 @@
 (defconstant +near-perfect-fidelity+ 0.99999d0
   "Even perfect operations are typically limited in their physical realization by, say, the granularity of control electronics. (For instance, waveform IQ values might be stored as complex fixnums of some specified depth.) This constant is a mnemonic for \"supposedly perfect\" and captures some of the loss incurred by these imperfections.")
 
+;; TODO: actually put a small value here.
+(defconstant +totally-awful-fidelity+ 0.99997d0
+  "In the event that the Forest database indicates that a gate is too error-prone even to accurately estimate the error, we use this value as a generic lowball for how awful the gate must be.")
+
+(defconstant +forest-error-sentinel+ -1
+  "The Forest database sometimes stores a fidelity of -1 to indicate that the fidelity estimation routine failed.")
+
 (defstruct chip-specification
   "Houses information about hardware components on a QPU.
 

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -39,7 +39,8 @@
     (def number-list       number-list-p       list     number)
     (def symbol-list       symbol-list-p       list     symbol)
     (def string-sequence   string-sequence-p   sequence string)
-    (def integeropt-vector integeropt-vector-p vector   (or null integer))))
+    (def integeropt-vector integeropt-vector-p vector   (or null integer))
+    (def integer-vector    integer-vector-p    vector   integer)))
 
 (deftype unsigned-fixnum ()
   `(and fixnum unsigned-byte))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -172,14 +172,10 @@
   \"16-17\": {}}}}"))
          (chip-spec (quil::qpu-hash-table-to-chip-specification isa)))
     (is (quil::chip-specification-p chip-spec))
-    ;; re-load the chip spec
-    (quil::load-isa-layer chip-spec (gethash "isa" isa))
+    (is (= 18 (quil::chip-spec-n-qubits chip-spec)))
     ;; check we got the goods
-    (dolist (presumed-dead '("4" "8" "9" "10" "11" "12"))
-      (let ((goods (gethash-chain (list "isa" "1Q" presumed-dead) isa)))
-        (is (and (not (null goods))
-                 (hash-table-p goods)
-                 (gethash "dead" goods))))))) ; RIP in piece
+    (dolist (presumed-dead '(4 8 9 10 11 12))
+      (is (quil::chip-spec-qubit-dead? chip-spec presumed-dead))))) ; RIP in piece
 
 (deftest test-bristlecone-chip ()
   "Test construction of Google's Bristlecone 72-qubit chip"


### PR DESCRIPTION
This PR defends against 3 kinds of malformed input:

* Forest DB has taken to assigning a fidelity of -1 when the backend determines that a qubit has such low gate fidelity that it isn't worth estimating. This is no bueno; we reset this is `+near-perfect-fidelity+` for lack of a real floor.
* Various lazy actors have been supply quilc with various malformed qubit keys in their ISA / specs payloads. We now deliberately consume all of them and convert them to something uniform internally.
* The problem that motivated this PR: under/over-specificity when trying to match `gate-binding`s could cause `specs` entries to get skipped. These are now more robustly treated.