### PR TITLE
Fix SPECIAL-BINDINGS-LET*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ QUICKLISP_HOME=$(HOME)/quicklisp
 QUICKLISP_SETUP=$(QUICKLISP_HOME)/setup.lisp
 QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
 	--eval '(push (truename ".") asdf:*central-registry*)' \
-	--eval '(push :hunchentoot-no-ssl *features*)' \
 	--eval '(push :drakma-no-ssl *features*)' \
 	--eval "(push (truename \"$(RIGETTI_LISP_LIBRARY_HOME)\") ql:*local-project-directories*)"
 QUICKLISP_BOOTSTRAP_URL=https://beta.quicklisp.org/quicklisp.lisp
@@ -79,7 +78,6 @@ install-tweedledum:
 quilc: system-index.txt
 	$(SBCL) $(FOREST_SDK_FEATURE) \
 	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
-		--eval '(push :hunchentoot-no-ssl *features*)' \
 		--eval '(push :drakma-no-ssl *features*)' \
 		--load "build-app.lisp" \
 		$(FOREST_SDK_OPTION) \

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -448,12 +448,6 @@ Version ~A is available from https://www.rigetti.com/forest~%"
 					   *error-output*)))
        (quil::*prefer-ranged-gates-to-SWAPs* prefer-gate-ladders)
        (*without-pretty-printing* without-pretty-printing)
-       (gate-blacklist (and gate-blacklist
-                            (split-sequence:split-sequence #\, (remove #\Space gate-blacklist)
-                                                           :remove-empty-subseqs t)))
-       (gate-whitelist (and gate-whitelist
-                            (split-sequence:split-sequence #\, (remove #\Space gate-whitelist)
-                                                           :remove-empty-subseqs t)))
        (quil::*enable-state-prep-compression* enable-state-prep-reductions)
        ;; Null out the streams. If no server mode is requested, these bindings will be modified
        ;; before calling run-CLI-mode, below.
@@ -494,8 +488,16 @@ Version ~A is available from https://www.rigetti.com/forest~%"
            (multiple-value-bind (processed-program statistics)
                (process-program program (lookup-isa-descriptor-for-name isa)
                                 :protoquil protoquil
-                                :gate-whitelist gate-whitelist
-                                :gate-blacklist gate-blacklist)
+                                :gate-whitelist (and gate-whitelist
+                                                     (split-sequence:split-sequence
+                                                      #\,
+                                                      (remove #\Space gate-whitelist)
+                                                      :remove-empty-subseqs t))
+                                :gate-blacklist (and gate-blacklist
+                                                     (split-sequence:split-sequence
+                                                      #\,
+                                                      (remove #\Space gate-blacklist)
+                                                      :remove-empty-subseqs t)))
              (print-program processed-program *quil-stream*)
              (when print-statistics
                (print-statistics statistics *quil-stream*))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -331,7 +331,7 @@ end of the name."
                   :collect `(,name ,value))
           (bordeaux-threads:*default-special-bindings*
             (list* ,@(loop :for (name value) :in let-defs
-                           :collect ``(,',name . ',,name))
+                           :collect `(cons ',name (list 'quote ,name)))
                    bordeaux-threads:*default-special-bindings*)))
      ,@body))
 

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -331,7 +331,7 @@ end of the name."
                   :collect `(,name ,value))
           (bordeaux-threads:*default-special-bindings*
             (list* ,@(loop :for (name value) :in let-defs
-                           :collect `(cons ',name ,name))
+                           :collect ``(,',name . ',,name))
                    bordeaux-threads:*default-special-bindings*)))
      ,@body))
 

--- a/app/tests/misc-tests.lisp
+++ b/app/tests/misc-tests.lisp
@@ -44,6 +44,11 @@
         (dolist (stat stats)
           (is (not (nth-value 1 (gethash stat statistics)))))))))
 
+(deftest test-special-bindings-let* ()
+  (dolist (thing '(42 "a string" :a-keyword quoted-symbol (a cons)))
+    (is (eq thing (quilc::special-bindings-let* ((not-special thing))
+                    (bt:join-thread (bt:make-thread (lambda () not-special))))))))
+
 (deftest test-%strip-halts-respecting-rewirings ()
   ;; empty parsed prog
   (is (equalp #() (quilc::%strip-halts-respecting-rewirings (quil:parse-quil ""))))

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -6,7 +6,6 @@
 (unless *load-truename*
   (error "This file is meant to be loaded."))
 
-(pushnew :hunchentoot-no-ssl *features*)
 (pushnew :drakma-no-ssl *features*)
 
 (require 'asdf)

--- a/quilc-tests.asd
+++ b/quilc-tests.asd
@@ -10,6 +10,7 @@
                #:fiasco
                #:uiop
                #:alexandria
+               #:bordeaux-threads ; for RPCQ tests and SPECIAL-BINDINGS-LET*
                #:uuid
                )
   :perform (asdf:test-op (o s)

--- a/quilc.asd
+++ b/quilc.asd
@@ -16,10 +16,9 @@
                #:cl-quil
                #:cl-quil-benchmarking
                #:uiop
-               #:hunchentoot          ; deprecated
-               #:bordeaux-threads     ; deprecated
+               #:bordeaux-threads
                #:cl-syslog
-               #:rpcq                 ; to replace HUNCHENTOOT and B-T
+               #:rpcq
                #:drakma
                #:trivial-features     ; for portable *features*
                #:alexandria


### PR DESCRIPTION
Fix a bug in `SPECIAL-BINDINGS-LET*` that was causing quilc to crash if the user specified either the `--gate-whitelist` or `--gate-blacklist` options in combination with `-S` or `-P`.

Also:

- use `SPECIAL-BINDINGS-LET*` in `TEST-QUIL-TO-NATIVE-QUIL-ENDPOINT-OVERRIDES-SERVER` rather than `SETF`.
- Remove last traces of hunchentoot from Makefile, build-app.lisp, and quilc.asd.

Copy/paste of commit message:

**Fix a bug in `SPECIAL-BINDINGS-LET*`**

`SPECIAL-BINDINGS-LET*` needs to expand to a form that quotes the value being added to `BT:*DEFAULT-SPECIAL-BINDINGS*`; otherwise, binding non-self-evaluating forms will cause an error once a new thread is created.

In other words, we want to expand to something like:

```
  CL-USER> (macroexpand '(quilc::special-bindings-let* ((*foo* 'foo))))
  (LET* ((*FOO* 'FOO)
         (BORDEAUX-THREADS:*DEFAULT-SPECIAL-BINDINGS*
          (LIST* `(,'*FOO* QUOTE ,*FOO*)
                 BORDEAUX-THREADS:*DEFAULT-SPECIAL-BINDINGS*))))
```

Whereas, previously, we expanded to:

```
  CL-USER> (macroexpand '(quilc::special-bindings-let* ((*foo* 'foo))))
  (LET* ((*FOO* 'FOO)
         (BORDEAUX-THREADS:*DEFAULT-SPECIAL-BINDINGS*
          (LIST* (CONS '*FOO* *FOO*)
                 BORDEAUX-THREADS:*DEFAULT-SPECIAL-BINDINGS*))))
```