### PR TITLE
Include memory definitions from included quil

### DIFF
--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -182,3 +182,23 @@ TEST 0 1 2"))
       (is (= 1 (length gates)))
       (is (typep (first gates) 'quil::permutation-gate-definition)))
     (signals quil-parse-error (parse-quil quil-bad))))
+
+(deftest test-process-include ()
+  (uiop:with-temporary-file (:stream stream :pathname path)
+    (format stream "DECLARE foo BIT~@
+                    MEASURE 0 foo")
+    (force-output stream)
+    (let* ((test-quil (format nil "H 0~@
+                                   INCLUDE \"~A\"" path))
+           (pp (parse-quil test-quil)))
+      (is (= 1 (length (parsed-program-memory-definitions pp)))))))
+
+(deftest test-process-include-declaration-collision ()
+  (uiop:with-temporary-file (:stream stream :pathname path)
+    (format stream "DECLARE foo BIT~@
+                    MEASURE 0 foo")
+    (force-output stream)
+    (let* ((test-quil (format nil "DECLARE foo BIT~@
+                                   H 0~@
+                                   INCLUDE \"~A\"" path)))
+      (signals quil-parse-error (parse-quil test-quil)))))


### PR DESCRIPTION
This addresses #91. When a memory region is declared across multiple files, this signals a `quil-parse-error`.