### PR TITLE
add semicolons to parser

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -254,7 +254,7 @@ the immediately preceding line."
                      (setf pieces-last (cdr pieces-last))
                      ;; Prepend appropriate indentation
                      (setf start (if (eq ':INDENTATION (token-type (car start)))
-                                     (cons (copy-structure (car start)) ; Shallow copy is ok here
+                                     (cons (car start)  ; Copy the indentation (line number on this token is irrelevant)
                                            (cdr end))
                                      (cdr end)))
                      (rplacd last nil)

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -215,7 +215,7 @@ A logical line may be introduced either as the result of a :NEWLINE or a
 the case of :SEMICOLON, the following line is prefixed with the indentation of
 the immediately preceding line."
   ;; note: something like "H 0 ; X 1" will produce two lines for internal processing,
-  ;; but the tokens themselves maintain their original line numbers for error reporting
+  ;; but the tokens themselves maintain their original line numbers for error reporting.
   (declare (type list tokens)
            (optimize speed (space 0)))
   (let* ((pieces      (cons nil nil))

--- a/tests/lexer-tests.lisp
+++ b/tests/lexer-tests.lisp
@@ -70,12 +70,6 @@
     (#.(string #\Tab) :indentation)
     (#.(format nil "~C    ~C    " #\Tab #\Tab) :indentation)))
 
-(deftest test-nsplit ()
-  "Test that NSPLIT works."
-  (is (null (quil::nsplit 'x nil)))
-  (is (equalp '((1) (2 3 4) (5 6)) (quil::nsplit 'x (list 'x 1 'x 2 3 4 'x 5 6 'x 'x))))
-  (is (equalp '((1 2 3 4 5 6))     (quil::nsplit 'x (list 1 2 3 4 5 6)))))
-
 (defun token-type-or-newline (tok)
   (if (eq tok ':newline)
       ':newline

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -41,6 +41,14 @@
             (declare (ignore c))
             (error 'quil:quil-parse-error)))))))
 
+(deftest test-semicolon-parsing ()
+  (let ((pp1 (parse-quil "H 0 ; X 1"))
+        (pp2 (parse-quil "DEFCIRCUIT foo:
+    X 0 ; H 0")))
+    (is (= 2 (length (parsed-program-executable-code pp1))))
+    (is (= 2 (length (quil::circuit-definition-body
+                      (first (parsed-program-circuit-definitions pp2))))))))
+
 (deftest test-pragma-parsing ()
   (let* ((p (with-output-to-quil
               "PRAGMA a"


### PR DESCRIPTION
Here's a proposal for #386, allowing for `:SEMICOLON` tokens early on which get removed at the same time as `:NEWLINE` tokens. Tokens still retain their line numbers relativ to `:NEWLINE` tokens.