### PR TITLE
Remove README references to the now-deleted HTTP server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,10 @@ or (2) communicating with the `quilc` server.
 
 #### quilc
 
-> *Note*: If you're on Windows and using the Command Prompt, the echo
-> command is slightly different to the examples shown below: do not
-> wrap your quil code in quotes. For example, in Command Prompt, you
-> would do `echo H 0 | quilc` *not* `echo "H 0" | quilc`.
-
 The `quilc` binary reads Quil code provided on `stdin`:
 
 ``` shell
-$ echo "H 0" | quilc
+$ echo H 0 | quilc
 $ cat large_file.quil | quilc
 ```
 
@@ -201,7 +196,7 @@ docker run --rm -it rigetti/quilc
 2. You can alternatively pipe Quil instructions into the `quilc` container if you drop the `-t`.
 
 ```shell
-echo "H 0" | docker run --rm -i rigetti/quilc
+echo H 0 | docker run --rm -i rigetti/quilc
 ```
 
 To run `quilc` in server mode, do the following:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Quilc comprises two projects. The first, `cl-quil`, does the heavy
 lifting of parsing, compiling, and optimizing Quil code. The second,
 `quilc`, presents an external interface for using `cl-quil`, either using
 the binary `quilc` application directly, or alternatively by
-communicating with a server (HTTP or [RPCQ](https://github.com/rigetti/rpcq/)).
+communicating with an [RPCQ](https://github.com/rigetti/rpcq/) server.
 
 Quil is the [quantum instruction language](https://arxiv.org/pdf/1608.03355.pdf) developed at
 [Rigetti Computing](https://rigetti.com). In Quil quantum algorithms are expressed using Quil's
@@ -97,40 +97,11 @@ $ cat large_file.quil | quilc
 
 For various reasons (e.g. not having to repeatedly load the `quilc`
 binary into memory, communicating over a network) `quilc` provides a
-server interface. `quilc` currently supports two server modes:
-
-##### HTTP
-
-The HTTP server was the original implementation of the server mode. It is now deprecated in favour
-of the RPCQ server mode. Do not depend on it. You can create the HTTP server with the `-S` flag
-```
-$ quilc -S
-+-----------------+
-|  W E L C O M E  |
-|   T O   T H E   |
-|  R I G E T T I  |
-|     Q U I L     |
-| C O M P I L E R |
-+-----------------+
-Copyright (c) 2016-2019 Rigetti Computing.
-
-
-
->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> IMPORTANT NOTICE <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-The HTTP endpoint has been deprecated in favor of the RPCQ endpoint.  In the
-future, it will be removed.  You're advised to modify your client code to talk
-to the RPCQ version instead.
->>>>>>>>>>>>>>>>>>>>>>>>>>>>> END IMPORTANT NOTICE <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-
-[2019-01-29 13:59:18] Starting server: 0.0.0.0 : 6000.
-```
-
-##### RPCQ
-
-[RPCQ](https://github.com/rigetti/rpcq/) is an open-source RPC framework developed at Rigetti for
-efficient network communication through the QCS stack. The server is started in RPCQ-mode using
-the `-R` flag
+an [RPCQ](https://github.com/rigetti/rpcq/) server
+interface. [RPCQ](https://github.com/rigetti/rpcq/) is an open-source
+RPC framework developed at Rigetti for efficient network communication
+through the QCS stack. The server is started in RPCQ-mode using the
+`-R` flag
 
 ```
 $ quilc -R


### PR DESCRIPTION
- HTTP server mode was recently deleted. Remove the README sections that mention it.
- Update examples that include `echo` commands to pass unquoted arguments, and remove the Windows-specific note.