### PR TITLE
Muffle start up warnings, and search more paths for libtweedledum.so

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -293,7 +293,8 @@
 
 (defun entry-point (argv)
   #-win32
-  (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum)
+  (handler-bind ((warning #'muffle-warning))
+    (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum))
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -292,6 +292,8 @@
   (disable-debugger))
 
 (defun entry-point (argv)
+  #-win32
+  (uiop:symbol-call ':cl-quil.tweedledum '#:load-tweedledum)
   (handler-case
       (%entry-point argv)
     (interactive-interrupt (c)

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -42,9 +42,7 @@
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "quilc")
     #-win32
-    (progn 
-      (asdf:load-system "cl-quil/tweedledum")
-      (uiop:symbol-call "CL-QUIL.TWEEDLEDUM" "LOAD-TWEEDLEDUM"))
+    (asdf:load-system "cl-quil/tweedledum")
     ;; TODO Something is broken here. If zap-info is left to do it's thing on
     ;; Windows or SBCL 1.5.6+, there is a weird error. This is a short-term fix.
     #-win32

--- a/src/contrib/tweedledum/tweedledum.lisp
+++ b/src/contrib/tweedledum/tweedledum.lisp
@@ -9,7 +9,7 @@
 (in-package #:cl-quil.tweedledum)
 
 (cffi:define-foreign-library
-    (libtweedledum :search-path "/usr/local/lib/rigetti/")
+    (libtweedledum :search-path (list #P"./" #P"/usr/local/lib/rigetti/" #P"/usr/local/lib/"))
   (:darwin (:or #.(merge-pathnames "libtweedledum.dylib"
                                    (or *compile-file-truename*
                                        *load-truename*))


### PR DESCRIPTION
I previously (#409) tried to clear up the quilc start-up warning spam that was introduced in #276, but that introduced a second issue (in the barebones distribution, the library would not be found).

So this PR covers two things:
* Muffle the warnings that happen at quilc startup. I'm still not sure what is causing these, but they're AFAICT harmless warnings that we can ignore.
* Add more paths to the list of paths that CFFI searches for libraries (this removes the requirement of modifying `LD_LIBRARY_PATH` to pick up the library in the current dir: e.g. `LD_LIBRARY_PATH=./ quilc`).