### PR TITLE
Rethink 'Raw' Quil

### DIFF
--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -167,7 +167,8 @@
 (defun rewrite-arithmetic-handler (request)
   "Rewrites the request program without arithmetic in gate parameters."
   (check-type request rpcq::|RewriteArithmeticRequest|)
-  (let ((program (quil::parse-quil-into-raw-program (rpcq::|RewriteArithmeticRequest-quil| request))))
+  (let ((program (quil::parse-quil (rpcq::|RewriteArithmeticRequest-quil| request)
+                                   :transforms nil)))
     (multiple-value-bind (rewritten-program original-memory-descriptors recalculation-table)
         (cl-quil::rewrite-arithmetic program)
       (let ((reformatted-rt (make-hash-table)))

--- a/src/analysis/compress-qubits.lisp
+++ b/src/analysis/compress-qubits.lisp
@@ -172,5 +172,4 @@ relabeled according to which free assignments remain."
   parsed-prog)
 
 (define-transform compress-qubits (compress-qubits)
-  "Relabel the qubits so that they are minimally numbered."
-  process-includes)
+  "Relabel the qubits so that they are minimally numbered.")

--- a/src/analysis/expand-circuits.lisp
+++ b/src/analysis/expand-circuits.lisp
@@ -5,8 +5,7 @@
 (in-package #:cl-quil)
 
 (define-transform expand-circuits (expand-circuits)
-  "This transform expands all circuits to create a circuit-free program."
-  resolve-applications)
+  "This transform expands all circuits to create a circuit-free program.")
 
 (defun relabel-circuit-labels-uniquely (circuit-body)
   "Non-destructively relabel all jump targets and associated JUMP-like instructions in the list of instructions CIRCUIT-BODY."

--- a/src/analysis/expand-circuits.lisp
+++ b/src/analysis/expand-circuits.lisp
@@ -6,7 +6,6 @@
 
 (define-transform expand-circuits (expand-circuits)
   "This transform expands all circuits to create a circuit-free program."
-  process-includes
   resolve-applications)
 
 (defun relabel-circuit-labels-uniquely (circuit-body)

--- a/src/analysis/fusion.lisp
+++ b/src/analysis/fusion.lisp
@@ -484,7 +484,6 @@ The list will actually be a list of lists, where each sublist commutes and can b
 
 (define-transform gate-fusion (fuse-gates-in-program)
   "Fuse gates together producing a new program that we stipulate will be more efficient to simulate."
-  process-includes
   ;; We need to resolve applications to the gate applications know
   ;; their definitions for fusion.
   resolve-applications)

--- a/src/analysis/fusion.lisp
+++ b/src/analysis/fusion.lisp
@@ -483,10 +483,7 @@ The list will actually be a list of lists, where each sublist commutes and can b
   parsed-program)
 
 (define-transform gate-fusion (fuse-gates-in-program)
-  "Fuse gates together producing a new program that we stipulate will be more efficient to simulate."
-  ;; We need to resolve applications to the gate applications know
-  ;; their definitions for fusion.
-  resolve-applications)
+  "Fuse gates together producing a new program that we stipulate will be more efficient to simulate.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Test Harness ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/analysis/patch-labels.lisp
+++ b/src/analysis/patch-labels.lisp
@@ -13,8 +13,7 @@ This changes the AST!
 
 becomes
 
-    JUMP-LABEL : JUMP -> non-negative integer."
-  process-includes)
+    JUMP-LABEL : JUMP -> non-negative integer.")
 
 (defun jump-target-positions (code)
   (loop :with positions := (make-hash-table :test 'equal)

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -4,22 +4,6 @@
 
 (in-package #:cl-quil)
 
-(defun definition-signature (instr)
-  "If INSTR is a definition or memory declaration, returns a signature used for
-determining ambiguity. Otherwise, return NIL."
-  (typecase instr
-    (gate-definition (cons 'gate-definition (gate-definition-name instr)))
-    (circuit-definition (cons 'circuit-definition (circuit-definition-name instr)))
-    (memory-descriptor (cons 'memory-descriptor (memory-descriptor-name instr)))))
-
-(defun signal-ambiguous-definition (instr file conflicts)
-  "Signal a condition indicating that the instruction INSTR parsed from FILE has
-a list of conflicts CONFLICTS."
-  (etypecase instr
-    (gate-definition (signal 'ambiguous-gate-definition :conflicts (acons instr file conflicts)))
-    (circuit-definition (signal 'ambiguous-circuit-definition :conflicts (acons instr file conflicts)))
-    (memory-descriptor (signal 'ambiguous-memory-declaration :conflicts (acons instr file conflicts)))))
-
 (defun process-includes (raw-quil &optional originating-file)
   "Recursively process all INCLUDE instructions in the list RAW-QUIL. The
 result is a new sequence with the included quil instructions spliced in."
@@ -29,9 +13,7 @@ result is a new sequence with the included quil instructions spliced in."
          ;; We track an active path of files from the "root" to whatever we are processing
          ;; at the moment, in order to check for cycles.
          (seen-files (when originating-file
-                       (list (namestring originating-file))))
-         ;; The following maps definition signatures to a list of (filename . defn) pairs
-         (seen-definitions (make-hash-table :test 'equalp)))
+                       (list (truename originating-file)))))
     (labels ((handle-include (incl originating-file)
                ;; load the file to be included, and recursively
                ;; expand includes within it
@@ -44,11 +26,12 @@ result is a new sequence with the included quil instructions spliced in."
                    (setf file (merge-pathnames file originating-dir)))
                  (unless (uiop:file-exists-p file)
                    (quil-parse-error "Could not include ~S because it does not exist." file))
-                 (when (member (namestring file) seen-files :test #'string=)
+                 (setf file (truename file))
+                 (when (member file seen-files :test #'uiop:pathname-equal)
                    (quil-parse-error "Cyclic INCLUDE detected: ~S is being INCLUDEd but has already been processed." file))
                  (let* ((*current-file* file)
                         (body (parse-quil-into-raw-program (a:read-file-into-string file))))
-                   (push (namestring file) seen-files)
+                   (push file seen-files)
                    (unwind-protect (expand-all-includes body file)
                      (pop seen-files)))))
              (expand-all-includes (instrs originating-file)
@@ -60,15 +43,6 @@ result is a new sequence with the included quil instructions spliced in."
                       (handle-include (car instrs) originating-file)
                       (expand-all-includes (cdr instrs) originating-file))
                      (t
-                      (let ((instr (car instrs)))
-                        (a:when-let ((signature (definition-signature instr)))
-                          ;; check for conflicts
-                          (with-simple-restart (continue "Continue with ambiguous definition.")
-                            (a:when-let ((entries (gethash signature seen-definitions)))
-                              (signal-ambiguous-definition instr originating-file entries)))
-                          ;; update definition table
-                          (push (cons instr originating-file)
-                                (gethash signature seen-definitions))))
                       (setf (cdr expanded-tail) instrs)
                       (setf expanded-tail (cdr expanded-tail))
                       (expand-all-includes (cdr instrs) originating-file)))))

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -26,7 +26,7 @@ result is a new sequence with the included quil instructions spliced in."
                    (error "Cycle detected in INCLUDe graph: ~S has already been processed." file))
                  (setf (gethash file seen-files) t)
                  (let* ((*current-file* file)
-                        (body (parse-quil-into-ast (a:read-file-into-string file))))
+                        (body (parse-quil-into-raw-program (a:read-file-into-string file))))
                    (expand-all-includes body file))))
              (expand-all-includes (instrs originating-file)
                ;; consume an instruction. if it's an include, we handoff to

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -4,62 +4,40 @@
 
 (in-package #:cl-quil)
 
-(define-transform process-includes (process-includes)
-  "This transform expands (and therefore eliminates) INCLUDE directives."
-  )
-
-(defun find-include (pp)
-  "Given a PARSED-PROGRAM PP, find the first INCLUDE instruction. Return two values: the instruction and its position. If the directive isn't found, return NIL."
-  (loop :for i :from 0
-        :for isn :across (parsed-program-executable-code pp)
-        :when (typep isn 'include)
-          :do (return (values isn i))
-        :finally (return nil)))
-
-(defun splice-code-at (code i code-to-splice)
-  "Replace the Ith element of CODE with the sequence CODE-TO-SPLICE."
-  (concatenate 'vector
-               (subseq code 0 i)
-               code-to-splice
-               (subseq code (1+ i))))
-
-(defun handle-include (pp incl pos originating-dir)
-  (let ((file (funcall *resolve-include-pathname* (include-pathname incl))))
-    (when (uiop:relative-pathname-p file)
-      (setf file (merge-pathnames file originating-dir)))
-    (unless (uiop:file-exists-p file)
-      (error "Could not include ~S because it does not exist." file))
-    (let ((incl-pp (parse-quil-into-raw-program (a:read-file-into-string file))))
-      (a:when-let ((collisions (intersection (parsed-program-memory-definitions pp)
-                                             (parsed-program-memory-definitions incl-pp)
-                                             :key #'memory-descriptor-name
-                                             :test #'string=)))
-        (quil-parse-error "Found memory declaration for ~A when processing ~S,
-but this region has already been declared elsewhere."
-                          (memory-descriptor-name (first collisions))
-                          file))
-      (a:appendf (parsed-program-gate-definitions pp)
-                 (parsed-program-gate-definitions incl-pp))
-      (a:appendf (parsed-program-circuit-definitions pp)
-                 (parsed-program-circuit-definitions incl-pp))
-      (a:appendf (parsed-program-memory-definitions pp)
-                 (parsed-program-memory-definitions incl-pp))
-      (setf (parsed-program-executable-code pp)
-            (splice-code-at (parsed-program-executable-code pp)
-                            pos
-                            (parsed-program-executable-code incl-pp)))
-      pp)))
-
-(defun process-includes (pp &optional originating-file)
-  "Process all INCLUDE forms by reading files off the disk. Produces a new PARSED-PROGRAM object."
-  (let ((originating-directory (if (null originating-file)
-                                   (pathname (uiop:getcwd))
-                                   (uiop:pathname-directory-pathname
-                                    originating-file))))
-    (labels ((expand-all-includes (pp)
-               (multiple-value-bind (incl pos) (find-include pp)
-                 (if (null incl)
-                     pp
-                     (expand-all-includes
-                      (handle-include pp incl pos originating-directory))))))
-      (expand-all-includes pp))))
+(defun process-includes (raw-quil &optional originating-file)
+  "Recursively process all INCLUDE instructions in the list RAW-QUIL. The
+result is a new sequence with the included quil instructions spliced in."
+  (let* ((expanded (cons nil nil))
+         (expanded-tail expanded)
+         (seen-files (make-hash-table :test 'equalp)))
+    (labels ((handle-include (incl originating-file)
+               ;; load the file to be included, and recursively
+               ;; expand includes within it
+               (let ((file (funcall *resolve-include-pathname* (include-pathname incl)))
+                     (originating-dir (if (null originating-file)
+                                          (pathname (uiop:getcwd))
+                                          (uiop:pathname-directory-pathname
+                                           originating-file))))
+                 (when (uiop:relative-pathname-p file)
+                   (setf file (merge-pathnames file originating-dir)))
+                 (unless (uiop:file-exists-p file)
+                   (error "Could not include ~S because it does not exist." file))
+                 (when (gethash file seen-files)
+                   (error "Cycle detected in INCLUDe graph: ~S has already been processed." file))
+                 (setf (gethash file seen-files) t)
+                 (let* ((*current-file* file)
+                        (body (parse-quil-into-ast (a:read-file-into-string file))))
+                   (expand-all-includes body file))))
+             (expand-all-includes (instrs originating-file)
+               ;; consume an instruction. if it's an include, we handoff to
+               ;; HANDLE-INCLUDE before continuing
+               (cond ((endp instrs)
+                      (cdr expanded))
+                     ((typep (car instrs) 'include)
+                      (handle-include (car instrs) originating-file)
+                      (expand-all-includes (cdr instrs) originating-file))
+                     (t
+                      (setf (cdr expanded-tail) instrs)
+                      (setf expanded-tail (cdr expanded-tail))
+                      (expand-all-includes (cdr instrs) originating-file)))))
+      (expand-all-includes raw-quil originating-file))))

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -12,8 +12,9 @@ result is a new sequence with the included quil instructions spliced in."
          (expanded-tail expanded)
          ;; We track an active path of files from the "root" to whatever we are processing
          ;; at the moment, in order to check for cycles.
-         (seen-files (when originating-file
-                       (list (truename originating-file)))))
+         (seen-files (if originating-file
+                         (list (truename originating-file))
+                         nil)))
     (labels ((handle-include (incl originating-file)
                ;; load the file to be included, and recursively
                ;; expand includes within it
@@ -26,13 +27,15 @@ result is a new sequence with the included quil instructions spliced in."
                    (setf file (merge-pathnames file originating-dir)))
                  (unless (uiop:file-exists-p file)
                    (quil-parse-error "Could not include ~S because it does not exist." file))
+                 ;; canonicalize the name for the sake of detecting cycles
                  (setf file (truename file))
                  (when (member file seen-files :test #'uiop:pathname-equal)
                    (quil-parse-error "Cyclic INCLUDE detected: ~S is being INCLUDEd but has already been processed." file))
-                 (let* ((*current-file* file)
-                        (body (parse-quil-into-raw-program (a:read-file-into-string file))))
+                 (let ((body
+                         (let ((*current-file* file))
+                           (parse-quil-into-raw-program (a:read-file-into-string file)))))
                    (push file seen-files)
-                   (unwind-protect (expand-all-includes body file)
+                   (prog1 (expand-all-includes body file)
                      (pop seen-files)))))
              (expand-all-includes (instrs originating-file)
                ;; consume an instruction. if it's an include, we handoff to

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -63,7 +63,8 @@ This also signals ambiguous definitions, which may be handled as needed."
                                         (lexical-context instr))))
                  ;; check for conflicts
                  (a:when-let ((entries (gethash signature all-seen-defns)))
-                   (signal (ambiguous-definition-condition instr originating-file entries)))
+                   (cerror "Continue with ambiguous definition."
+                           (ambiguous-definition-condition instr originating-file entries)))
                  (push (cons instr originating-file)
                        (gethash signature all-seen-defns))))
              (typecase instr

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -4,8 +4,78 @@
 
 (in-package #:cl-quil)
 
-;;; Used solely for application resolution to detect if we are resolving things inside of a circuit.
+;;; Used solely for application resolution to detect if we are resolving things
+;;; inside of a circuit.
 (defvar *in-circuit-body* nil)
+
+(defun definition-signature (instr)
+  "If INSTR is a definition or memory declaration, returns a signature used for
+determining ambiguity. Otherwise, return NIL."
+  (flet ((gate-or-circuit-signature (name params args)
+           ;; TODO in principle the signature should include the number of params and args
+           ;; since e.g. we can tell the difference between FOO 1 and FOO 1 2. however,
+           ;; for now we follow the convention of not discriminating between these.
+           (declare (ignore params args))
+           (list 'gate-or-circuit-definition
+                 name)))
+    (typecase instr
+      (gate-definition (gate-or-circuit-signature (gate-definition-name instr)
+                                                  (when (typep instr 'parameterized-gate-definition)
+                                                    (gate-definition-parameters instr))
+                                                  (gate-definition-qubits-needed instr)) )
+      (circuit-definition (gate-or-circuit-signature (circuit-definition-name instr)
+                                                     (circuit-definition-parameters instr)
+                                                     (circuit-definition-arguments instr)))
+      (memory-descriptor (cons 'memory-descriptor (memory-descriptor-name instr))))))
+
+(defun signal-ambiguous-definition (instr file conflicts)
+  "Signal a condition indicating that the instruction INSTR parsed from FILE has
+a list of conflicts CONFLICTS."
+  (let ((combined (acons instr file conflicts)))
+    (etypecase instr
+      (gate-definition (signal 'ambiguous-gate-or-circuit-definition :conflicts combined))
+      (circuit-definition (signal 'ambiguous-gate-or-circuit-definition :conflicts combined))
+      (memory-descriptor (signal 'ambiguous-memory-declaration :conflicts combined)))))
+
+(defun extract-code-sections (code)
+  "Partition CODE into four values:
+
+    1. List of gate definitions.
+
+    2. List of circuit definitions.
+
+    3. List of memory descriptors.
+
+    4. List of code to execute.
+
+This also signals ambiguous definitions, which may be handled as needed."
+  ;; Note: this preserves the order of definitions.
+  (let ((gate-defs nil)
+        (circ-defs nil)
+        (memory-defs nil)
+        (exec-code nil)
+        ;; The following maps definition signatures to a list of (filename . defn) pairs
+        (all-seen-defns (make-hash-table :test 'equal)))
+    (flet ((bin (instr)
+             (a:when-let ((signature (definition-signature instr)))
+               (let ((originating-file (token-pathname
+                                        (token-context instr))))
+                 ;; check for conflicts
+                 (with-simple-restart (continue "Continue with ambiguous definition.")
+                   (a:when-let ((entries (gethash signature all-seen-defns)))
+                     (signal-ambiguous-definition instr originating-file entries)))
+                 (push (cons instr originating-file)
+                       (gethash signature all-seen-defns))))
+             (typecase instr
+               (gate-definition (push instr gate-defs))
+               (circuit-definition (push instr circ-defs))
+               (memory-descriptor (push instr memory-defs))
+               (t (push instr exec-code)))))
+      (mapc #'bin code)
+      (values (nreverse gate-defs)
+              (nreverse circ-defs)
+              (nreverse memory-defs)
+              (nreverse exec-code)))))
 
 ;;; TODO: Factor out this gate arity computation to something nicer.
 (defgeneric resolve-application (app &key gate-definitions circuit-definitions)

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -4,6 +4,7 @@
 
 (in-package #:cl-quil)
 
+;;; Used solely for application resolution to detect if we are resolving things inside of a circuit.
 (defvar *in-circuit-body* nil)
 
 ;;; TODO: Factor out this gate arity computation to something nicer.

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -59,8 +59,11 @@ This also signals ambiguous definitions, which may be handled as needed."
         (all-seen-defns (make-hash-table :test 'equal)))
     (flet ((bin (instr)
              (a:when-let ((signature (definition-signature instr)))
-               (let ((originating-file (token-pathname
-                                        (lexical-context instr))))
+               (let ((originating-file (typecase (lexical-context instr)
+                                         (token
+                                          (token-pathname (lexical-context instr)))
+                                         (t
+                                          (quil-parse-error "Unable to resolve definition context ~A" instr)))))
                  ;; check for conflicts
                  (a:when-let ((entries (gethash signature all-seen-defns)))
                    (cerror "Continue with ambiguous definition."

--- a/src/analysis/rewrite-arithmetic.lisp
+++ b/src/analysis/rewrite-arithmetic.lisp
@@ -181,5 +181,4 @@ a list of the original memory descriptors (to which the user can write
 any value, which is not allowed for the new descriptor, _p) as well as
 a mapping from _p[i] to the original delayed expression of the ith
 gate with parameter arithmetic."
-  process-includes
   expand-circuits)

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -292,12 +292,14 @@ If no exit rewiring is found, return NIL."
 
 ;;;;;;;;;;;;;;;;;;;; Gate and Circuit Definitions ;;;;;;;;;;;;;;;;;;;;
 
-(defclass lexical-context ()
-  ((context :initarg :context
-            :type (or null token)
-            :accessor lexical-context))
-  (:metaclass abstract-class)
-  (:documentation "Associates a `lexical context' to an AST object, which may be useful for downstream processing."))
+;;; Note: In the future this might be expanded to include other objects.
+(deftype lexical-context () '(or null token))
+
+(defgeneric lexical-context (instr)
+  (:method ((instr t))
+    ;; By default, there is none.
+    nil)
+  (:documentation "Get the lexical context of an instruction."))
 
 (defclass gate-definition (lexical-context)
   ((name :initarg :name
@@ -308,7 +310,10 @@ If no exit rewiring is found, return NIL."
    ;; of many repeated calculations of a GATE object. See the function
    ;; GATE-DEFINITION-TO-GATE.
    (cached-gate :initform nil
-                :accessor %gate-definition-cached-gate))
+                :accessor %gate-definition-cached-gate)
+   (context :initarg :context
+            :type lexical-context
+            :accessor lexical-context))
   (:metaclass abstract-class)
   (:documentation "A representation of a raw, user-specified gate definition. This is *not* supposed to be an executable representation."))
 
@@ -383,7 +388,7 @@ as a permutation."
                        :entries entries
                        :context context))))
 
-(defclass circuit-definition (lexical-context)
+(defclass circuit-definition ()
   ((name :initarg :name
          :reader circuit-definition-name)
    (parameters :initarg :parameters
@@ -391,7 +396,10 @@ as a permutation."
    (arguments :initarg :arguments
               :reader circuit-definition-arguments)
    (body :initarg :body
-         :reader circuit-definition-body)))
+         :reader circuit-definition-body)
+   (context :initarg :context
+            :type lexical-context
+            :accessor lexical-context)))
 
 (defun make-circuit-definition (name params args body &key context)
   (check-type name string)

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -301,7 +301,7 @@ If no exit rewiring is found, return NIL."
     nil)
   (:documentation "Get the lexical context of an instruction."))
 
-(defclass gate-definition (lexical-context)
+(defclass gate-definition ()
   ((name :initarg :name
          :reader gate-definition-name)
    (entries :initarg :entries

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -292,7 +292,13 @@ If no exit rewiring is found, return NIL."
 
 ;;;;;;;;;;;;;;;;;;;; Gate and Circuit Definitions ;;;;;;;;;;;;;;;;;;;;
 
-(defclass gate-definition ()
+(defclass context-token-mixin ()
+  ((token :initarg :token
+          :accessor token-context))
+  (:documentation "Associates a 'context token' to an AST object, which may be
+  useful for downstream processing."))
+
+(defclass gate-definition (context-token-mixin)
   ((name :initarg :name
          :reader gate-definition-name)
    (entries :initarg :entries
@@ -373,7 +379,7 @@ as a permutation."
                        :name name
                        :entries entries))))
 
-(defclass circuit-definition ()
+(defclass circuit-definition (context-token-mixin)
   ((name :initarg :name
          :reader circuit-definition-name)
    (parameters :initarg :parameters

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -659,10 +659,11 @@ Return the following values:
   nil)
 
 (defun output-cfg (quil out-file &key parallel dce simplify)
-  (let ((pp (parse-quil-into-raw-program (if (pathnamep quil)
-                                             (a:read-file-into-string quil)
-                                             quil))))
-    (setf pp (transform 'process-includes pp (if (pathnamep quil) quil nil)))
+  (let ((pp (parse-quil (if (pathnamep quil)
+                            (a:read-file-into-string quil)
+                            quil)
+                        :originating-file (and (pathnamep quil) quil)
+                        :transforms '(process-includes))))
     (output-cfg-from-program pp out-file :parallel parallel :dce dce :simplify simplify)))
 
 (defun output-cfg-from-program (pp out-file &key parallel dce simplify)

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -662,8 +662,7 @@ Return the following values:
   (let ((pp (parse-quil (if (pathnamep quil)
                             (a:read-file-into-string quil)
                             quil)
-                        :originating-file (and (pathnamep quil) quil)
-                        :transforms '(process-includes))))
+                        :originating-file (and (pathnamep quil) quil))))
     (output-cfg-from-program pp out-file :parallel parallel :dce dce :simplify simplify)))
 
 (defun output-cfg-from-program (pp out-file &key parallel dce simplify)

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -666,7 +666,6 @@ Return the following values:
     (output-cfg-from-program pp out-file :parallel parallel :dce dce :simplify simplify)))
 
 (defun output-cfg-from-program (pp out-file &key parallel dce simplify)
-  (setf pp (transform 'resolve-applications pp))
   (setf pp (transform 'expand-circuits pp))
   (let ((cfg (program-cfg pp :dce dce :simplify simplify)))
     ;; Parallelize the CFG if asked for.

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -5,13 +5,15 @@
 (in-package #:cl-quil)
 
 (defvar *standard-post-process-transforms*
-  '(resolve-applications expand-circuits type-check)
+  '(expand-circuits type-check)
   "The standard transforms that are applied by PARSE-QUIL.")
 
 (defun parse-quil (string &key originating-file (transforms *standard-post-process-transforms*))
   "Parse and process the Quil string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string."
   (let* ((*current-file* originating-file)
-         (pp (parse-quil-into-raw-program string originating-file)))
+         (raw-quil (parse-quil-into-ast string))
+         (pp (resolve-applications
+              (process-includes raw-quil originating-file))))
     (dolist (xform transforms pp)
       (setf pp (transform xform pp)))))
 

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -10,7 +10,7 @@
 
 (defun parse-quil (string &key originating-file
                             (transforms *standard-post-process-transforms*)
-                            (ambiguous-definition-handler (constantly nil)))
+                            (ambiguous-definition-handler #'continue))
   "Parse and process the Quil string STRING, which originated from the file
 ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed
 Quil string. In the presence of multiple definitions with a common signature, a
@@ -29,7 +29,7 @@ signal is raised, with the default handler specified by AMBIGUOUS-DEFINITION-HAN
                                name recent-file previous-file))))
        ;; Note: we could generally allow for more sophisticated handling, but for now the default
        ;; is to continue chugging along.
-       (ambiguous-definition ambiguous-definition-handler))
+       (ambiguous-gate-or-circuit-definition ambiguous-definition-handler))
       (let* ((*current-file* originating-file)
              (raw-quil (parse-quil-into-raw-program string))
              (pp (resolve-applications

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -10,7 +10,7 @@
 
 (defun parse-quil (string &key originating-file
                             (transforms *standard-post-process-transforms*)
-                            (ambiguous-definition-handler #'continue))
+                            (ambiguous-definition-handler (constantly nil)))
   "Parse and process the Quil string STRING, which originated from the file
 ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed
 Quil string. In the presence of multiple definitions with a common signature, a

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -5,17 +5,15 @@
 (in-package #:cl-quil)
 
 (defvar *standard-post-process-transforms*
-  '(process-includes resolve-applications expand-circuits type-check)
+  '(resolve-applications expand-circuits type-check)
   "The standard transforms that are applied by PARSE-QUIL.")
 
 (defun parse-quil (string &key originating-file (transforms *standard-post-process-transforms*))
   "Parse and process the Quil string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string."
   (let* ((*current-file* originating-file)
-         (pp (parse-quil-into-raw-program string)))
+         (pp (parse-quil-into-raw-program string originating-file)))
     (dolist (xform transforms pp)
-      (case xform
-        (process-includes (setf pp (transform xform pp originating-file)))
-        (otherwise        (setf pp (transform xform pp)))))))
+      (setf pp (transform xform pp)))))
 
 (defun read-quil-file (filespec)
   "Read the Quil file designated by FILESPEC, and parse it as if by PARSE-QUIL."

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -10,7 +10,8 @@
 
 (defun parse-quil (string &key originating-file (transforms *standard-post-process-transforms*))
   "Parse and process the Quil string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string."
-  (let ((pp (parse-quil-into-raw-program string)))
+  (let* ((*current-file* originating-file)
+         (pp (parse-quil-into-raw-program string)))
     (dolist (xform transforms pp)
       (case xform
         (process-includes (setf pp (transform xform pp originating-file)))

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -9,13 +9,28 @@
   "The standard transforms that are applied by PARSE-QUIL.")
 
 (defun parse-quil (string &key originating-file (transforms *standard-post-process-transforms*))
-  "Parse and process the Quil string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string."
-  (let* ((*current-file* originating-file)
-         (raw-quil (parse-quil-into-raw-program string))
-         (pp (resolve-applications
-              (process-includes raw-quil originating-file))))
-    (dolist (xform transforms pp)
-      (setf pp (transform xform pp)))))
+  "Parse and process the Quil string STRING, which originated from the file
+ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed
+Quil string."
+  (handler-bind
+      ((ambiguous-memory-declaration
+         (lambda  (c)
+           ;; Within a single file, multiple declarations of the same memory region
+           ;; (even if equivalent) are disallowed. We thus extent this to declarations across
+           ;; multiple files.
+           (let ((name (memory-descriptor-name (car (first (ambiguous-definition-conflicts c)))))
+                 (recent-file (cdr (first (ambiguous-definition-conflicts c))))
+                 (previous-file (cdr (second (ambiguous-definition-conflicts c)))))
+             (quil-parse-error "Memory region ~A~@[ (in ~A)~] has already been DECLAREd~@[ (in ~A)~]."
+                               name recent-file previous-file))))
+       ;; Ignore other ambiguities (with undefined behavior).
+       (ambiguous-definition #'continue))
+      (let* ((*current-file* originating-file)
+             (raw-quil (parse-quil-into-raw-program string))
+             (pp (resolve-applications
+                  (process-includes raw-quil originating-file))))
+        (dolist (xform transforms pp)
+          (setf pp (transform xform pp))))))
 
 (defun read-quil-file (filespec)
   "Read the Quil file designated by FILESPEC, and parse it as if by PARSE-QUIL."

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -11,7 +11,7 @@
 (defun parse-quil (string &key originating-file (transforms *standard-post-process-transforms*))
   "Parse and process the Quil string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string."
   (let* ((*current-file* originating-file)
-         (raw-quil (parse-quil-into-ast string))
+         (raw-quil (parse-quil-into-raw-program string))
          (pp (resolve-applications
               (process-includes raw-quil originating-file))))
     (dolist (xform transforms pp)

--- a/src/classical-memory.lisp
+++ b/src/classical-memory.lisp
@@ -47,7 +47,12 @@
   ;; NOTE: we may want to make these writeable for a compiler that slots user-
   ;;       defined memory spaces into hardware-available memory spaces
   (sharing-parent nil :read-only t :type (or null string))
-  (sharing-offset-alist nil :read-only t :type list))
+  (sharing-offset-alist nil :read-only t :type list)
+  ;; Context token, available for later resolution
+  (token nil :read-only t :type (or null token)))
+
+(defmethod token-context ((obj memory-descriptor))
+  (memory-descriptor-token obj))
 
 (defun simple-memory-descriptor-p (desc)
   "Is the object DESC a memory descriptor that is \"simple\", i.e., does not alias?"

--- a/src/classical-memory.lisp
+++ b/src/classical-memory.lisp
@@ -49,9 +49,9 @@
   (sharing-parent nil :read-only t :type (or null string))
   (sharing-offset-alist nil :read-only t :type list)
   ;; Context token, available for later resolution
-  (token nil :read-only t :type (or null token)))
+  (lexical-context nil :read-only t :type (or null token)))
 
-(defmethod token-context ((obj memory-descriptor))
+(defmethod lexical-context ((obj memory-descriptor))
   (memory-descriptor-token obj))
 
 (defun simple-memory-descriptor-p (desc)

--- a/src/classical-memory.lisp
+++ b/src/classical-memory.lisp
@@ -52,7 +52,7 @@
   (lexical-context nil :read-only t :type (or null token)))
 
 (defmethod lexical-context ((obj memory-descriptor))
-  (memory-descriptor-token obj))
+  (memory-descriptor-lexical-context obj))
 
 (defun simple-memory-descriptor-p (desc)
   "Is the object DESC a memory descriptor that is \"simple\", i.e., does not alias?"

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -161,9 +161,6 @@ Returns a value list: (processed-program, of type parsed-program
 
   (warm-chip-spec-lookup-cache chip-specification)
 
-  ;; start by doing some basic expansion transformations
-  (transform 'resolve-applications parsed-program)
-
   ;; we disallow compilation of programs that use memory aliasing
   (loop :for mdesc :in (parsed-program-memory-definitions parsed-program)
         :when (memory-descriptor-sharing-parent mdesc)

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -293,7 +293,7 @@
 (global-vars:define-global-var **default-gate-definitions**
     (let ((table (make-hash-table :test 'equal))
           (gate-defs (remove-if-not (lambda (obj) (typep obj 'gate-definition))
-                      (parse-quil-into-ast
+                      (parse-quil-into-raw-program
                        (a:read-file-into-string
                         (asdf:system-relative-pathname
                          "cl-quil" "src/quil/stdgates.quil"))))))

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -292,8 +292,8 @@
 ;;; Load all of the standard gates from src/quil/stdgates.quil
 (global-vars:define-global-var **default-gate-definitions**
     (let ((table (make-hash-table :test 'equal))
-          (gate-defs (parsed-program-gate-definitions
-                      (parse-quil-into-raw-program
+          (gate-defs (remove-if-not (lambda (obj) (typep obj 'gate-definition))
+                      (parse-quil-into-ast
                        (a:read-file-into-string
                         (asdf:system-relative-pathname
                          "cl-quil" "src/quil/stdgates.quil"))))))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -108,7 +108,6 @@ as needed so that they are the same size."
  than 'physical', qubits. When :COMPRESS-QUBITS is enabled (default:
  nil), qubit indices are permuted to minimize matrix size."
   (when compress-qubits
-    (setf pp (transform 'process-includes pp nil))
     (setf pp (transform 'compress-qubits pp)))
   ;; to handle a l2p rewiring, we need to conjugate the "physical"
   ;; matrix of a block by the permutation matrix associated with the

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1617,6 +1617,23 @@ result of BODY, and the (possibly null) list of remaining lines.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Entry Point ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define-condition ambiguous-definition (quil-parse-error)
+  ((conflicts :initarg :conflicts :reader ambiguous-definition-conflicts
+              :documentation "A list of (filename . definition) pairs which conflict."))
+  (:documentation "A condition indicating the presence of multiple (possibly conflicting) definitions."))
+
+(define-condition ambiguous-gate-definition (ambiguous-definition)
+  ()
+  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DEFGATE forms."))
+
+(define-condition ambiguous-memory-declaration (ambiguous-definition)
+  ()
+  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DECLARE forms."))
+
+(define-condition ambiguous-circuit-definition (ambiguous-definition)
+  ()
+  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DEFCIRCUIT forms."))
+
 (defun extract-code-sections (code)
   "Partition CODE into three values:
 

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1231,7 +1231,8 @@ result of BODY, and the (possibly null) list of remaining lines.
                              :type type
                              :length length
                              :sharing-parent sharing-parent
-                             :sharing-offset-alist (reverse sharing-offset-alist))
+                             :sharing-offset-alist (reverse sharing-offset-alist)
+                             :token (first (first tok-lines)))
      (rest tok-lines))))
 
 (defun parse-label (tok-lines)
@@ -1633,41 +1634,13 @@ result of BODY, and the (possibly null) list of remaining lines.
               :documentation "A list of (filename . definition) pairs which conflict."))
   (:documentation "A condition indicating the presence of multiple (possibly conflicting) definitions."))
 
-(define-condition ambiguous-gate-definition (ambiguous-definition)
-  ()
-  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DEFGATE forms."))
-
 (define-condition ambiguous-memory-declaration (ambiguous-definition)
   ()
   (:documentation "A condition indicating the presence of multiple (possibly conflicting) DECLARE forms."))
 
-(define-condition ambiguous-circuit-definition (ambiguous-definition)
+(define-condition ambiguous-gate-or-circuit-definition (ambiguous-definition)
   ()
-  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DEFCIRCUIT forms."))
-
-(defun extract-code-sections (code)
-  "Partition CODE into three values:
-
-    1. List of gate definitions.
-
-    2. List of circuit definitions.
-
-    3. List of code to execute."
-  (let ((gate-defs nil)
-        (circ-defs nil)
-        (memory-defs nil)
-        (exec-code nil))
-    (flet ((bin (x)
-             (typecase x
-               (gate-definition (push x gate-defs))
-               (circuit-definition (push x circ-defs))
-               (memory-descriptor (push x memory-defs))
-               (t (push x exec-code)))))
-      (mapc #'bin code)
-      (values (nreverse gate-defs)
-              (nreverse circ-defs)
-              (nreverse memory-defs)
-              (nreverse exec-code)))))
+  (:documentation "A condition indicating the presence of multiple (possibly conflicting) DEFGATE or DEFCIRCUIT forms."))
 
 (defun parse-quil-into-raw-program (string)
   "Parse a string STRING into a list of raw Quil syntax objects."

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1641,8 +1641,8 @@ result of BODY, and the (possibly null) list of remaining lines.
               (nreverse memory-defs)
               (nreverse exec-code)))))
 
-(defun parse-quil-into-ast (string)
-  "Parse a string STRING into a sequence of raw Quil syntax objects."
+(defun parse-quil-into-raw-program (string)
+  "Parse a string STRING into a list of raw Quil syntax objects."
   (check-type string string)
   (let* ((*memory-region-names* nil)
          (tok-lines (tokenize string)))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1654,20 +1654,6 @@ result of BODY, and the (possibly null) list of remaining lines.
               (setf tok-lines rest-toks))
           :finally (return (nreverse parsed-program)))))
 
-(defun parse-quil-into-raw-program (string &optional originating-file)
-  "Parse a string STRING into a raw, untransformed PARSED-PROGRAM object."
-  (check-type string string)
-  (let ((parsed-program (parse-quil-into-ast string)))
-    (setf parsed-program (process-includes parsed-program originating-file))
-    ;; Return the parsed sequence of objects.
-    (multiple-value-bind (gate-defs circ-defs memory-defs exec-code)
-        (extract-code-sections parsed-program)
-      (make-instance 'parsed-program
-                     :gate-definitions gate-defs
-                     :circuit-definitions circ-defs
-                     :memory-definitions memory-defs
-                     :executable-code (coerce exec-code 'simple-vector)))))
-
 (defvar *safe-include-directory* nil)
 
 (defun resolve-safely (filename)

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1664,7 +1664,7 @@ result of BODY, and the (possibly null) list of remaining lines.
   (let* ((*memory-region-names* nil)
          (tok-lines (tokenize string)))
     (loop :with parsed-program := nil
-          :until (null tok-lines) :do
+          :until (endp tok-lines) :do
             (multiple-value-bind (program-entity rest-toks)
                 (parse-program-lines tok-lines)
               (push program-entity parsed-program)

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1623,7 +1623,7 @@ result of BODY, and the (possibly null) list of remaining lines.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Entry Point ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-condition ambiguous-definition (quil-parse-error)
+(define-condition ambiguous-definition ()
   ((conflicts :initarg :conflicts :reader ambiguous-definition-conflicts
               :documentation "A list of (filename . definition) pairs which conflict."))
   (:documentation "A condition indicating the presence of multiple (possibly conflicting) definitions."))

--- a/tests/cfg-tests.lisp
+++ b/tests/cfg-tests.lisp
@@ -24,7 +24,7 @@
   (is (string= (format nil "H 0~%CNOT 0 1~%")
                (with-output-to-string (out)
                  (quil::print-code-list (quil:parsed-program-executable-code
-                                         (quil::parse-quil-into-raw-program (format nil "H 0~%CNOT 0 1"))) out)))))
+                                         (quil::parse-quil (format nil "H 0~%CNOT 0 1"))) out)))))
 
 (defun assert-cfg-edge-invariant (cfg)
   "Asserts that the outgoing and incoming fields of blocks in CFG are a valid match."
@@ -44,7 +44,7 @@
 
 (deftest test-reconstitute-unconditional-jump ()
   "Test that the correct program is parsed from a CFG with one edge"
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "H 0~%JUMP @NEXT~%LABEL @NEXT~%X 1")))
+  (let* ((p (quil::parse-quil (format nil "H 0~%JUMP @NEXT~%LABEL @NEXT~%X 1")))
          (blk-1 (format nil "H 0~%JUMP"))
          (blk-2 "X 1")
          (cfg (quil::program-cfg p))
@@ -55,7 +55,7 @@
     (is (search blk-2 string-result))))
 
 (deftest test-reconstitute-conditional-jump ()
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "DECLARE ro BIT~%H 0~%JUMP-UNLESS @NEXT ro[0]~%LABEL @NEXT~%Z 0")))
+  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%H 0~%JUMP-UNLESS @NEXT ro[0]~%LABEL @NEXT~%Z 0")))
          (blk-0 (format nil "H 0~%JUMP-WHEN"))
          (blk-1 "LABEL @NEXT")
          (blk-2 "Z 0")
@@ -79,7 +79,7 @@
 
 (deftest test-remove-block ()
   "Tests that removing a block from the CFG preserves the validity of the CFG."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "X 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END")))
          (cfg (quil::program-cfg p))
          (to-remove (first (quil::cfg-blocks cfg))))
     
@@ -89,14 +89,14 @@
 
 (deftest test-dce-none ()
   "Tests the operation of dead code elimination when the cfg is already optimal."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "X 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
     (is (= 2 (length blocks-result)))))
 
 (deftest test-dce-simple-extras ()
   "Tests the operation of dead code elimination when presented with a simple graph with extra labels."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "X 0~%JUMP @END~%LABEL @END~%Y 0~%JUMP @ANOTHER~%LABEL @ANOTHER~%Z 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END~%Y 0~%JUMP @ANOTHER~%LABEL @ANOTHER~%Z 0~%JUMP @END~%LABEL @END")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -105,7 +105,7 @@
 
 (deftest test-dce-dead-loop ()
   "Tests the operation of dead code elimination when the cfg has a dead loop."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "JUMP @L~%LABEL @D~%X 0~%JUMP @D~%LABEL @L~%H 0")))
+  (let* ((p (quil::parse-quil (format nil "JUMP @L~%LABEL @D~%X 0~%JUMP @D~%LABEL @L~%H 0")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -119,7 +119,7 @@
 
 (deftest test-block-fusion-maximally-simplified ()
   "Tests the operation of block fusion when the CGF is already maximally simplified."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "X 0")))
+  (let* ((p (quil::parse-quil (format nil "X 0")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg))
          (entry (quil::entry-point cfg))
@@ -132,7 +132,7 @@
 
 (deftest test-block-fusion-simple-contraction ()
   "Tests the operation of block fusion when the CFG has a single edge that can be contracted."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "X 0~%JUMP @NEXT~%LABEL @NEXT~%JUMP @ANOTHER~%LABEL @ANOTHER~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @NEXT~%LABEL @NEXT~%JUMP @ANOTHER~%LABEL @ANOTHER~%JUMP @END~%LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -141,7 +141,7 @@
 
 (deftest test-block-fusion-multiple-contraction-unique-code ()
   "Tests the operation of block fusion when the CFG has multiple edges that can be contracted, where each block has disimilar code."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "LABEL @START~%X 0~%JUMP @MID~%LABEL @MID~%Y 0~%JUMP @END~%LABEL @END~%Z 0")))
+  (let* ((p (quil::parse-quil (format nil "LABEL @START~%X 0~%JUMP @MID~%LABEL @MID~%Y 0~%JUMP @END~%LABEL @END~%Z 0")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg))
          (merged-blk (first (remove-if (lambda (blk)
@@ -159,7 +159,7 @@
 
 (deftest test-block-fusion-empty-single-unconditional-self-loop ()
   "Tests the operation of block fusion when the CFG has an unconditional self-loop with a single empty block."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "LABEL @START~%H 0~%JUMP @LOOPER~%LABEL @LOOPER~%JUMP @START")))
+  (let* ((p (quil::parse-quil (format nil "LABEL @START~%H 0~%JUMP @LOOPER~%LABEL @LOOPER~%JUMP @START")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -169,7 +169,7 @@
 
 (deftest test-block-fusion-nonempty-conditional-multiple-self-loop ()
   "Tests the operation of block fusion when the CFG has a long self loop with code inside."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%X 0~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%X 0~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -179,7 +179,7 @@
 
 (deftest test-block-fusion-empty-conditional-self-loop ()
   "Tests the operaton of block fusion when the CFG has an empty self loop with a conditional control."
-  (let* ((p (quil::parse-quil-into-raw-program (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -192,5 +192,5 @@
 
 This is a regression test for https://github.com/rigetti/quilc/issues/244"
   (dolist (jump-instr '("JUMP-WHEN" "JUMP-UNLESS"))
-    (let ((p (quil::parse-quil-into-raw-program (format nil "DECLARE ro BIT~%LABEL @START~%~A @START ro[0]" jump-instr))))
+    (let ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%~A @START ro[0]" jump-instr))))
       (not-signals error (quil::program-cfg p :dce t :simplify t)))))

--- a/tests/cfg-tests.lisp
+++ b/tests/cfg-tests.lisp
@@ -24,7 +24,7 @@
   (is (string= (format nil "H 0~%CNOT 0 1~%")
                (with-output-to-string (out)
                  (quil::print-code-list (quil:parsed-program-executable-code
-                                         (quil::parse-quil (format nil "H 0~%CNOT 0 1"))) out)))))
+                                         (quil::parse-quil "H 0;CNOT 0 1")) out)))))
 
 (defun assert-cfg-edge-invariant (cfg)
   "Asserts that the outgoing and incoming fields of blocks in CFG are a valid match."
@@ -44,7 +44,7 @@
 
 (deftest test-reconstitute-unconditional-jump ()
   "Test that the correct program is parsed from a CFG with one edge"
-  (let* ((p (quil::parse-quil (format nil "H 0~%JUMP @NEXT~%LABEL @NEXT~%X 1")))
+  (let* ((p (quil::parse-quil "H 0;JUMP @NEXT;LABEL @NEXT;X 1"))
          (blk-1 (format nil "H 0~%JUMP"))
          (blk-2 "X 1")
          (cfg (quil::program-cfg p))
@@ -55,7 +55,7 @@
     (is (search blk-2 string-result))))
 
 (deftest test-reconstitute-conditional-jump ()
-  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%H 0~%JUMP-UNLESS @NEXT ro[0]~%LABEL @NEXT~%Z 0")))
+  (let* ((p (quil::parse-quil "DECLARE ro BIT;H 0;JUMP-UNLESS @NEXT ro[0];LABEL @NEXT;Z 0"))
          (blk-0 (format nil "H 0~%JUMP-WHEN"))
          (blk-1 "LABEL @NEXT")
          (blk-2 "Z 0")
@@ -79,7 +79,7 @@
 
 (deftest test-remove-block ()
   "Tests that removing a block from the CFG preserves the validity of the CFG."
-  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END")))
          (cfg (quil::program-cfg p))
          (to-remove (first (quil::cfg-blocks cfg))))
     
@@ -89,14 +89,14 @@
 
 (deftest test-dce-none ()
   "Tests the operation of dead code elimination when the cfg is already optimal."
-  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
     (is (= 2 (length blocks-result)))))
 
 (deftest test-dce-simple-extras ()
   "Tests the operation of dead code elimination when presented with a simple graph with extra labels."
-  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @END~%LABEL @END~%Y 0~%JUMP @ANOTHER~%LABEL @ANOTHER~%Z 0~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END;Y 0;JUMP @ANOTHER;LABEL @ANOTHER;Z 0;JUMP @END;LABEL @END")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -105,7 +105,7 @@
 
 (deftest test-dce-dead-loop ()
   "Tests the operation of dead code elimination when the cfg has a dead loop."
-  (let* ((p (quil::parse-quil (format nil "JUMP @L~%LABEL @D~%X 0~%JUMP @D~%LABEL @L~%H 0")))
+  (let* ((p (quil::parse-quil (format nil "JUMP @L;LABEL @D;X 0;JUMP @D;LABEL @L;H 0")))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -132,7 +132,7 @@
 
 (deftest test-block-fusion-simple-contraction ()
   "Tests the operation of block fusion when the CFG has a single edge that can be contracted."
-  (let* ((p (quil::parse-quil (format nil "X 0~%JUMP @NEXT~%LABEL @NEXT~%JUMP @ANOTHER~%LABEL @ANOTHER~%JUMP @END~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @NEXT;LABEL @NEXT;JUMP @ANOTHER;LABEL @ANOTHER;JUMP @END;LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -141,7 +141,7 @@
 
 (deftest test-block-fusion-multiple-contraction-unique-code ()
   "Tests the operation of block fusion when the CFG has multiple edges that can be contracted, where each block has disimilar code."
-  (let* ((p (quil::parse-quil (format nil "LABEL @START~%X 0~%JUMP @MID~%LABEL @MID~%Y 0~%JUMP @END~%LABEL @END~%Z 0")))
+  (let* ((p (quil::parse-quil (format nil "LABEL @START;X 0;JUMP @MID;LABEL @MID;Y 0;JUMP @END;LABEL @END;Z 0")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg))
          (merged-blk (first (remove-if (lambda (blk)
@@ -159,7 +159,7 @@
 
 (deftest test-block-fusion-empty-single-unconditional-self-loop ()
   "Tests the operation of block fusion when the CFG has an unconditional self-loop with a single empty block."
-  (let* ((p (quil::parse-quil (format nil "LABEL @START~%H 0~%JUMP @LOOPER~%LABEL @LOOPER~%JUMP @START")))
+  (let* ((p (quil::parse-quil (format nil "LABEL @START;H 0;JUMP @LOOPER;LABEL @LOOPER;JUMP @START")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -169,7 +169,7 @@
 
 (deftest test-block-fusion-nonempty-conditional-multiple-self-loop ()
   "Tests the operation of block fusion when the CFG has a long self loop with code inside."
-  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%X 0~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;X 0;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -179,7 +179,7 @@
 
 (deftest test-block-fusion-empty-conditional-self-loop ()
   "Tests the operaton of block fusion when the CFG has an empty self loop with a conditional control."
-  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%H 0~%JUMP-WHEN @LOOPER ro[0]~%JUMP @END~%LABEL @LOOPER~%JUMP @LOOPER2~%LABEL @LOOPER2~%JUMP @LOOPER3~%LABEL @LOOPER3~%JUMP @START~%LABEL @END")))
+  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END")))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -192,5 +192,5 @@
 
 This is a regression test for https://github.com/rigetti/quilc/issues/244"
   (dolist (jump-instr '("JUMP-WHEN" "JUMP-UNLESS"))
-    (let ((p (quil::parse-quil (format nil "DECLARE ro BIT~%LABEL @START~%~A @START ro[0]" jump-instr))))
+    (let ((p (quil::parse-quil (format nil "DECLARE ro BIT;LABEL @START;~A @START ro[0]" jump-instr))))
       (not-signals error (quil::program-cfg p :dce t :simplify t)))))

--- a/tests/cfg-tests.lisp
+++ b/tests/cfg-tests.lisp
@@ -79,7 +79,7 @@
 
 (deftest test-remove-block ()
   "Tests that removing a block from the CFG preserves the validity of the CFG."
-  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END")))
+  (let* ((p (quil::parse-quil "X 0;JUMP @END;LABEL @END"))
          (cfg (quil::program-cfg p))
          (to-remove (first (quil::cfg-blocks cfg))))
     
@@ -89,14 +89,14 @@
 
 (deftest test-dce-none ()
   "Tests the operation of dead code elimination when the cfg is already optimal."
-  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END")))
+  (let* ((p (quil::parse-quil "X 0;JUMP @END;LABEL @END"))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
     (is (= 2 (length blocks-result)))))
 
 (deftest test-dce-simple-extras ()
   "Tests the operation of dead code elimination when presented with a simple graph with extra labels."
-  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @END;LABEL @END;Y 0;JUMP @ANOTHER;LABEL @ANOTHER;Z 0;JUMP @END;LABEL @END")))
+  (let* ((p (quil::parse-quil "X 0;JUMP @END;LABEL @END;Y 0;JUMP @ANOTHER;LABEL @ANOTHER;Z 0;JUMP @END;LABEL @END"))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -105,7 +105,7 @@
 
 (deftest test-dce-dead-loop ()
   "Tests the operation of dead code elimination when the cfg has a dead loop."
-  (let* ((p (quil::parse-quil (format nil "JUMP @L;LABEL @D;X 0;JUMP @D;LABEL @L;H 0")))
+  (let* ((p (quil::parse-quil "JUMP @L;LABEL @D;X 0;JUMP @D;LABEL @L;H 0"))
          (cfg (quil::program-cfg p :dce t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -119,7 +119,7 @@
 
 (deftest test-block-fusion-maximally-simplified ()
   "Tests the operation of block fusion when the CGF is already maximally simplified."
-  (let* ((p (quil::parse-quil (format nil "X 0")))
+  (let* ((p (quil::parse-quil "X 0"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg))
          (entry (quil::entry-point cfg))
@@ -132,7 +132,7 @@
 
 (deftest test-block-fusion-simple-contraction ()
   "Tests the operation of block fusion when the CFG has a single edge that can be contracted."
-  (let* ((p (quil::parse-quil (format nil "X 0;JUMP @NEXT;LABEL @NEXT;JUMP @ANOTHER;LABEL @ANOTHER;JUMP @END;LABEL @END")))
+  (let* ((p (quil::parse-quil "X 0;JUMP @NEXT;LABEL @NEXT;JUMP @ANOTHER;LABEL @ANOTHER;JUMP @END;LABEL @END"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -141,7 +141,7 @@
 
 (deftest test-block-fusion-multiple-contraction-unique-code ()
   "Tests the operation of block fusion when the CFG has multiple edges that can be contracted, where each block has disimilar code."
-  (let* ((p (quil::parse-quil (format nil "LABEL @START;X 0;JUMP @MID;LABEL @MID;Y 0;JUMP @END;LABEL @END;Z 0")))
+  (let* ((p (quil::parse-quil "LABEL @START;X 0;JUMP @MID;LABEL @MID;Y 0;JUMP @END;LABEL @END;Z 0"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg))
          (merged-blk (first (remove-if (lambda (blk)
@@ -159,7 +159,7 @@
 
 (deftest test-block-fusion-empty-single-unconditional-self-loop ()
   "Tests the operation of block fusion when the CFG has an unconditional self-loop with a single empty block."
-  (let* ((p (quil::parse-quil (format nil "LABEL @START;H 0;JUMP @LOOPER;LABEL @LOOPER;JUMP @START")))
+  (let* ((p (quil::parse-quil "LABEL @START;H 0;JUMP @LOOPER;LABEL @LOOPER;JUMP @START"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -169,7 +169,7 @@
 
 (deftest test-block-fusion-nonempty-conditional-multiple-self-loop ()
   "Tests the operation of block fusion when the CFG has a long self loop with code inside."
-  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;X 0;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END")))
+  (let* ((p (quil::parse-quil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;X 0;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 
@@ -179,7 +179,7 @@
 
 (deftest test-block-fusion-empty-conditional-self-loop ()
   "Tests the operaton of block fusion when the CFG has an empty self loop with a conditional control."
-  (let* ((p (quil::parse-quil (format nil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END")))
+  (let* ((p (quil::parse-quil "DECLARE ro BIT;LABEL @START;H 0;JUMP-WHEN @LOOPER ro[0];JUMP @END;LABEL @LOOPER;JUMP @LOOPER2;LABEL @LOOPER2;JUMP @LOOPER3;LABEL @LOOPER3;JUMP @START;LABEL @END"))
          (cfg (quil::program-cfg p :dce t :simplify t))
          (blocks-result (quil::cfg-blocks cfg)))
 

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -276,8 +276,7 @@ CZ 2 7
                                                p)))))))
                                  (application-parameters instr))))
 
-         (make-pp () (quil::parse-quil program-string
-                                       :transforms '(quil::resolve-applications))))
+         (make-pp () (quil::parse-quil program-string :transforms nil)))
     (let* ((chip (quil::build-8Q-chip :architecture ':cz))
            (processed-pp (compiler-hook (make-pp) chip))
            (orig-pp (make-pp)))
@@ -366,7 +365,6 @@ MEASURE 0 ro[0]
 MEASURE 1 ro[1]
 MEASURE 2 ro[2]
 ")))
-    (quil::transform 'quil::resolve-applications pp)
     (multiple-value-bind (initial code final)
         (quil::do-greedy-temporal-addressing
             (coerce (parsed-program-executable-code pp) 'list)

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -92,7 +92,7 @@ CNOT 0 1")
   (dolist (quil::*addresser-move-to-rewiring-swap-search-type* '(:greedy-path :greedy-qubit :a*))
     (format t "~&    Testing addresser move type ~A~%" quil::*addresser-move-to-rewiring-swap-search-type*)
     (finish-output)
-    (let* ((pp (quil::parse-quil-into-raw-program "
+    (let* ((pp (quil::parse-quil "
 LABEL @a
 CNOT 0 1
 CNOT 1 2
@@ -217,7 +217,7 @@ MEASURE 0 ro[1]"))
 (deftest test-compiler-hook-reset-naive-rewiring ()
   ;; Note this numbering depends on the fact that the CZ gates are
   ;; native on the 8Q chip.
-  (let* ((pp (quil::parse-quil-into-raw-program "
+  (let* ((pp (quil::parse-quil "
 PRAGMA INITIAL_REWIRING \"NAIVE\"
 CZ 1 2
 CZ 3 4
@@ -233,7 +233,7 @@ CZ 5 6
                                (_ nil))))))))
 
 (deftest test-compiler-hook-reset-partial-rewiring ()
-  (let* ((pp (quil::parse-quil-into-raw-program "
+  (let* ((pp (quil::parse-quil "
 PRAGMA INITIAL_REWIRING \"PARTIAL\"
 CZ 1 2
 CZ 7 6
@@ -250,7 +250,7 @@ CZ 2 7
 
 (deftest test-compiling-empty-program ()
   "Test that an empty program goes through the pipes correctly."
-  (let* ((pp (quil::parse-quil-into-raw-program ""))
+  (let* ((pp (quil::parse-quil ""))
          (processed-program (quil::compiler-hook pp (quil::build-8Q-chip))))
     (is (every (lambda (isn)
                  (or (typep isn 'quil:halt)
@@ -276,9 +276,8 @@ CZ 2 7
                                                p)))))))
                                  (application-parameters instr))))
 
-         (make-pp ()
-           (quil::transform 'quil::resolve-applications
-                            (quil::parse-quil-into-raw-program program-string))))
+         (make-pp () (quil::parse-quil program-string
+                                       :transforms '(quil::resolve-applications))))
     (let* ((chip (quil::build-8Q-chip :architecture ':cz))
            (processed-pp (compiler-hook (make-pp) chip))
            (orig-pp (make-pp)))
@@ -330,7 +329,7 @@ CNOT 1 2"))
         (is (quil::matrix-equals-dwim old-matrix new-matrix))))))
 
 (deftest test-rewiring-backfilling ()
-  (let ((pp (quil::parse-quil-into-raw-program "
+  (let ((pp (quil::parse-quil "
 DECLARE beta REAL[1]
 DECLARE gamma REAL[1]
 DECLARE ro BIT[3]
@@ -479,7 +478,7 @@ MEASURE 1
 
 (deftest test-clever-CCNOT-depth-reduction ()
   "Test that the ':GREEDY-QUBIT swap selection strategy brings CZ depth down to optimal for CCNOT."
-  (let ((p (quil::compiler-hook (quil::parse-quil-into-raw-program "
+  (let ((p (quil::compiler-hook (quil::parse-quil "
 PRAGMA INITIAL_REWIRING \"GREEDY\"
 CCNOT 0 1 2")
                                 (quil::build-8Q-chip)))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -21,14 +21,6 @@
     (test-it t '((2 2)) '(2 2))
     (test-it t '((2) (1 1) (2 2 2) (1 1 1 1)) '(2 1 1 2 2 2 1 1 1 1))))
 
-(deftest test-code-splicing ()
-  (is (equalp (cl-quil::splice-code-at #(1 x 2 3) 1 #(a b c))
-              #(1 A B C 2 3)))
-  (is (equalp (cl-quil::splice-code-at #(x 1 2 3) 0 #(a b c))
-              #(A B C 1 2 3)))
-  (is (equalp (cl-quil::splice-code-at #(0 1 2 x) 3 #(a b c))
-              #(0 1 2 A B C))))
-
 (deftest test-append-reduce ()
   (is (equal nil (quil::reduce-append nil)))
   (is (equal nil (quil::reduce-append '(nil))))

--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -57,8 +57,7 @@
                    (format s ", ")))
                (format s "~%"))
              (format s "TEST ~{~d ~}" (a:iota qubit-count))))
-         (parsed-prog (quil::parse-quil-into-raw-program program-string)))
-    (setf parsed-prog (quil::transform 'quil::resolve-applications parsed-prog))
+         (parsed-prog (quil::parse-quil program-string)))
     (is (quil::matrix-equality (magicl:make-identity-matrix (expt 2 qubit-count))
                                (quil::make-matrix-from-quil (coerce (parsed-program-executable-code parsed-prog) 'list))))))
 

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -201,12 +201,12 @@ TEST 0 1 2"))
            (pp (parse-quil test-quil)))
       (is (= 1 (length (parsed-program-memory-definitions pp)))))))
 
-(deftest test-process-include-declaration-collision ()
-  (uiop:with-temporary-file (:stream stream :pathname path)
-    (format stream "DECLARE foo BIT~@
-                    MEASURE 0 foo")
-    (force-output stream)
-    (let* ((test-quil (format nil "DECLARE foo BIT~@
-                                   H 0~@
-                                   INCLUDE \"~A\"" path)))
-      (signals quil-parse-error (parse-quil test-quil)))))
+;; (deftest test-process-include-declaration-collision ()
+;;   (uiop:with-temporary-file (:stream stream :pathname path)
+;;     (format stream "DECLARE foo BIT~@
+;;                     MEASURE 0 foo")
+;;     (force-output stream)
+;;     (let* ((test-quil (format nil "DECLARE foo BIT~@
+;;                                    H 0~@
+;;                                    INCLUDE \"~A\"" path)))
+;;       (signals quil-parse-error (parse-quil test-quil)))))

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -191,7 +191,7 @@ TEST 0 1 2"))
       (is (typep (first gates) 'quil::permutation-gate-definition)))
     (signals quil-parse-error (parse-quil quil-bad))))
 
-(deftest test-process-include ()
+(deftest test-parsing-process-include ()
   (uiop:with-temporary-file (:stream stream :pathname path)
     (format stream "DECLARE foo BIT~@
                     MEASURE 0 foo")
@@ -201,7 +201,7 @@ TEST 0 1 2"))
            (pp (parse-quil test-quil)))
       (is (= 1 (length (parsed-program-memory-definitions pp)))))))
 
-(deftest test-process-include-declaration-collision ()
+(deftest test-parsing-include-declaration-collision ()
   (uiop:with-temporary-file (:stream stream :pathname path)
     (format stream "DECLARE foo BIT~@
                     MEASURE 0 foo")
@@ -211,8 +211,35 @@ TEST 0 1 2"))
                                    INCLUDE \"~A\"" path)))
       (signals quil-parse-error (parse-quil test-quil)))))
 
+(deftest test-parsing-include-defgate-ambiguity ()
+  (uiop:with-temporary-file (:stream stream :pathname path)
+    (format stream "
+DEFGATE FOO:
+    1/sqrt(2), 1/sqrt(2)
+    1/sqrt(2), -1/sqrt(2)")
+    (force-output stream)
+    (let* ((test-quil (format nil "
+DEFGATE FOO:
+    1/sqrt(2), 1/sqrt(2)
+    1/sqrt(2), -1/sqrt(2)
 
-(deftest test-multiple-includes-good ()
+INCLUDE \"~A\"" path)))
+      (signals quil::ambiguous-gate-or-circuit-definition
+        (parse-quil test-quil :ambiguous-definition-handler #'identity)))))
+
+(deftest test-parsing-defgate-defcircuit-ambiguity ()
+  (let ((test-quil "
+DEFGATE FOO(%a):
+    1/sqrt(2), 1/sqrt(2)
+    1/sqrt(2), -1/sqrt(2)
+
+DEFCIRCUIT FOO(%a) q v:
+    X q
+"))
+    (signals quil::ambiguous-gate-or-circuit-definition
+      (parse-quil test-quil :ambiguous-definition-handler #'identity))))
+
+(deftest test-parsing-multiple-includes-good ()
   (uiop:with-temporary-file (:stream stream :pathname path)
     (format stream "X 0")
     (force-output stream)
@@ -224,7 +251,7 @@ TEST 0 1 2"))
            (pp (parse-quil test-quil)))
       (is (= 3 (length (parsed-program-executable-code pp)))))))
 
-(deftest test-cyclic-include ()
+(deftest test-parsing-cyclic-include ()
   (uiop:with-temporary-file (:stream stream1 :pathname path1)
     (uiop:with-temporary-file (:stream stream2 :pathname path2)
       (format stream1 "X 0;INCLUDE \"~A\"" path2)

--- a/tests/printer-tests.lisp
+++ b/tests/printer-tests.lisp
@@ -140,8 +140,7 @@ DEFCIRCUIT TEST(%a) b c:
 TEST(0.5) 0 1
 ")
          (after (parse-and-print-quil-to-string before :parser (lambda (string)
-                                                                 (quil::parse-quil string
-                                                                                   :transforms '(quil::resolve-applications))))))
+                                                                 (quil::parse-quil string :transforms nil)))))
     (is (string= before after))))
 
 (deftest test-jump-to-integer-label-printing ()

--- a/tests/printer-tests.lisp
+++ b/tests/printer-tests.lisp
@@ -141,8 +141,7 @@ TEST(0.5) 0 1
 ")
          (after (parse-and-print-quil-to-string before :parser (lambda (string)
                                                                  (quil::parse-quil string
-                                                                                   :transforms '(quil::process-includes
-                                                                                                 quil::resolve-applications))))))
+                                                                                   :transforms '(quil::resolve-applications))))))
     (is (string= before after))))
 
 (deftest test-jump-to-integer-label-printing ()

--- a/tests/printer-tests.lisp
+++ b/tests/printer-tests.lisp
@@ -127,7 +127,7 @@ R 0"))
       (not-signals error (quil::parse-quil after)))))
 
 (deftest test-circuit-and-declare-printing ()
-  ;; This test relies on the fact that PARSE-QUIL-INTO-RAW-PROGRAM doesn't EXPAND-CIRCUITS,
+  ;; This test relies on not applying the EXPAND-CIRCUITS transform,
   ;; otherwise it could be included in TEST-PRINT-PARSED-PROGRAM-GOLDEN-FILES, above.
   (let* ((before "DECLARE theta REAL[16]
 DECLARE theta-bits BIT[100] SHARING theta OFFSET 1 REAL
@@ -139,7 +139,10 @@ DEFCIRCUIT TEST(%a) b c:
 
 TEST(0.5) 0 1
 ")
-         (after (parse-and-print-quil-to-string before :parser #'quil::parse-quil-into-raw-program)))
+         (after (parse-and-print-quil-to-string before :parser (lambda (string)
+                                                                 (quil::parse-quil string
+                                                                                   :transforms '(quil::process-includes
+                                                                                                 quil::resolve-applications))))))
     (is (string= before after))))
 
 (deftest test-jump-to-integer-label-printing ()

--- a/tests/state-prep-tests.lisp
+++ b/tests/state-prep-tests.lisp
@@ -25,7 +25,7 @@
 (deftest test-aqvm-unlink-refuses-large-GHZ-state ()
   "Checks that an AQVM correctly assembles a GHZ state and then correctly disables itself."
   (let ((aqvm (quil::build-aqvm 8))
-        (quil (quil::parse-quil-into-raw-program "
+        (quil (quil::parse-quil "
 H 0
 CNOT 0 1
 CNOT 1 2
@@ -71,7 +71,7 @@ CNOT 2 3
 (deftest test-aqvm-unlink-on-10Q ()
   (let ((quil::*aqvm-correlation-threshold* 4)
         (aqvm (quil::build-aqvm 11))
-        (pp (quil::parse-quil-into-raw-program "
+        (pp (quil::parse-quil "
 # set up wf
 RX(1.0) 3
 RX(1.3) 1

--- a/tests/state-prep-tests.lisp
+++ b/tests/state-prep-tests.lisp
@@ -31,7 +31,6 @@ CNOT 0 1
 CNOT 1 2
 CNOT 2 3
 ")))
-    (quil::transform 'quil::resolve-applications quil)
     (dolist (instr (coerce (quil::parsed-program-executable-code quil) 'list))
       (quil::aqvm-apply-instruction aqvm instr))
     ;; check that the correct state was constructed
@@ -97,7 +96,6 @@ CNOT 6 5
 CNOT 3 5
 CNOT 3 5
 ")))
-    (quil::transform 'quil::resolve-applications pp)
     (dolist (instr (coerce (parsed-program-executable-code pp) 'list))
       (quil::aqvm-apply-instruction aqvm instr))
     (quil::aqvm-stop-simulating aqvm 10)

--- a/tests/typed-memory-tests.lisp
+++ b/tests/typed-memory-tests.lisp
@@ -8,7 +8,7 @@
 (in-package #:cl-quil-tests)
 
 (deftest test-typed-circuit-expansion ()
-  (let ((pp (quil::parse-quil-into-raw-program "
+  (let ((pp (quil::parse-quil "
 DECLARE a BIT
 
 DEFCIRCUIT CLEAR q scratch-bit:
@@ -18,10 +18,6 @@ DEFCIRCUIT CLEAR q scratch-bit:
     LABEL @end
 
 CLEAR 0 a")))
-    (quil::transform 'quil::process-includes pp nil)
-    (quil::transform 'quil::resolve-applications pp)
-    (quil::transform 'quil::expand-circuits pp)
-    (quil::transform 'quil::type-check pp)
     (let ((instr (aref (quil::parsed-program-executable-code pp) 0)))
       (is (typep instr 'quil::measure))
       (is (= (quil::qubit-index (quil::measurement-qubit instr)) 0))
@@ -29,7 +25,7 @@ CLEAR 0 a")))
                   (quil::mref "a" 0 (first (quil::parsed-program-memory-definitions pp))))))))
 
 (deftest test-constant-coercion ()
-  (let ((pp (quil::parse-quil-into-raw-program "
+  (let ((pp (quil::parse-quil "
 DECLARE stats INTEGER
 DECLARE angle REAL
 
@@ -38,10 +34,6 @@ MOVE stats 0
 MOVE angle 0
 
 RX(-2.0*angle) 0")))
-    (quil::transform 'quil::process-includes pp nil)
-    (quil::transform 'quil::resolve-applications pp)
-    (quil::transform 'quil::expand-circuits pp)
-    (quil::transform 'quil::type-check pp)
     (let ((code (parsed-program-executable-code pp)))
       (is (equalp quil::quil-integer (quil::constant-value-type
                                       (quil::classical-right-operand (aref code 0)))))
@@ -51,7 +43,7 @@ RX(-2.0*angle) 0")))
         (is (typep param 'quil::delayed-expression))))))
 
 (deftest test-compression-with-classical-angles ()
-  (let ((pp (quil::parse-quil-into-raw-program "
+  (let ((pp (quil::parse-quil "
 DECLARE val REAL[8]
 DECLARE ro BIT
 DECLARE int INTEGER
@@ -60,15 +52,11 @@ RZ(val[2]) 0
 RZ(val[0]+val[1]) 0
 RZ(val[1]) 0
 RZ(val[3]) 1")))
-    (quil::transform 'quil::process-includes pp nil)
-    (quil::transform 'quil::resolve-applications pp)
-    (quil::transform 'quil::expand-circuits pp)
-    (quil::transform 'quil::type-check pp)
     (let ((cpp (quil::compiler-hook pp (quil::build-8Q-chip))))
       (is (= 3 (length (quil::parsed-program-executable-code cpp)))))))
 
 (deftest test-compression-with-classical-angles-+-resource-usage ()
-  (let ((pp (quil::parse-quil-into-raw-program "
+  (let ((pp (quil::parse-quil "
 DECLARE val REAL[8]
 DECLARE ro BIT
 DECLARE int INTEGER
@@ -78,10 +66,6 @@ STORE val int[0] val[1]
 RZ(val[0]+val[1]) 0
 RZ(val[1]) 0
 RZ(val[3]) 1")))
-    (quil::transform 'quil::process-includes pp nil)
-    (quil::transform 'quil::resolve-applications pp)
-    (quil::transform 'quil::expand-circuits pp)
-    (quil::transform 'quil::type-check pp)
     (let ((cpp (quil::compiler-hook pp (quil::build-8Q-chip))))
       (is (= 5 (length (quil::parsed-program-executable-code cpp)))))))
 


### PR DESCRIPTION
Previously `PARSE-QUIL-INTO-RAW-PROGRAM` produced a `PARSED-PROGRAM` object, which in particular had no notion of where or in what order its various definitions originated. This is fine if the presence of multiple conflicting definitions results in undefined behavior, but e.g. it might be nice to have the option for more fine-grained control in name resolution. Further, the quilt proposal allows (and even encourages) multiple calibrations for a given gate, and we need to be able to support that adequately. After discussions with @ecpeterson and @stylewarning I've opted to shuffle things around a bit.

This PR changes `PARSE-QUIL-INTO-RAW-PROGRAM` to produce a list of ast objects in their source order. `PROCESS-INCLUDES` and `RESOLVE-APPLICATIONS` have been downgraded to ordinary functions (i.e. they are no longer registered transforms), which are invoked by `PARSE-QUIL`.  The other transforms are still valid and work with `PARSED-PROGRAM` objects, as before. 

When includes are processed, we maintain a table mapping definition signatures to (name . definition) pairs. When a collision is observed, this prompts a signal to be raised. The policy for handling these should be explicit. Right now the only handler I have in mind (seen in `PARSE-QUIL`) is for memory declarations (which are treated rather strictly in the parser), but this could naturally be extended for the other definition types. Note that quilt will also add `DEFWAVEFORM` and `DEFCAL`, so the flexibility here may prove useful.

There are a few other changes that go with this. Tokens now get a filename slot.