### PR TITLE
Disable ZAP-INFO on SBCL 1.5.6+

### DIFF
--- a/build-app.lisp
+++ b/build-app.lisp
@@ -42,9 +42,10 @@
     #-win32
     (asdf:load-system "cl-quil/tweedledum")
     ;; TODO Something is broken here. If zap-info is left to do it's thing on
-    ;; Windows, there is a weird error. This is a short-term fix.
+    ;; Windows or SBCL 1.5.6+, there is a weird error. This is a short-term fix.
     #-win32
-    (funcall (read-from-string "quilc::zap-info"))
+    (when (uiop:version< (lisp-implementation-version) "1.5.6")
+      (funcall (read-from-string "quilc::zap-info")))
     (funcall (read-from-string "quilc::setup-debugger"))
     (when (option-present-p "--quilc-sdk")
       (load "app/src/mangle-shared-objects.lisp"))

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -35,7 +35,9 @@
                :do (setf (gethash (pathname-name system-file) system-table)
                          (merge-pathnames system-file)))))
          (local-system-search (name)
-           (values (gethash name system-table))))
+           (values (gethash name system-table)))
+         (strip-version-githash (version)
+           (subseq version 0 (position #\- version :test #'eql))))
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
@@ -44,7 +46,7 @@
     ;; TODO Something is broken here. If zap-info is left to do it's thing on
     ;; Windows or SBCL 1.5.6+, there is a weird error. This is a short-term fix.
     #-win32
-    (when (uiop:version< (lisp-implementation-version) "1.5.6")
+    (when (uiop:version< (strip-version-githash (lisp-implementation-version)) "1.5.6")
       (funcall (read-from-string "quilc::zap-info")))
     (funcall (read-from-string "quilc::setup-debugger"))
     (when (option-present-p "--quilc-sdk")


### PR DESCRIPTION
Disable `zap-info` in build-app.lisp on SBCL 1.5.6+.

This is similar to work-around in https://github.com/rigetti/qvm/issues/172, but limited to SBCL versions >= 1.5.6.

Updates #401 

~~Build is now working, but test suite still fails with memory corruption error.~~

The non-zap-info-related memory corruption issues mentioned in #401 were resolved by the following SBCL commit:
https://sourceforge.net/p/sbcl/sbcl/ci/550c4d23c77cc670fb95d7216e3c6d493bbd76eb/

All tests (including qvm and pyquil tests) are now passing locally when built with SBCL master with the above fix.