### PR TITLE
Set *PRINT-PRETTY* to NIL in MAKE-REWIRING-COMMENT

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -237,13 +237,14 @@ If both ENTERING and EXITING are null, signal an error."
   (when (typep exiting 'rewiring)
     (setf exiting (rewiring-l2p exiting)))
 
-  (cond ((and (not (null entering)) (not (null exiting)))
-         (format nil "~A(~A . ~A)" +entering/exiting-rewiring-prefix+ entering exiting))
-        ((not (null entering))
-         (format nil "~A~A" +entering-rewiring-prefix+ entering))
-        ((not (null exiting))
-         (format nil "~A~A" +exiting-rewiring-prefix+ exiting))
-        (t (error "MAKE-REWIRING-COMMENT: Both ENTERING and EXITING cannot be NULL"))))
+  (let ((*print-pretty* nil))
+    (cond ((and (not (null entering)) (not (null exiting)))
+           (format nil "~A(~A . ~A)" +entering/exiting-rewiring-prefix+ entering exiting))
+          ((not (null entering))
+           (format nil "~A~A" +entering-rewiring-prefix+ entering))
+          ((not (null exiting))
+           (format nil "~A~A" +exiting-rewiring-prefix+ exiting))
+          (t (error "MAKE-REWIRING-COMMENT: Both ENTERING and EXITING cannot be NULL")))))
 
 (defun instruction-rewirings (instruction)
   "Return the pair of entering and exiting rewirings associated with instruction.

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -519,21 +519,20 @@ Return the following values:
       ;; If a jump was never used, we better add one to the end
       (unless jump-used
         (add-to-section end-jump)))
-    (let ((*print-pretty* nil))
-      (cond
-        ((and (basic-block-in-rewiring blk)
-              (basic-block-out-rewiring blk)
-              (= 1 (length code-section)))
+    (cond
+      ((and (basic-block-in-rewiring blk)
+            (basic-block-out-rewiring blk)
+            (= 1 (length code-section)))
+       (setf (comment (aref code-section 0))
+             (make-rewiring-comment :entering (basic-block-in-rewiring blk)
+                                    :exiting (basic-block-out-rewiring blk))))
+      (t
+       (when (basic-block-in-rewiring blk)
          (setf (comment (aref code-section 0))
-               (make-rewiring-comment :entering (basic-block-in-rewiring blk)
-                                      :exiting (basic-block-out-rewiring blk))))
-        (t
-         (when (basic-block-in-rewiring blk)
-           (setf (comment (aref code-section 0))
-                 (make-rewiring-comment :entering (basic-block-in-rewiring blk))))
-         (when (basic-block-out-rewiring blk)
-           (setf (comment (aref code-section (1- (length code-section))))
-                 (make-rewiring-comment :exiting (basic-block-out-rewiring blk)))))))
+               (make-rewiring-comment :entering (basic-block-in-rewiring blk))))
+       (when (basic-block-out-rewiring blk)
+         (setf (comment (aref code-section (1- (length code-section))))
+               (make-rewiring-comment :exiting (basic-block-out-rewiring blk))))))
     code-section))
 
 (defun reconstitute-program (cfg)


### PR DESCRIPTION
Fixes a bug introduced in #375 which resulted in the final exit rewiring comment sometimes getting pretty-printed.

This bug is a gentle reminder that the changes suggested in #381 would not be in vain.

Fixes #414