### PR TITLE
Update parsing of STORE instruction to conform to Quil spec

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1342,13 +1342,10 @@ result of BODY, and the (possibly null) list of remaining lines.
                             :left (parse-memory-region-name left)
                             :right (parse-classical-argument right)))
             ((:STORE)
-             (unless (= 1 (length right))
-               (quil-parse-error "Malformed STORE. Expected a memory reference ~
-                                  as the third argument."))
              (make-instance 'classical-store
                             :target (parse-memory-region-name target)
-                            :left (parse-classical-argument (list left))
-                            :right (parse-memory-or-formal-token (first right))))
+                            :left (parse-memory-or-formal-token left)
+                            :right (parse-classical-argument right)))
             ((:EQ :GT :GE :LT :LE)
              (make-instance
               (ecase tok-type

--- a/tests/bad-test-files/bad-load-store.quil
+++ b/tests/bad-test-files/bad-load-store.quil
@@ -1,0 +1,18 @@
+# test parsing invalid LOAD and STORE
+
+DECLARE ro BIT[4]
+DECLARE oct OCTET
+DECLARE x REAL[2]
+DECLARE int INTEGER[2]
+
+LOAD x x 1
+LOAD x x[1] oct
+LOAD ro ro x
+
+STORE ro int x
+STORE ro 0 ro
+STORE x int int
+STORE int int x
+STORE ro int 1.0
+STORE x int 1
+STORE int int 2.0

--- a/tests/good-test-files/good-classical-binaries.quil
+++ b/tests/good-test-files/good-classical-binaries.quil
@@ -14,6 +14,18 @@ LT ro[0] ro[1] ro[2]
 GE ro[0] ro[1] ro[2]
 GT ro[0] ro[1] ro[2]
 
+EQ ro[0] oct 1
+LE ro[0] oct 2
+LT ro[0] oct 3
+GE ro[0] oct 4
+GT ro[0] oct 5
+
+EQ ro[0] x 1.1
+LE ro[0] x 2.2
+LT ro[0] x 3.3
+GE ro[0] x 4.4
+GT ro[0] x 5.5
+
 ADD x[0] x[1]
 SUB x[0] x[1]
 MUL x[0] x[1]

--- a/tests/good-test-files/good-classical-load-store.quil
+++ b/tests/good-test-files/good-classical-load-store.quil
@@ -1,0 +1,17 @@
+# test parsing good LOAD and STORE
+
+DECLARE ro BIT[4]
+DECLARE oct OCTET
+DECLARE x REAL[2]
+DECLARE int INTEGER
+DECLARE ri INTEGER[2]
+
+LOAD x x int
+LOAD ro ro int
+
+STORE ro int ro
+STORE ro int ro[2]
+STORE x int x
+STORE ri int int
+STORE x int 1.1
+STORE ri int 2

--- a/tests/printer-test-files/gold-standard/classical.quil
+++ b/tests/printer-test-files/gold-standard/classical.quil
@@ -2,6 +2,7 @@
 DECLARE int INTEGER[4]
 DECLARE ro BIT[4]
 DECLARE b BIT
+DECLARE rr REAL
 
 NEG int[0]
 NOT ro[1]
@@ -10,11 +11,16 @@ EXCHANGE int[0] int[1]
 CONVERT ro[0] int[0]
 LOAD b b int[0]
 STORE b int[0] b
+STORE rr int rr
+STORE rr int 2.0
+STORE int int int
+STORE int int 11
 
 # Output
 DECLARE int INTEGER[4]
 DECLARE ro BIT[4]
 DECLARE b BIT
+DECLARE rr REAL
 
 NEG int[0]
 NOT ro[1]
@@ -23,4 +29,8 @@ EXCHANGE int[0] int[1]
 CONVERT ro[0] int[0]
 LOAD b[0] b int[0]
 STORE b int[0] b[0]
+STORE rr int[0] rr[0]
+STORE rr int[0] 2.0
+STORE int int[0] int[0]
+STORE int int[0] 11
 

--- a/tests/printer-test-files/gold-standard/plundered-gold.quil
+++ b/tests/printer-test-files/gold-standard/plundered-gold.quil
@@ -30,6 +30,18 @@ LT ro[0] ro[1] ro[2]
 GE ro[0] ro[1] ro[2]
 GT ro[0] ro[1] ro[2]
 
+EQ ro[0] oct 1
+LE ro[0] oct 2
+LT ro[0] oct 3
+GE ro[0] oct 4
+GT ro[0] oct 5
+
+EQ ro[0] x 1.1
+LE ro[0] x 2.2
+LT ro[0] x 3.3
+GE ro[0] x 4.4
+GT ro[0] x 5.5
+
 ADD x[0] x[1]
 SUB x[0] x[1]
 MUL x[0] x[1]
@@ -49,6 +61,16 @@ LE ro[0] ro[1] ro[2]
 LT ro[0] ro[1] ro[2]
 GE ro[0] ro[1] ro[2]
 GT ro[0] ro[1] ro[2]
+EQ ro[0] oct[0] 1
+LE ro[0] oct[0] 2
+LT ro[0] oct[0] 3
+GE ro[0] oct[0] 4
+GT ro[0] oct[0] 5
+EQ ro[0] x[0] 1.1
+LE ro[0] x[0] 2.2
+LT ro[0] x[0] 3.3
+GE ro[0] x[0] 4.4
+GT ro[0] x[0] 5.5
 ADD x[0] x[1]
 SUB x[0] x[1]
 MUL x[0] x[1]
@@ -85,6 +107,42 @@ AND ro[0] ro[1]
 IOR ro[0] ro[1]
 MOVE ro[0] ro[1]
 EXCHANGE ro[0] ro[1]
+
+# Input
+# Plundered from ../../good-test-files/good-classical-load-store.quil
+# test parsing good LOAD and STORE
+
+DECLARE ro BIT[4]
+DECLARE oct OCTET
+DECLARE x REAL[2]
+DECLARE int INTEGER
+DECLARE ri INTEGER[2]
+
+LOAD x x int
+LOAD ro ro int
+
+STORE ro int ro
+STORE ro int ro[2]
+STORE x int x
+STORE ri int int
+STORE x int 1.1
+STORE ri int 2
+
+# Output
+DECLARE ro BIT[4]
+DECLARE oct OCTET
+DECLARE x REAL[2]
+DECLARE int INTEGER
+DECLARE ri INTEGER[2]
+
+LOAD x[0] x int[0]
+LOAD ro[0] ro int[0]
+STORE ro int[0] ro[0]
+STORE ro int[0] ro[2]
+STORE x int[0] x[0]
+STORE ri int[0] int[0]
+STORE x int[0] 1.1
+STORE ri int[0] 2
 
 # Input
 # Plundered from ../../good-test-files/good-classical-unaries.quil


### PR DESCRIPTION
According to the Quil spec, `STORE`'s second argument must be a reference to an int, and its third argument can be either a memory reference or an immediate value.

Fixes #425