### PR TITLE
put guards around type vs gate-information

### DIFF
--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -264,7 +264,7 @@ used to specify CHIP-SPEC."
   (check-type qubit1 unsigned-byte)
   (check-type gate-information (or null hash-table))
   (assert (/= qubit0 qubit1))
-  (assert (xor (null gate-information) (null type)))
+  (assert (a:xor (null gate-information) (null type)))
   (setf type (a:ensure-list type))
   (let* ((obj (make-hardware-object
                :order 1
@@ -324,7 +324,7 @@ used to specify CHIP-SPEC."
 
  * The GATE-INFORMATION keyword can be used to directly supply a hash table to be installed in the GATE-INFORMATION slot on the hardware object, allowing completely custom gateset control."
   (check-type gate-information (or null hash-table))
-  (assert (xor (null gate-information) (null type)))
+  (assert (a:xor (null gate-information) (null type)))
   (let ((obj (make-hardware-object :order 0)))
     ;; new style of initialization
     (when gate-information

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -208,7 +208,3 @@ contains the bits of INTEGER. See http://www.cliki.net/ROTATE-BYTE"
   (fresh-line stream)
   (dohash ((key val) hash)
     (format stream "~a -> ~a~%" key val)))
-
-(defun xor (&rest vals)
-  (oddp (loop :for val :in vals
-              :count val)))


### PR DESCRIPTION
Supplying both `type` and `gate-information` kwargs to `build-qubit` and `build-link` would result in mildly bad behavior: there might be some loss of specs information, there might be some duplicate entries, ... . This PR adds a guard that throws an error if both are provided. Eventually we'll also phase `type` out.