### PR TITLE
Exact 2Q state preparation

### DIFF
--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -127,7 +127,7 @@
 ;; there are several such matrices; this one is just easy to write down.
 (a:define-constant
     +e-basis+
-    (let* ((sqrt2 (/ (sqrt 2) 2))
+    (let* ((sqrt2 (/ (sqrt 2d0) 2))
            (-sqrt2 (- sqrt2))
            (isqrt2 (complex 0 sqrt2))
            (-isqrt2 (complex 0 -sqrt2)))
@@ -141,7 +141,7 @@
 
 (a:define-constant
     +edag-basis+
-    (let* ((sqrt2 (/ (sqrt 2) 2))
+    (let* ((sqrt2 (/ (sqrt 2d0) 2))
            (-sqrt2 (- sqrt2))
            (isqrt2 (complex 0 sqrt2))
            (-isqrt2 (complex 0 -sqrt2)))


### PR DESCRIPTION
A long while back, Oscar Perdomo provided us with some formulas to perform exact state-to-state transformations between two-qubit systems. This PR implements his techniques.

TODO:
* [x] The case where the source is unentangled and the target is entangled is handled by reversing the state prep instruction, compiling that, and then reversing the output. _Very_ confusingly, this seems to result in a loss of precision. Addressing this is probably a requirement before merging.
* [x] Write to Oscar to announce the inclusion of these methods.
* [x] Change `#+#:ignore` to whatever the informative attic feature is.