### PR TITLE
4q state prep

### DIFF
--- a/src/chip-specification.lisp
+++ b/src/chip-specification.lisp
@@ -400,6 +400,7 @@ used to specify CHIP-SPEC."
             'ucr-compiler-to-iswap))
         (constantly 'state-prep-1q-compiler)
         (constantly 'state-prep-2q-compiler)
+        (constantly 'state-prep-4q-compiler)
         (constantly 'state-prep-trampolining-compiler)
         (constantly 'recognize-ucr)
         (lambda (chip-spec arch)

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -238,13 +238,13 @@
        elts))
 
 (defun schmidt-decomposition (phi num-a num-b)
-  "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI.
-Returns c, U, V, where c is vector and U,V are unitary matrices (of dimensions
-NUM-A and NUM-B respectively) such that
-
-   PHI = \sum_{i} d_i U_i V _i
-
-where U_i, V_i denotes the ith column of the matrix U, V respectively."
+  "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI."
+  ;; Returns c, U, V, where c is vector and U, V are unitary matrices (of dimensions
+  ;; NUM-A and NUM-B respectively) such that
+  ;;
+  ;;    PHI = \sum_{i} c_i U_i V _i
+  ;;
+  ;; where U_i, V_i denotes the ith column of the matrix U, V respectively.
   (assert (= (qubit-count phi) (+ num-a num-b)))
   (when (listp phi)
     (setf phi (coerce-to-complex-double-vector phi)))
@@ -261,10 +261,8 @@ where U_i, V_i denotes the ith column of the matrix U, V respectively."
               (magicl:transpose vt)))))
 
 (defun state-prep-4q (wf q0 q1 q2 q3 &key reversed)
-  "Produce instructions to prepare the wavefunction WF with respect to qubits Q0
-Q1 Q2 Q3, starting from the zero state. If REVERSED is T, the instructions
-instead prepare the zero state from WF."
-   ;;; The following is from arXiv:1003.5760
+  "Produce instructions to prepare the wavefunction WF with respect to qubits Q0 Q1 Q2 Q3, starting from the zero state. If REVERSED is T, the instructions instead prepare the zero state from WF."
+  ;; The following is from arXiv:1003.5760
   (assert (= 4 (qubit-count wf)))
   ;; each function in the following FLET is responsible for handling the REVERSED
   ;; flag on its own
@@ -276,7 +274,7 @@ instead prepare the zero state from WF."
                           :target-wf target
                           :arguments (mapcar #'qubit qubit-indices)))
          (cnot (a b)
-           (build-gate "CNOT" nil a b))
+           (build-gate "CNOT" () a b))
          (2q-evolution (U a b)
            (anon-gate "STATE-2Q"
                       (if reversed (magicl:dagger U) U)

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -239,7 +239,7 @@
 
 (defun schmidt-decomposition (phi num-a num-b)
   "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI."
-  ;; Returns c, U, V, where c is vector and U, V are unitary matrices (of dimensions
+  ;; Returns c, U, V, where c is a vector and U, V are unitary matrices (of dimensions
   ;; NUM-A and NUM-B respectively) such that
   ;;
   ;;    PHI = \sum_{i} c_i U_i V _i

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -301,3 +301,21 @@
      (state-prep-2Q-compiler instr))
     (otherwise
      (state-prep-trampolining-compiler instr))))
+
+(defun schmidt-decomposition (phi num-a num-b)
+  "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI.
+Returns c, U, V, where c is vector and U,V are unitary matrices (of dimensions
+NUM-A and NUM-B respectively) such that
+
+   PHI = \sum_{i} d_i U_i V _i
+
+where U_i, V_i denotes the ith column of the matrix U, V respectively."
+  (assert (= (qubit-count phi) (+ num-a num-b)))
+  (let ((reshaped (magicl:make-matrix :rows (expt 2 num-a)
+                                      :cols (expt 2 num-b)
+                                      :data phi)))
+    (multiple-value-bind (u d vt)
+        (magicl:svd reshaped)
+      (values u
+              (magicl:matrix-diagonal d)
+              (magicl:transpose vt)))))

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -232,6 +232,92 @@
                                      :operator #.(named-operator "RHS-state-prep-gate")
                                      :arguments (list (first (application-arguments instr))))))))))
 
+(defun coerce-to-complex-double-vector (elts)
+  (map '(vector (complex double-float))
+       (lambda (val) (coerce val '(complex double-float)))
+       elts))
+
+(defun schmidt-decomposition (phi num-a num-b)
+  "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI.
+Returns c, U, V, where c is vector and U,V are unitary matrices (of dimensions
+NUM-A and NUM-B respectively) such that
+
+   PHI = \sum_{i} d_i U_i V _i
+
+where U_i, V_i denotes the ith column of the matrix U, V respectively."
+  (assert (= (qubit-count phi) (+ num-a num-b)))
+  (when (listp phi)
+    (setf phi (coerce-to-complex-double-vector phi)))
+  (let* ((size-a (expt 2 num-a))
+         (size-b (expt 2 num-b))
+         ;; tranpose here to make this row-major
+         (reshaped (magicl:transpose (magicl:make-matrix :rows size-a
+                                                         :cols size-b
+                                                         :data phi))))
+    (multiple-value-bind (u d vt)
+        (magicl:svd reshaped)
+      (values (coerce-to-complex-double-vector (magicl:matrix-diagonal d))
+              u
+              (magicl:transpose vt)))))
+
+(defun state-prep-4q (wf q0 q1 q2 q3 &key reversed)
+  "Produce instructions to prepare the wavefunction WF with respect to qubits Q0
+Q1 Q2 Q3, starting from the zero state. If REVERSED is T, the instructions
+instead prepare the zero state from WF."
+   ;;; The following is from arXiv:1003.5760
+  (assert (= 4 (qubit-count wf)))
+  ;; each function in the following FLET is responsible for handling the REVERSED
+  ;; flag on its own
+  (flet ((state-prep-2q (source target qubit-indices)
+           (when reversed
+             (rotatef source target))
+           (make-instance 'state-prep-application
+                          :source-wf source
+                          :target-wf target
+                          :arguments (mapcar #'qubit qubit-indices)))
+         (cnot (a b)
+           (build-gate "CNOT" nil a b))
+         (2q-evolution (U a b)
+           (anon-gate "STATE-2Q"
+                      (if reversed (magicl:dagger U) U)
+                      a b)))
+    (multiple-value-bind (c U V)
+        (schmidt-decomposition wf 2 2)
+      (let ((instrs
+              (list
+               ;; prepare on qubits 2,3
+               (state-prep-2q (build-ground-state 2)
+                              c
+                              (list q2 q3))
+               ;; entangle
+               (cnot q2 q0)
+               (cnot q3 q1)
+
+               ;; apply unitaries, transposing qubits to account for LSB <-> MSB mismatch
+               (2q-evolution U q3 q2)
+               (2q-evolution V q1 q0))))
+        (if reversed
+            (reverse instrs)
+            instrs)))))
+
+(define-compiler state-prep-4Q-compiler
+    ((instr (_ _ q0 q1 q2 q3)
+            :where (typep instr 'state-prep-application)))
+  "Compiler for STATE-PREP-APPLICATION instances that target a single qubit."
+  (let ((source-wf (vector-scale
+                    (/ (norm (coerce (state-prep-application-source-wf instr) 'list)))
+                    (coerce (state-prep-application-source-wf instr) 'list)))
+        (target-wf (vector-scale
+                    (/ (norm (coerce (state-prep-application-target-wf instr) 'list)))
+                    (coerce (state-prep-application-target-wf instr) 'list))))
+    (append
+     ;; prepare source -> zero state
+     (state-prep-4q source-wf q0 q1 q2 q3
+                    :reversed t)
+     ;; prepare zero state -> target
+     (state-prep-4q target-wf q0 q1 q2 q3))))
+
+
 (define-compiler state-prep-trampolining-compiler
     ((instr :where (typep instr 'state-prep-application)))
   "Recursive compiler for STATE-PREP-APPLICATION instances. It's probably wise to use this only if the state preparation instruction targets at least two qubits."
@@ -290,10 +376,10 @@
 (defun state-prep-compiler (instr &key (target ':cz))
   "Compiles a STATE-PREP-APPLICATION instance by intelligently selecting one of the special-case compilation routines above."
   (declare (ignore target))
-  
+
   (unless (typep instr 'state-prep-application)
     (give-up-compilation))
-  
+
   (case (length (application-arguments instr))
     (1
      (state-prep-1Q-compiler instr))
@@ -303,87 +389,3 @@
      (state-prep-4Q-compiler instr))
     (otherwise
      (state-prep-trampolining-compiler instr))))
-
-(defun state-prep-4q (wf q0 q1 q2 q3 &key reversed)
-  "Produce instructions to prepare the wavefunction WF with respect to qubits Q0
-Q1 Q2 Q3, starting from the zero state. If REVERSED is T, the instructions
-instead prepare the zero state from WF."
-  (assert (= 4 (qubit-count wf)))
-  ;; each function in the following FLET is responsible for handling the REVERSED
-  ;; flag on its own
-  (flet ((state-prep-2q (source target qubit-indices)
-           (when reversed
-             (rotatef source target))
-           (make-instance 'state-prep-application
-                          :source-wf source
-                          :target-wf target
-                          :arguments (mapcar #'qubit qubit-indices)))
-         (cnot (a b)
-           (build-gate "CNOT" nil a b))
-         (2q-evolution (U a b)
-           (anon-gate "STATE-2Q"
-                      (if reversed (magicl:dagger U) U)
-                      a b)))
-    (multiple-value-bind (c U V)
-        (schmidt-decomposition wf 2 2)
-      (let ((instrs
-              (list
-               ;; prepare on qubits 2,3
-               (state-prep-2q (build-ground-state 2)
-                              c
-                              (list q2 q3))
-               ;; entangle
-               (cnot q2 q0)
-               (cnot q3 q1)
-
-               ;; apply unitaries, transposing qubits to account for LSB <-> MSB mismatch
-               (2q-evolution U q3 q2)
-               (2q-evolution V q1 q0))))
-        (if reversed
-            (reverse instrs)
-            instrs)))))
-
-(define-compiler state-prep-4Q-compiler
-    ((instr (_ _ q0 q1 q2 q3)
-            :where (typep instr 'state-prep-application)))
-  "Compiler for STATE-PREP-APPLICATION instances that target a single qubit."
-  (let ((source-wf (vector-scale
-                    (/ (norm (coerce (state-prep-application-source-wf instr) 'list)))
-                    (coerce (state-prep-application-source-wf instr) 'list)))
-        (target-wf (vector-scale
-                    (/ (norm (coerce (state-prep-application-target-wf instr) 'list)))
-                    (coerce (state-prep-application-target-wf instr) 'list))))
-    (append
-     ;; prepare source -> zero state
-     (state-prep-4q source-wf q0 q1 q2 q3
-                    :reversed t)
-     ;; prepare zero state -> target
-     (state-prep-4q target-wf q0 q1 q2 q3))))
-
-(defun coerce-to-complex-double-vector (elts)
-  (map '(vector (complex double-float))
-       (lambda (val) (coerce val '(complex double-float)))
-       elts))
-
-(defun schmidt-decomposition (phi num-a num-b)
-  "Given a wavefunction PHI containing subystems of size NUM-A and NUM-B qubits, compute the Schmidt decomposition of PHI.
-Returns c, U, V, where c is vector and U,V are unitary matrices (of dimensions
-NUM-A and NUM-B respectively) such that
-
-   PHI = \sum_{i} d_i U_i V _i
-
-where U_i, V_i denotes the ith column of the matrix U, V respectively."
-  (assert (= (qubit-count phi) (+ num-a num-b)))
-  (when (listp phi)
-    (setf phi (coerce-to-complex-double-vector phi)))
-  (let* ((size-a (expt 2 num-a))
-         (size-b (expt 2 num-b))
-         ;; tranpose here to make this row-major
-         (reshaped (magicl:transpose (magicl:make-matrix :rows size-a
-                                                         :cols size-b
-                                                         :data phi))))
-    (multiple-value-bind (u d vt)
-        (magicl:svd reshaped)
-      (values (coerce-to-complex-double-vector (magicl:matrix-diagonal d))
-              u
-              (magicl:transpose vt)))))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -186,14 +186,14 @@ as needed so that they are the same size."
   "Get a random complex unit vector with (EXPT 2 N-QUBITS) entries."
   (let* ((size (expt 2 n-qubits)))
     (loop :repeat size
-          :for c := (complex (alexandria:gaussian-random)
-                                 (alexandria:gaussian-random))
+          :for c := (complex (a:gaussian-random)
+                             (a:gaussian-random))
           :collect c :into entries
           :sum (expt (abs c) 2) :into norm-squared
           :finally
              (return (make-array size
                                  :initial-contents
-                                 (let ((scaling-factor (/ 1 (sqrt norm-squared))))
+                                 (let ((scaling-factor (/ (sqrt norm-squared))))
                                    (mapcar (lambda (c) (* scaling-factor c)) entries))
                                  :element-type '(complex double-float))))))
 
@@ -269,7 +269,7 @@ as needed so that they are the same size."
         (loop :for u :in ret :do
           (setf v (vector-difference v (vector-scale (dot-product v u) u))))
         (when (not (double= 0 (norm v)))
-          (setf ret (cons (vector-scale (/ 1 (norm v)) v) ret)))))
+          (setf ret (cons (vector-scale (/ (norm v)) v) ret)))))
     ret))
 
 (defun collinearp (vect1 vect2)

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -184,7 +184,7 @@ as needed so that they are the same size."
 
 (defun random-wavefunction (n-qubits)
   "Get a random complex unit vector with (EXPT 2 N-QUBITS) entries."
-  (let* ((size (expt 2 n-qubits)))
+  (let ((size (expt 2 n-qubits)))
     (loop :repeat size
           :for c := (complex (a:gaussian-random)
                              (a:gaussian-random))
@@ -269,7 +269,7 @@ as needed so that they are the same size."
         (loop :for u :in ret :do
           (setf v (vector-difference v (vector-scale (dot-product v u) u))))
         (when (not (double= 0 (norm v)))
-          (setf ret (cons (vector-scale (/ (norm v)) v) ret)))))
+          (push (vector-scale (/ (norm v)) v) ret))))
     ret))
 
 (defun collinearp (vect1 vect2)

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -182,6 +182,21 @@ as needed so that they are the same size."
   (let ((m (magicl:random-unitary n)))
     (magicl:scale (expt (magicl:det m) (/ (- n))) m)))
 
+(defun random-wavefunction (n-qubits)
+  "Get a random complex unit vector with (EXPT 2 N-QUBITS) entries."
+  (let* ((size (expt 2 n-qubits)))
+    (loop :repeat size
+          :for c := (complex (alexandria:gaussian-random)
+                                 (alexandria:gaussian-random))
+          :collect c :into entries
+          :sum (expt (abs c) 2) :into norm-squared
+          :finally
+             (return (make-array size
+                                 :initial-contents
+                                 (let ((scaling-factor (/ 1 (sqrt norm-squared))))
+                                   (mapcar (lambda (c) (* scaling-factor c)) entries))
+                                 :element-type '(complex double-float))))))
+
 (defun orthonormalize-matrix (m)
   "Applies Gram-Schmidt to the columns of a full rank square matrix to produce a unitary matrix."
   ;; consider each column

--- a/tests/state-prep-tests.lisp
+++ b/tests/state-prep-tests.lisp
@@ -68,52 +68,44 @@ CNOT 2 3
            (magicl:multiply-complex-matrices output-matrix random-matrix)
            (magicl:diag 2 2 (list 1d0 1d0)))))))
 
+(defun wf-to-matrix (wf)
+  "Convert a sequence WF to a corresponding column vector."
+  (magicl:make-matrix :rows (length wf)
+                      :cols 1
+                      :data (copy-seq wf)))
+
 (deftest test-state-prep-4q ()
   (let* ((qubits (mapcar #'quil::qubit (list 0 1 2 3)))
-         (size (expt 2 (length qubits)))
-         (random-matrix (quil::random-special-unitary size))
-         (column (loop :for j :below size :collect (magicl:ref random-matrix j 0)))
+         (source-wf (quil::random-wavefunction 4))
+         (target-wf (quil::random-wavefunction 4))
          (instr (make-instance 'quil::state-prep-application
                                :arguments qubits
-                               :target-wf (make-array size :initial-contents column :element-type '(complex double-float))
-                               :source-wf (make-array size :initial-element #C(0d0 0d0) :element-type '(complex double-float)))))
-    (setf (aref (quil::state-prep-application-source-wf instr) 0) #C(1d0 0d0))
+                               :target-wf target-wf
+                               :source-wf source-wf)))
     (let* ((output-matrix (quil::make-matrix-from-quil
                            (quil::expand-to-native-instructions
                             (quil::state-prep-4q-compiler instr)
                             (quil::build-8Q-chip))))
-           (prefactor (/ (magicl:ref random-matrix 0 0) (magicl:ref output-matrix 0 0)))
-           (result (magicl:scale prefactor (magicl:matrix-column output-matrix 0))))
+           (result (magicl:multiply-complex-matrices
+                    output-matrix
+                    (wf-to-matrix source-wf)))
+           (prefactor (/ (aref target-wf 0) (magicl:ref result 0 0))))
+      (setf result (magicl:scale prefactor result))
       (is (quil::matrix-equality result
-                                 (magicl:make-complex-vector column))))))
-
-(defun destructively-swap-significance (seq)
-  "Given a sequence SEQ of length 2**N, swap elements at all pairs of indices i and j with
-mirrored binary expansions (e.g. 1010 <--> 0101)."
-  (let ((n (quil::qubit-count seq)))
-    (assert (= (expt 2 n) (length seq)))
-    (dotimes (i (expt 2 (1- n)) seq)
-      (let ((j (loop :with old := i
-                     :with new := 0
-                     :repeat n
-                     :do (progn (setf new (+ (ash new 1) (mod old 2)))
-                                (setf old (ash old -1)))
-                     :finally (return new))))
-        (rotatef (elt seq i) (elt seq j))))))
+                                 (wf-to-matrix target-wf))))))
 
 (deftest test-schmidt-decomposition ()
-  (let* ((random-matrix (quil::random-special-unitary 16))
-         (column (loop :for j :below 16 :collect (magicl:ref random-matrix j 0))))
-    (multiple-value-bind (c U V) (quil::schmidt-decomposition column 2 2)
+  (let* ((random-wf (quil::random-wavefunction 4)))
+    (multiple-value-bind (c U V) (quil::schmidt-decomposition random-wf 2 2)
       (let* ((schmidt-terms (loop :for i :from 0 :below 4
                                   :collect (magicl:scale (aref c i)
                                                          (magicl::kron
                                                           (magicl:matrix-column U i)
                                                           (magicl:matrix-column V i)))))
-             (reconstructed-column (apply #'magicl:add-matrix schmidt-terms)))
+             (reconstructed-wf (apply #'magicl:add-matrix schmidt-terms)))
         ;; adjust for column major nonsense
-        (is (quil::matrix-equality reconstructed-column
-                                   (magicl:make-complex-vector column)))))))
+        (is (quil::matrix-equality reconstructed-wf
+                                   (wf-to-matrix random-wf)))))))
 
 (deftest test-aqvm-unlink-on-10Q ()
   (let ((quil::*aqvm-correlation-threshold* 4)

--- a/tests/state-prep-tests.lisp
+++ b/tests/state-prep-tests.lisp
@@ -76,21 +76,23 @@ CNOT 2 3
                             (quil::build-8Q-chip)))))
       (check-state-prep source-wf target-wf output-matrix))))
 
-(deftest test-state-prep-4q ()
+(deftest test-state-prep-4q-compiler ()
+  "Check that STATE-PREP-4Q-COMPILER (with arbitrary SOURCE-WF and TARGET-WF) correctly compiles into native instructions."
   (let* ((qubits (mapcar #'quil::qubit (list 0 1 2 3)))
          (source-wf (quil::random-wavefunction 4))
          (target-wf (quil::random-wavefunction 4))
          (instr (make-instance 'quil::state-prep-application
                                :arguments qubits
                                :target-wf target-wf
-                               :source-wf source-wf)))
-    (let* ((output-matrix (quil::make-matrix-from-quil
-                           (quil::expand-to-native-instructions
-                            (quil::state-prep-4q-compiler instr)
-                            (quil::build-8Q-chip)))))
-      (check-state-prep source-wf target-wf output-matrix))))
+                               :source-wf source-wf))
+         (output-matrix (quil::make-matrix-from-quil
+                         (quil::expand-to-native-instructions
+                          (quil::state-prep-4q-compiler instr)
+                          (quil::build-8Q-chip)))))
+    (check-state-prep source-wf target-wf output-matrix)))
 
 (deftest test-schmidt-decomposition ()
+  "Check that a random wavefunction can be reconstructed from its SCHMIDT-DECOMPOSITION."
   (let* ((random-wf (quil::random-wavefunction 4)))
     (multiple-value-bind (c U V) (quil::schmidt-decomposition random-wf 2 2)
       (let* ((schmidt-terms (loop :for i :from 0 :below 4


### PR DESCRIPTION
This implements the 4q state prep method mentioned in https://github.com/rigetti/quilc/issues/76.
It also updates the test that https://github.com/rigetti/magicl/pull/58 breaks.