### PR TITLE
Fix startup spam

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -292,8 +292,6 @@
   (disable-debugger))
 
 (defun entry-point (argv)
-  #-win32
-  (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum)
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -42,7 +42,9 @@
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
     #-win32
-    (asdf:load-system "cl-quil/tweedledum")
+    (progn 
+      (asdf:load-system "cl-quil/tweedledum")
+      (uiop:symbol-call "CL-QUIL.TWEEDLEDUM" "LOAD-TWEEDLEDUM"))
     ;; TODO Something is broken here. If zap-info is left to do it's thing on
     ;; Windows or SBCL 1.5.6+, there is a weird error. This is a short-term fix.
     #-win32


### PR DESCRIPTION
Moves the tweedledum load call into `build-app.lisp`.