### PR TITLE
Feature: DEFGATE AS PAULI-SUM (a/k/a DEFEXPI)

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -78,7 +78,7 @@
                              (:file "approx")
                              (:file "state-prep")
                              (:file "translators")
-                             (:file "pauli-pair")
+                             (:file "linear-paulis")
                              ;; attic'd files / pedagogical purposes only
                              (:file "optimal-2q")
                              (:static-file "cs-compile")))

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -78,6 +78,7 @@
                              (:file "approx")
                              (:file "state-prep")
                              (:file "translators")
+                             (:file "pauli-pair")
                              ;; attic'd files / pedagogical purposes only
                              (:file "optimal-2q")
                              (:static-file "cs-compile")))

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -78,8 +78,8 @@
                              (:file "approx")
                              (:file "state-prep")
                              (:file "translators")
+                             ;; attic'd files / pedagogical purposes only
                              (:file "optimal-2q")
-                             ;; attic'd file / pedagogical purposes only
                              (:static-file "cs-compile")))
                (:module "analysis"
                 :serial t

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -389,13 +389,14 @@ If no exit rewiring is found, return NIL."
 (defclass pauli-sum-gate-definition (gate-definition)
   ((terms :initarg :terms
           :reader pauli-sum-gate-definition-terms
-          :documentation "")            ; XXX
+          :documentation "List of PAULI-TERMs comprising the sum.")
    (parameters :initarg :parameters
                :reader pauli-sum-gate-definition-parameters
-               :documentation "")       ; XXX
+               :documentation "Ordered list of parameter names to be supplied to the definition, which can appear in arithmetical expressions weighting the definition's Pauli terms.")
    (arguments :initarg :arguments
               :reader pauli-sum-gate-definition-arguments
-              :documentation "")))      ; XXX
+              :documentation "Ordered list of formal arguments appearing in the definition's Pauli terms."))
+  (:documentation "Represents a gate definition as the exponential of a weighted sum of Pauli matrices."))
 
 (defmethod gate-definition-qubits-needed ((gate pauli-sum-gate-definition))
   (length (pauli-sum-gate-definition-arguments gate)))

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -386,6 +386,20 @@ If no exit rewiring is found, return NIL."
                 :reader permutation-gate-definition-permutation))
   (:documentation "A gate definition whose entries can be represented by a permutation of natural numbers."))
 
+(defclass pauli-sum-gate-definition (gate-definition)
+  ((terms :initarg :terms
+          :reader pauli-sum-gate-definition-terms
+          :documentation "")            ; XXX
+   (parameters :initarg :parameters
+               :reader pauli-sum-gate-definition-parameters
+               :documentation "")       ; XXX
+   (arguments :initarg :arguments
+              :reader pauli-sum-gate-definition-arguments
+              :documentation "")))      ; XXX
+
+(defmethod gate-definition-qubits-needed ((gate pauli-sum-gate-definition))
+  (length (pauli-sum-gate-definition-arguments gate)))
+
 (defmethod gate-definition-qubits-needed ((gate permutation-gate-definition))
   (ilog2 (length (permutation-gate-definition-permutation gate))))
 
@@ -1527,7 +1541,22 @@ For example,
     (format stream ":~%")
     (print-instruction-sequence (circuit-definition-body defn)
                                 :stream stream
-                                :prefix "    ")))
+                                :prefix "    "))
+
+  (:method ((gate pauli-sum-gate-definition) (stream stream))
+    (format stream "DEFGATE ~A~@[(~{%~A~^, ~})~]~{ ~A~} AS PAULI-SUM:~%"
+            (gate-definition-name gate)
+            (mapcar #'param-name (pauli-sum-gate-definition-parameters gate))
+            (mapcar #'formal-name (pauli-sum-gate-definition-arguments gate)))
+    (dolist (pauli-term (pauli-sum-gate-definition-terms gate))
+      (with-slots (pauli-word prefactor arguments) pauli-term
+        (format stream "    ~a(" pauli-word)
+        (print-instruction prefactor stream)
+        (format stream ")")
+        (dolist (arg arguments)
+          (format stream " ")
+          (print-instruction arg stream))
+        (terpri stream)))))
 
 (defmethod print-object ((object instruction) stream)
   (print-unreadable-object (object stream :type nil :identity nil)

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1546,12 +1546,16 @@ For example,
   (:method ((gate pauli-sum-gate-definition) (stream stream))
     (format stream "DEFGATE ~A~@[(~{%~A~^, ~})~]~{ ~A~} AS PAULI-SUM:~%"
             (gate-definition-name gate)
-            (mapcar #'param-name (pauli-sum-gate-definition-parameters gate))
+            (mapcar #'string (pauli-sum-gate-definition-parameters gate))
             (mapcar #'formal-name (pauli-sum-gate-definition-arguments gate)))
     (dolist (pauli-term (pauli-sum-gate-definition-terms gate))
       (with-slots (pauli-word prefactor arguments) pauli-term
         (format stream "    ~a(" pauli-word)
-        (print-instruction prefactor stream)
+        (typecase prefactor
+          (number
+           (format stream "~a" prefactor))
+          (cons
+           (print-instruction (make-delayed-expression nil nil prefactor) stream)))
         (format stream ")")
         (dolist (arg arguments)
           (format stream " ")

--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -54,15 +54,23 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
 
 (define-global-counter **anonymous-gate-counter** get-anonymous-gate-counter)
 
-(defun anon-gate (operator gate qubit &rest qubits)
+(defun anon-gate (operator-or-gate gate-or-parameters qubit &rest qubits)
   "Variant of BUILD-GATE for constructing anonymous gate applications."
-  (check-type operator string)
   (push qubit qubits)
-  (let* ((name (format nil "~A-~A" operator (get-anonymous-gate-counter)))
+  (let* ((name
+           (etypecase operator-or-gate
+             (string
+              (format nil "~A-~A" operator-or-gate (get-anonymous-gate-counter)))
+             (gate
+              (format nil "~A-~A" (gate-name operator-or-gate) (get-anonymous-gate-counter)))))
          (gate
-           (etypecase gate
-             (gate gate)
-             (magicl:matrix (make-instance 'simple-gate :matrix gate :name name)))))
+           (cond
+             ((typep operator-or-gate 'gate)
+              operator-or-gate)
+             ((typep gate-or-parameters 'magicl:matrix)
+              (make-instance 'simple-gate :matrix gate-or-parameters :name name))
+             (t
+              (error "Cannot find gate definition.")))))
     (make-instance 'gate-application
                    :operator (named-operator name)
                    :gate gate

--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -54,15 +54,18 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
 
 (define-global-counter **anonymous-gate-counter** get-anonymous-gate-counter)
 
-(defun anon-gate (operator matrix qubit &rest qubits)
+(defun anon-gate (operator gate qubit &rest qubits)
   "Variant of BUILD-GATE for constructing anonymous gate applications."
   (check-type operator string)
-  (check-type matrix magicl:matrix)
   (push qubit qubits)
-  (let ((name (format nil "~A-~A" operator (get-anonymous-gate-counter))))
+  (let* ((name (format nil "~A-~A" operator (get-anonymous-gate-counter)))
+         (gate
+           (etypecase gate
+             (gate gate)
+             (magicl:matrix (make-instance 'simple-gate :matrix gate :name name)))))
     (make-instance 'gate-application
                    :operator (named-operator name)
-                   :gate (make-instance 'simple-gate :matrix matrix :name name)
+                   :gate gate
                    :arguments (mapcar #'%capture-arg qubits))))
 
 (defun repeatedly-fork (op n)
@@ -73,6 +76,8 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
 (defun build-UCR (roll-name params qubit &rest qubits)
   (apply #'build-gate (repeatedly-fork (named-operator roll-name) (length qubits))
          params qubit qubits))
+
+(defun pauli-gate (operator &rest pauli-))
 
 ;;; functions for dealing with mixed constant vs delayed-expression types
 

--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -70,11 +70,16 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
              ((typep gate-or-parameters 'magicl:matrix)
               (make-instance 'simple-gate :matrix gate-or-parameters :name name))
              (t
-              (error "Cannot find gate definition.")))))
+              (error "Cannot find gate definition."))))
+         (parameters
+           (typecase gate-or-parameters
+             (cons gate-or-parameters)
+             (otherwise nil))))
     (make-instance 'gate-application
                    :operator (named-operator name)
                    :gate gate
-                   :arguments (mapcar #'%capture-arg qubits))))
+                   :arguments (mapcar #'%capture-arg qubits)
+                   :parameters parameters)))
 
 (defun repeatedly-fork (op n)
   (loop :repeat n

--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -403,6 +403,8 @@ used to specify CHIP-SPEC."
         (constantly 'state-prep-4q-compiler)
         (constantly 'state-prep-trampolining-compiler)
         (constantly 'recognize-ucr)
+        (constantly 'parametric-pauli-compiler)
+        (constantly 'parametric-diagonal-compiler)
         (lambda (chip-spec arch)
           (declare (ignore chip-spec))
           (a:curry 'approximate-2q-compiler

--- a/src/compilers/linear-paulis.lisp
+++ b/src/compilers/linear-paulis.lisp
@@ -203,7 +203,8 @@
                    (otherwise
                     (give-up-compilation)))))
         (dolist (term terms)
-          (crawl-parameter (pauli-term-prefactor term))))
+          (unless (= 1 (crawl-parameter (pauli-term-prefactor term)))
+            (give-up-compilation))))
       
       ;; instantiate the Hamiltonian
       (let ((H (magicl:make-zero-matrix dimension dimension)))

--- a/src/compilers/linear-paulis.lisp
+++ b/src/compilers/linear-paulis.lisp
@@ -1,4 +1,4 @@
-;;;; pauli-pair.lisp
+;;;; linear-paulis.lisp
 ;;;;
 ;;;; Author: Eric Peterson
 ;;;;

--- a/src/compilers/pauli-pair.lisp
+++ b/src/compilers/pauli-pair.lisp
@@ -13,11 +13,18 @@
   (cond
     ((listp big-tree)
      (mapcar (a:rcurry #'tree-substitute substitution-table) big-tree))
+    ((delayed-expression-p big-tree)
+     (make-delayed-expression
+      (delayed-expression-params big-tree)
+      (delayed-expression-lambda-params big-tree)
+      (tree-substitute (delayed-expression-expression big-tree) substitution-table)))
     ((assoc big-tree substitution-table)
      (cdr (assoc big-tree substitution-table)))
     (t
      big-tree)))
 
+;; WARNING: i don't know where this method has been considered before, and i
+;;          myself haven't worked out a proof that it's correct. caveat compiler
 (define-compiler parametric-diagonal-compiler
     ((instr _
             :where (and (typep (gate-application-gate instr) 'pauli-sum-gate)
@@ -46,7 +53,13 @@
              (inst "RZ"
                    (list (param-* 2.0d0
                                   (tree-substitute (pauli-term-prefactor term)
-                                                   (mapcar #'cons parameters (application-parameters instr)))))
+                                                   (mapcar (lambda (ep ap)
+                                                             (typecase ap
+                                                               (delayed-expression
+                                                                (cons ep (delayed-expression-expression ap)))
+                                                               (otherwise
+                                                                (cons ep ap))))
+                                                           parameters (application-parameters instr)))))
                    (nth (position (nth Z-position (pauli-term-arguments term))
                                   arguments :test #'equalp)
                         (application-arguments instr))))
@@ -101,73 +114,38 @@
                      (application-parameters instr)
                      (application-arguments instr))))
           ;; emit the Zs
-          (let* ((localized-terms
-                   (loop :for (term Z-pos) :in Zs
-                         :collect (make-pauli-term
-                                   :prefactor (pauli-term-prefactor term)
-                                   :arguments (pauli-term-arguments term)
-                                   :pauli-word (coerce (loop :for letter :across (pauli-term-pauli-word term)
-                                                             :for j :from 0
-                                                             :if (eql j Z-pos)
-                                                               :collect #\I
-                                                             :else
-                                                               :collect letter)
-                                                       'string))))
-                 (Z-gate (make-instance 'pauli-sum-gate
-                                        :arguments arguments
-                                        :parameters parameters
-                                        :arity arity
-                                        :dimension dimension
-                                        :terms localized-terms
-                                        :name "Zs-GATE"))
-                 (control-qubit (nth vote (application-arguments instr)))
-                 ;; TODO: there's room here to make an intelligent choice of
-                 ;; target qubit. they all act the same, so it'd be best to pick
-                 ;; that one that's topologically nearest the control.
-                 (target-qubit (if (zerop vote)
-                                   (second (application-arguments instr))
-                                   (first (application-arguments instr)))))
-            (print (pauli-sum-gate-terms Z-gate))
-            (inst "CNOT" () control-qubit target-qubit)
-            (inst* Z-gate
-                   (application-parameters instr)
-                   (application-arguments instr))
-            (inst "CNOT" () control-qubit target-qubit)))))))
-
-;; i think that a generic diagonal gate
-;;     DIAG(alpha0, ..., alpha(2^n-1)) qn ... q0
-;; can be written as
-;;     FORKED ... FORKED RZ(a0, ..., a(2^(n-1)-1)) qn ... q0
-;;     FORKED ... FORKED RZ(b0, ..., b(2^(n-2)-1)) qn ... q1
-;;     ...
-;;     FORKED RZ(y0, y1) qn q(n-1)
-;;     RZ(z0) qn.
-;;
-;; the original gate has 2^n - 1 free parameters, neglecting global phase.
-;; this sum has 2^(n-1) + 2^(n-2) + ... + 2 + 1 free parameters, which agrees, so that's good.
-;;
-;; i think i can give a state-prep-style calculation of the roman parameters from the greek parameters.
-;; a better question is: is there a decomposition where the Pauli parameters directly show up?
-;;
-;; let's try a couple of smaller examples.
-;; n = 0:  a I + b Z = (a + b, a - b)
-;; in this case, b turns into the 'difference' angle RZ(z0), and a is a global shift.
-;; n = 1:  a ZI + b IZ + c ZZ = (a + b + c, -a + b - c, a - b - c, -a - b + c)
-;;         the goal is to make this look like (e, e, -e, -e).
-;;         take e = b; then (a + c, -a - c, a - c, -a + c) + (b, b, -b, -b)
-;;                     then (a + c, -a - c, a - c, -a + c) = (a, -a, a, -a) + (c, -c, -c, c)
-;;                     then (c, -c, -c, c) = CNOT 1 0 ZI(c) CNOT 1 0  (i.e., the target matches the Z)
-;;                          (a, -a, a, -a) = ZI(a), and (b, b, -b, -b) = IZ(b).
-;; n = 2: a ZII + b IZI + c IIZ + d ZZI + e ZIZ + f IZZ + g ZZZ =
-;;        ZII(a) + IZI(b) + IIZ(c) + (d ZZI + e ZIZ + f IZZ + g ZZZ)
-;;        then (d ZZI + e ZIZ + f IZZ + g ZZZ) =
-;;             (d + e + f + g, -d - e + f - g, -d + e - f - g, d - e - f + g,
-;;              d - e - f - g, -d + e - f + g, -d - e + f + g, d + e + f - g)
-;;        ZZI = (1, -1, -1,  1,  1, -1, -1,  1)
-;;        ZIZ = (1, -1,  1, -1, -1,  1, -1,  1)
-;;        IZZ = (1,  1, -1, -1, -1, -1,  1,  1)
-;;        ZZZ = (1, -1, -1,  1, -1,  1,  1, -1) <-- CNOT 2 0 ; CNOT 1 0 ; RZ(g) 0 ; CNOT 1 0 ; CNOT 2 0
-
+          (unless (endp Zs)
+            (let* ((localized-terms
+                     (loop :for (term Z-pos) :in Zs
+                           :collect (make-pauli-term
+                                     :prefactor (pauli-term-prefactor term)
+                                     :arguments (pauli-term-arguments term)
+                                     :pauli-word (coerce (loop :for letter :across (pauli-term-pauli-word term)
+                                                               :for j :from 0
+                                                               :if (eql j Z-pos)
+                                                                 :collect #\I
+                                                               :else
+                                                                 :collect letter)
+                                                         'string))))
+                   (Z-gate (make-instance 'pauli-sum-gate
+                                          :arguments arguments
+                                          :parameters parameters
+                                          :arity arity
+                                          :dimension dimension
+                                          :terms localized-terms
+                                          :name "Zs-GATE"))
+                   (control-qubit (nth vote (application-arguments instr)))
+                   ;; TODO: there's room here to make an intelligent choice of
+                   ;; target qubit. they all act the same, so it'd be best to pick
+                   ;; that one that's topologically nearest the control.
+                   (target-qubit (if (zerop vote)
+                                     (second (application-arguments instr))
+                                     (first (application-arguments instr)))))
+              (inst "CNOT" () control-qubit target-qubit)
+              (inst* Z-gate
+                     (application-parameters instr)
+                     (application-arguments instr))
+              (inst "CNOT" () control-qubit target-qubit))))))))
 
 
 ;; TODO: also write an orthogonal gate compiler somewhere? approx.lisp will take
@@ -186,88 +164,43 @@
       ;; instantiate the Hamiltonian
       (let ((H (magicl:make-zero-matrix dimension dimension)))
         (dolist (term terms)
-          (setf m (m+ m (pauli-term->matrix term arguments (list 1d0) parameters))))
+          (setf H (m+ H (pauli-term->matrix term arguments (list 1d0) parameters))))
         ;; orthogonally diagonalize it: H = O D O^T
         (multiple-value-bind (diagonal O) (magicl:eig H)
-          ;; TODO: build a diagonal Pauli sum
-          (let ((diagonal-gate (make-instance 'pauli-sum-gate
-                                              :arguments arguments
-                                              :parameters parameters
-                                              :dimension size
-                                              :terms ...
-                                              :arity 1
-                                              :name (string (gensym "DIAG-PAULI-")))))
-            (inst* "RIGHT-O-T" (magicl:conjugate-transpose O) (application-arguments instr))
-            (inst (make-instance 'gate-application
-                                 :gate diagonal-gate
-                                 :arguments (application-arguments instr)
-                                 :parameters (application-parameters instr)
-                                 :operator (named-operator (string (gensym "DIAG-INSTR-")))))
-            (inst* "LEFT-O" O (application-arguments instr))))))))
-
-
-
-;; TODO: consider whether you should be extracting the Hamiltonian from sampling
-;;       the unitary family or if you should be applying EIG to the pauli sum directly.
-#+ignore
-(define-compiler pauli-pair-compiler
-    ((instr (_ (time) q1 q0)            ; name params q1 q0
-            :where (and (not (typep time 'number))
-                        (typep (gate-application-gate instr) 'pauli-sum-gate))))
-  "Rewrites a parametric 2Q gate application described by a time-independent Hamiltonian into canonical form."
-  (let ((gate (gate-application-gate instr)))
-    ;; XXX: check that the hamiltonian H(t) is time-independent (i.e., time-linear)
-    ;; instantiate the hamiltonian H0 = H(1) at a particular time
-    (let* ((H0 (gate-matrix gate 1.0d0)))
-      ;; diagonalize it: H0 = U D U*
-      (multiple-value-bind (dd u) (magicl:eig H0)
-        ;; canonicalize d and u so that the phases of d are sorted ascending.
-        ;; XXX: also deal with equivalence in d up to multiplication by i
-        (let* ((pairs (loop :for d :in dd
-                            :for j :below 4
-                            :for row := (loop :for i :below 4 :collect (magicl:ref u j i))
-                            :collect (list d row)))
-               (sorted-pairs (sort pairs #'< :key (a:compose #'phase #'car)))
-               (dd (mapcar #'car sorted-pairs))
-               (u (make-row-major-matrix 4 4 (loop :for (phase row) :in sorted-pairs
-                                                   :nconc row))))
-          ;; XXX: if U escaped SU(4), add a phase shift to put it back in.
-          (format t "~&diagonal phases: ~a~%" (mapcar #'phase dd))
-          (let* (;; infer a presentation of D as a hamiltonian: D = EXPI(a ZI + b IZ + c ZZ)
-                 (kernel (print (m* (magicl:inv (make-row-major-matrix 3 3 (list -1  1 -1
-                                                                                 -1 -1  1 
-                                                                                 1  1  1)))
-                                    (make-row-major-matrix 3 1 (mapcar #'phase (rest dd))))))
-                 (ZI (magicl:ref kernel 0 0))
-                 (IZ (magicl:ref kernel 1 0))
-                 (ZZ (magicl:ref kernel 2 0))
-                 ;; use +e-basis+ to turn the middle into a canonical gate:
-                 ;;     H0 = UDU* = UE* EDE* EU* and EDE* = EXPI(a XX + b YY + c ZZ)
-                 (formal-qubit-args (list (formal "q1") (formal "q0")))
-                 (formal-parameter-name (make-symbol "time"))
-                 (canonical-hamiltonian
-                   (make-instance 'pauli-sum-gate
-                                  :arguments formal-qubit-args
-                                  :parameters (list formal-parameter-name)
-                                  :terms (list (make-pauli-term :pauli-word "XX"
-                                                                :prefactor `(* ,ZI ,formal-parameter-name)
-                                                                :arguments formal-qubit-args)
-                                               (make-pauli-term :pauli-word "YY"
-                                                                :prefactor `(* ,IZ ,formal-parameter-name)
-                                                                :arguments formal-qubit-args)
-                                               (make-pauli-term :pauli-word "ZZ"
-                                                                :prefactor `(* ,ZZ ,formal-parameter-name)
-                                                                :arguments formal-qubit-args))
-                                  :dimension 4
-                                  :arity 1
-                                  :name "CANONICALIZED-HAM"))
-                 ;; return: anonymous gate (UE*) canonical hamiltonian (EDE*) anonymous gate (EU*)
-                 (left-matrix  (m* u +edag-basis+))
-                 (right-matrix (m* +e-basis+ (magicl:conjugate-transpose u))))
-            (inst "CONJ-RIGHT"   right-matrix q1 q0)
-            (inst (make-instance 'gate-application
-                                 :operator (named-operator "CANONICAL-AS-PAULI")
-                                 :arguments (list (qubit q1) (qubit q0))
-                                 :parameters (list time)
-                                 :gate canonical-hamiltonian))
-            (inst "CONJ-LEFT"    left-matrix q1 q0)))))))
+          ;; convert diagonal into a sum of Z paulis
+          (let ((pauli-prefactors (make-array dimension :initial-element 0d0))
+                terms diagonal-gate)
+            (loop :for d :in diagonal
+                  :for i :from 0
+                  :do (dotimes (j dimension)
+                        (incf (aref pauli-prefactors j)
+                              (if (evenp (logcount (logand i j)))
+                                  (/    d  dimension)
+                                  (/ (- d) dimension)))))
+            (setf terms (loop :for prefactor :across pauli-prefactors
+                              :for j :from 0
+                              :unless (double= 0d0 prefactor)
+                                :collect (let ((term-arguments
+                                                 (loop :for i :below (length arguments)
+                                                       :for arg :in arguments
+                                                       :when (logbitp (- (length arguments) i 1) j)
+                                                         :collect arg)))
+                                           (make-pauli-term
+                                            :prefactor (param-* (realpart prefactor)
+                                                                (make-delayed-expression
+                                                                 nil nil (first parameters)))
+                                            :arguments term-arguments
+                                            :pauli-word (coerce (make-array (length term-arguments)
+                                                                            :initial-element #\Z)
+                                                                'string))))
+                  diagonal-gate (make-instance 'pauli-sum-gate
+                                               :arguments arguments
+                                               :parameters parameters
+                                               :terms terms
+                                               :arity 1
+                                               :dimension dimension
+                                               :name (string (gensym "DIAG-PAULI-"))))
+            ;; emit the instructions
+            (inst* "RIGHT-O-T"   (magicl:conjugate-transpose O) (application-arguments instr))
+            (inst* diagonal-gate (application-parameters instr) (application-arguments instr))
+            (inst* "LEFT-O"      O                              (application-arguments instr))))))))

--- a/src/compilers/pauli-pair.lisp
+++ b/src/compilers/pauli-pair.lisp
@@ -2,26 +2,216 @@
 ;;;;
 ;;;; Author: Eric Peterson
 ;;;;
-;;;; This file contains routines for the parametric compilation of two-qubit
-;;;; gates determined by time-independent Hamiltonians via expression as a
+;;;; This file contains routines for the parametric compilation of gates defined
+;;;; by time-independent Hamiltonians via expression as a
 ;;;; PAULI-SUM-GATE.
 
 (in-package #:cl-quil)
 
-#+ignore
-(define-compiler canonical-hamiltonian-compiler
-    ((instr (_ _ q1 q0)
-            :where (and (typep (gate-application-gate instr) 'pauli-sum-gate)
-                        (loop :for term :in (pauli-sum-gate-terms (gate-application-gate instr))
-                              :always (or (string= "XX" (pauli-term-pauli-word term))
-                                          (string= "YY" (pauli-term-pauli-word term))
-                                          (string= "ZZ" (pauli-term-pauli-word term)))))))
-  "Parametric compiler to CZs for time-independent canonical Hamiltonians."
-  
-    )
+;; WARNING: this consumes stack space like (* tree-depth fan-out)
+(defun tree-substitute (big-tree substitution-table)
+  (cond
+    ((listp big-tree)
+     (mapcar (a:rcurry #'tree-substitute substitution-table) big-tree))
+    ((assoc big-tree substitution-table)
+     (cdr (assoc big-tree substitution-table)))
+    (t
+     big-tree)))
 
+(define-compiler parametric-diagonal-compiler
+    ((instr _
+            :where (and (typep (gate-application-gate instr) 'pauli-sum-gate)
+                        (every (lambda (term) (every (lambda (letter) (or (eql letter #\Z) (eql letter #\I)))
+                                                     (pauli-term-pauli-word term)))
+                               (pauli-sum-gate-terms (gate-application-gate instr))))))
+  "Decomposes a diagonal Pauli gate by a single step."
+  (declare (optimize (debug 3) (speed 0)))
+  (with-slots (arguments parameters terms arity dimension) (gate-application-gate instr)
+    (let ((nonlocal-terms nil))
+      ;; first, deal with the words with a zero Zs / one Z: they're local gates
+      (dolist (term terms)
+        (multiple-value-bind (Z-count Z-position)
+            (loop :for letter :across (pauli-term-pauli-word term)
+                  :for j :from 0
+                  :with pos := 0
+                  :with count := 0
+                  :when (eql #\Z letter)
+                    :do (setf count (1+ count)
+                              pos j)
+                  :finally (return (values count pos)))
+          (case Z-count
+            (0
+             nil)
+            (1
+             (inst "RZ"
+                   (list (param-* 2.0d0
+                                  (tree-substitute (pauli-term-prefactor term)
+                                                   (mapcar #'cons parameters (application-parameters instr)))))
+                   (nth (position (nth Z-position (pauli-term-arguments term))
+                                  arguments :test #'equalp)
+                        (application-arguments instr))))
+            (otherwise
+             (push term nonlocal-terms)))))
+      (let ((votes (make-array (length arguments) :initial-element 0))
+            vote)
+        ;; we can break nonlocal terms into two collections: those with Zs in
+        ;; some spot and those without Zs in that spot. the result will be to
+        ;; conjugate the first collection by CNOT, which flips those Zs to Is.
+        ;; since we can only emit local gates, almost all such Zs will have to
+        ;; be eliminated, and so we'll want to pick the position so that this
+        ;; group is as large as possible.
+        (dolist (term nonlocal-terms)
+          (loop :for letter :across (pauli-term-pauli-word term)
+                :for argument :in (pauli-term-arguments term)
+                :when (eql #\Z letter)
+                  :do (incf (aref votes (position argument arguments :test #'equalp)))))
+        (loop :with pos := 0
+              :with current-max := (aref votes 0)
+              :for j :from 0
+              :for item :across votes
+              :when (< current-max item)
+                :do (setf current-max item
+                          pos j)
+              :finally (setf vote current-max))
+        ;; now we re-sort the nonlocal terms into two buckets: those with a Z in
+        ;; the voted-upon location, and those without
+        (let ((Is nil) (Zs nil))
+          (dolist (term nonlocal-terms)
+            (let ((Z-pos (loop :for letter :across (pauli-term-pauli-word term)
+                               :for arg :in (pauli-term-arguments term)
+                               :for j :from 0
+                               :when (and (eql #\Z letter)
+                                          (eql vote (position arg arguments :test #'equalp)))
+                                 :do (return j))))
+              (cond
+                (Z-pos
+                 (push (list term Z-pos) Zs))
+                (t
+                 (push term Is)))))
+          ;; emit the Is
+          (unless (endp Is)
+            (let ((I-gate (make-instance 'pauli-sum-gate
+                                         :arguments arguments
+                                         :parameters parameters
+                                         :arity arity
+                                         :dimension dimension
+                                         :name "Is"
+                                         :terms Is)))
+              (inst* I-gate
+                     (application-parameters instr)
+                     (application-arguments instr))))
+          ;; emit the Zs
+          (let* ((localized-terms
+                   (loop :for (term Z-pos) :in Zs
+                         :collect (make-pauli-term
+                                   :prefactor (pauli-term-prefactor term)
+                                   :arguments (pauli-term-arguments term)
+                                   :pauli-word (coerce (loop :for letter :across (pauli-term-pauli-word term)
+                                                             :for j :from 0
+                                                             :if (eql j Z-pos)
+                                                               :collect #\I
+                                                             :else
+                                                               :collect letter)
+                                                       'string))))
+                 (Z-gate (make-instance 'pauli-sum-gate
+                                        :arguments arguments
+                                        :parameters parameters
+                                        :arity arity
+                                        :dimension dimension
+                                        :terms localized-terms
+                                        :name "Zs-GATE"))
+                 (control-qubit (nth vote (application-arguments instr)))
+                 ;; TODO: there's room here to make an intelligent choice of
+                 ;; target qubit. they all act the same, so it'd be best to pick
+                 ;; that one that's topologically nearest the control.
+                 (target-qubit (if (zerop vote)
+                                   (second (application-arguments instr))
+                                   (first (application-arguments instr)))))
+            (print (pauli-sum-gate-terms Z-gate))
+            (inst "CNOT" () control-qubit target-qubit)
+            (inst* Z-gate
+                   (application-parameters instr)
+                   (application-arguments instr))
+            (inst "CNOT" () control-qubit target-qubit)))))))
+
+;; i think that a generic diagonal gate
+;;     DIAG(alpha0, ..., alpha(2^n-1)) qn ... q0
+;; can be written as
+;;     FORKED ... FORKED RZ(a0, ..., a(2^(n-1)-1)) qn ... q0
+;;     FORKED ... FORKED RZ(b0, ..., b(2^(n-2)-1)) qn ... q1
+;;     ...
+;;     FORKED RZ(y0, y1) qn q(n-1)
+;;     RZ(z0) qn.
+;;
+;; the original gate has 2^n - 1 free parameters, neglecting global phase.
+;; this sum has 2^(n-1) + 2^(n-2) + ... + 2 + 1 free parameters, which agrees, so that's good.
+;;
+;; i think i can give a state-prep-style calculation of the roman parameters from the greek parameters.
+;; a better question is: is there a decomposition where the Pauli parameters directly show up?
+;;
+;; let's try a couple of smaller examples.
+;; n = 0:  a I + b Z = (a + b, a - b)
+;; in this case, b turns into the 'difference' angle RZ(z0), and a is a global shift.
+;; n = 1:  a ZI + b IZ + c ZZ = (a + b + c, -a + b - c, a - b - c, -a - b + c)
+;;         the goal is to make this look like (e, e, -e, -e).
+;;         take e = b; then (a + c, -a - c, a - c, -a + c) + (b, b, -b, -b)
+;;                     then (a + c, -a - c, a - c, -a + c) = (a, -a, a, -a) + (c, -c, -c, c)
+;;                     then (c, -c, -c, c) = CNOT 1 0 ZI(c) CNOT 1 0  (i.e., the target matches the Z)
+;;                          (a, -a, a, -a) = ZI(a), and (b, b, -b, -b) = IZ(b).
+;; n = 2: a ZII + b IZI + c IIZ + d ZZI + e ZIZ + f IZZ + g ZZZ =
+;;        ZII(a) + IZI(b) + IIZ(c) + (d ZZI + e ZIZ + f IZZ + g ZZZ)
+;;        then (d ZZI + e ZIZ + f IZZ + g ZZZ) =
+;;             (d + e + f + g, -d - e + f - g, -d + e - f - g, d - e - f + g,
+;;              d - e - f - g, -d + e - f + g, -d - e + f + g, d + e + f - g)
+;;        ZZI = (1, -1, -1,  1,  1, -1, -1,  1)
+;;        ZIZ = (1, -1,  1, -1, -1,  1, -1,  1)
+;;        IZZ = (1,  1, -1, -1, -1, -1,  1,  1)
+;;        ZZZ = (1, -1, -1,  1, -1,  1,  1, -1) <-- CNOT 2 0 ; CNOT 1 0 ; RZ(g) 0 ; CNOT 1 0 ; CNOT 2 0
+
+
+
+;; TODO: also write an orthogonal gate compiler somewhere? approx.lisp will take
+;;       care of it in the 2Q case, at least.
+
+(define-compiler parametric-pauli-compiler
+    ((instr _ :where (and (typep (gate-application-gate instr) 'pauli-sum-gate)
+                          (= 1 (length (application-parameters instr)))
+                          (not (typep (first (application-parameters instr)) 'constant)))))
+  "Decomposes a gate described by the exponential of a time-independent Hamiltonian into static orthogonal and parametric diagonal components."
+  (let ((gate (gate-application-gate instr)))
+    (with-slots (arguments parameters terms dimension) gate
+      ;; XXX: check that every component in the gate has coefficient of the form
+      ;;      c*t for c a constant and t the application-parameter.
+      
+      ;; instantiate the Hamiltonian
+      (let ((H (magicl:make-zero-matrix dimension dimension)))
+        (dolist (term terms)
+          (setf m (m+ m (pauli-term->matrix term arguments (list 1d0) parameters))))
+        ;; orthogonally diagonalize it: H = O D O^T
+        (multiple-value-bind (diagonal O) (magicl:eig H)
+          ;; TODO: build a diagonal Pauli sum
+          (let ((diagonal-gate (make-instance 'pauli-sum-gate
+                                              :arguments arguments
+                                              :parameters parameters
+                                              :dimension size
+                                              :terms ...
+                                              :arity 1
+                                              :name (string (gensym "DIAG-PAULI-")))))
+            (inst* "RIGHT-O-T" (magicl:conjugate-transpose O) (application-arguments instr))
+            (inst (make-instance 'gate-application
+                                 :gate diagonal-gate
+                                 :arguments (application-arguments instr)
+                                 :parameters (application-parameters instr)
+                                 :operator (named-operator (string (gensym "DIAG-INSTR-")))))
+            (inst* "LEFT-O" O (application-arguments instr))))))))
+
+
+
+;; TODO: consider whether you should be extracting the Hamiltonian from sampling
+;;       the unitary family or if you should be applying EIG to the pauli sum directly.
+#+ignore
 (define-compiler pauli-pair-compiler
-    ((instr (_ (time) q1 q0)                 ; name params q1 q0
+    ((instr (_ (time) q1 q0)            ; name params q1 q0
             :where (and (not (typep time 'number))
                         (typep (gate-application-gate instr) 'pauli-sum-gate))))
   "Rewrites a parametric 2Q gate application described by a time-independent Hamiltonian into canonical form."
@@ -30,43 +220,54 @@
     ;; instantiate the hamiltonian H0 = H(1) at a particular time
     (let* ((H0 (gate-matrix gate 1.0d0)))
       ;; diagonalize it: H0 = U D U*
-      (multiple-value-bind (d u) (magicl:eig H0)
-        (format t "~&diagonal phases: ~a~%" (mapcar #'phase d))
-        (let* (;; infer a presentation of D as a hamiltonian: D = EXPI(a ZI + b IZ + c ZZ)
-               (kernel (print (m* (magicl:inv (make-row-major-matrix 3 3 (list -1  1 -1
-                                                                               -1 -1  1 
-                                                                                1  1  1)))
-                                  (make-row-major-matrix 3 1 (mapcar #'phase (rest d))))))
-               (ZI (magicl:ref kernel 0 0))
-               (IZ (magicl:ref kernel 1 0))
-               (ZZ (magicl:ref kernel 2 0))
-               ;; use +e-basis+ to turn the middle into a canonical gate:
-               ;;     H0 = UDU* = UE* EDE* EU* and EDE* = EXPI(a XX + b YY + c ZZ)
-               (formal-qubit-args (list (formal "q1") (formal "q0")))
-               (formal-parameter-name (make-symbol "time"))
-               (canonical-hamiltonian
-                 (make-instance 'pauli-sum-gate
-                                :arguments formal-qubit-args
-                                :parameters (list formal-parameter-name)
-                                :terms (list (make-pauli-term :pauli-word "XX"
-                                                              :prefactor `(* ,ZI ,formal-parameter-name)
-                                                              :arguments formal-qubit-args)
-                                             (make-pauli-term :pauli-word "YY"
-                                                              :prefactor `(* ,IZ ,formal-parameter-name)
-                                                              :arguments formal-qubit-args)
-                                             (make-pauli-term :pauli-word "ZZ"
-                                                              :prefactor `(* ,ZZ ,formal-parameter-name)
-                                                              :arguments formal-qubit-args))
-                                :dimension 4
-                                :arity 1
-                                :name "CANONICALIZED-HAM"))
-               ;; return: anonymous gate (UE*) canonical hamiltonian (EDE*) anonymous gate (EU*)
-               (left-matrix  (m* u +edag-basis+))
-               (right-matrix (m* +e-basis+ (magicl:conjugate-transpose u))))
-          (inst "CONJ-RIGHT"   right-matrix q1 q0)
-          (inst (make-instance 'gate-application
-                               :operator (named-operator "CANONICAL-AS-PAULI")
-                               :arguments (list (qubit q1) (qubit q0))
-                               :parameters (list time)
-                               :gate canonical-hamiltonian))
-          (inst "CONJ-LEFT"    left-matrix q1 q0))))))
+      (multiple-value-bind (dd u) (magicl:eig H0)
+        ;; canonicalize d and u so that the phases of d are sorted ascending.
+        ;; XXX: also deal with equivalence in d up to multiplication by i
+        (let* ((pairs (loop :for d :in dd
+                            :for j :below 4
+                            :for row := (loop :for i :below 4 :collect (magicl:ref u j i))
+                            :collect (list d row)))
+               (sorted-pairs (sort pairs #'< :key (a:compose #'phase #'car)))
+               (dd (mapcar #'car sorted-pairs))
+               (u (make-row-major-matrix 4 4 (loop :for (phase row) :in sorted-pairs
+                                                   :nconc row))))
+          ;; XXX: if U escaped SU(4), add a phase shift to put it back in.
+          (format t "~&diagonal phases: ~a~%" (mapcar #'phase dd))
+          (let* (;; infer a presentation of D as a hamiltonian: D = EXPI(a ZI + b IZ + c ZZ)
+                 (kernel (print (m* (magicl:inv (make-row-major-matrix 3 3 (list -1  1 -1
+                                                                                 -1 -1  1 
+                                                                                 1  1  1)))
+                                    (make-row-major-matrix 3 1 (mapcar #'phase (rest dd))))))
+                 (ZI (magicl:ref kernel 0 0))
+                 (IZ (magicl:ref kernel 1 0))
+                 (ZZ (magicl:ref kernel 2 0))
+                 ;; use +e-basis+ to turn the middle into a canonical gate:
+                 ;;     H0 = UDU* = UE* EDE* EU* and EDE* = EXPI(a XX + b YY + c ZZ)
+                 (formal-qubit-args (list (formal "q1") (formal "q0")))
+                 (formal-parameter-name (make-symbol "time"))
+                 (canonical-hamiltonian
+                   (make-instance 'pauli-sum-gate
+                                  :arguments formal-qubit-args
+                                  :parameters (list formal-parameter-name)
+                                  :terms (list (make-pauli-term :pauli-word "XX"
+                                                                :prefactor `(* ,ZI ,formal-parameter-name)
+                                                                :arguments formal-qubit-args)
+                                               (make-pauli-term :pauli-word "YY"
+                                                                :prefactor `(* ,IZ ,formal-parameter-name)
+                                                                :arguments formal-qubit-args)
+                                               (make-pauli-term :pauli-word "ZZ"
+                                                                :prefactor `(* ,ZZ ,formal-parameter-name)
+                                                                :arguments formal-qubit-args))
+                                  :dimension 4
+                                  :arity 1
+                                  :name "CANONICALIZED-HAM"))
+                 ;; return: anonymous gate (UE*) canonical hamiltonian (EDE*) anonymous gate (EU*)
+                 (left-matrix  (m* u +edag-basis+))
+                 (right-matrix (m* +e-basis+ (magicl:conjugate-transpose u))))
+            (inst "CONJ-RIGHT"   right-matrix q1 q0)
+            (inst (make-instance 'gate-application
+                                 :operator (named-operator "CANONICAL-AS-PAULI")
+                                 :arguments (list (qubit q1) (qubit q0))
+                                 :parameters (list time)
+                                 :gate canonical-hamiltonian))
+            (inst "CONJ-LEFT"    left-matrix q1 q0)))))))

--- a/src/compilers/pauli-pair.lisp
+++ b/src/compilers/pauli-pair.lisp
@@ -1,0 +1,72 @@
+;;;; pauli-pair.lisp
+;;;;
+;;;; Author: Eric Peterson
+;;;;
+;;;; This file contains routines for the parametric compilation of two-qubit
+;;;; gates determined by time-independent Hamiltonians via expression as a
+;;;; PAULI-SUM-GATE.
+
+(in-package #:cl-quil)
+
+#+ignore
+(define-compiler canonical-hamiltonian-compiler
+    ((instr (_ _ q1 q0)
+            :where (and (typep (gate-application-gate instr) 'pauli-sum-gate)
+                        (loop :for term :in (pauli-sum-gate-terms (gate-application-gate instr))
+                              :always (or (string= "XX" (pauli-term-pauli-word term))
+                                          (string= "YY" (pauli-term-pauli-word term))
+                                          (string= "ZZ" (pauli-term-pauli-word term)))))))
+  "Parametric compiler to CZs for time-independent canonical Hamiltonians."
+  
+    )
+
+(define-compiler pauli-pair-compiler
+    ((instr (_ (time) q1 q0)                 ; name params q1 q0
+            :where (and (not (typep time 'number))
+                        (typep (gate-application-gate instr) 'pauli-sum-gate))))
+  "Rewrites a parametric 2Q gate application described by a time-independent Hamiltonian into canonical form."
+  (let ((gate (gate-application-gate instr)))
+    ;; XXX: check that the hamiltonian H(t) is time-independent (i.e., time-linear)
+    ;; instantiate the hamiltonian H0 = H(1) at a particular time
+    (let* ((H0 (gate-matrix gate 1.0d0)))
+      ;; diagonalize it: H0 = U D U*
+      (multiple-value-bind (d u) (magicl:eig H0)
+        (format t "~&diagonal phases: ~a~%" (mapcar #'phase d))
+        (let* (;; infer a presentation of D as a hamiltonian: D = EXPI(a ZI + b IZ + c ZZ)
+               (kernel (print (m* (magicl:inv (make-row-major-matrix 3 3 (list -1  1 -1
+                                                                               -1 -1  1 
+                                                                                1  1  1)))
+                                  (make-row-major-matrix 3 1 (mapcar #'phase (rest d))))))
+               (ZI (magicl:ref kernel 0 0))
+               (IZ (magicl:ref kernel 1 0))
+               (ZZ (magicl:ref kernel 2 0))
+               ;; use +e-basis+ to turn the middle into a canonical gate:
+               ;;     H0 = UDU* = UE* EDE* EU* and EDE* = EXPI(a XX + b YY + c ZZ)
+               (formal-qubit-args (list (formal "q1") (formal "q0")))
+               (formal-parameter-name (make-symbol "time"))
+               (canonical-hamiltonian
+                 (make-instance 'pauli-sum-gate
+                                :arguments formal-qubit-args
+                                :parameters (list formal-parameter-name)
+                                :terms (list (make-pauli-term :pauli-word "XX"
+                                                              :prefactor `(* ,ZI ,formal-parameter-name)
+                                                              :arguments formal-qubit-args)
+                                             (make-pauli-term :pauli-word "YY"
+                                                              :prefactor `(* ,IZ ,formal-parameter-name)
+                                                              :arguments formal-qubit-args)
+                                             (make-pauli-term :pauli-word "ZZ"
+                                                              :prefactor `(* ,ZZ ,formal-parameter-name)
+                                                              :arguments formal-qubit-args))
+                                :dimension 4
+                                :arity 1
+                                :name "CANONICALIZED-HAM"))
+               ;; return: anonymous gate (UE*) canonical hamiltonian (EDE*) anonymous gate (EU*)
+               (left-matrix  (m* u +edag-basis+))
+               (right-matrix (m* +e-basis+ (magicl:conjugate-transpose u))))
+          (inst "CONJ-RIGHT"   right-matrix q1 q0)
+          (inst (make-instance 'gate-application
+                               :operator (named-operator "CANONICAL-AS-PAULI")
+                               :arguments (list (qubit q1) (qubit q0))
+                               :parameters (list time)
+                               :gate canonical-hamiltonian))
+          (inst "CONJ-LEFT"    left-matrix q1 q0))))))

--- a/src/compilers/ucr-recognize.lisp
+++ b/src/compilers/ucr-recognize.lisp
@@ -9,7 +9,10 @@
 (define-compiler recognize-ucr ((instr
                                  :where (anonymous-gate-application-p instr)))
   "Checks whether an anonymous gate is a UCRY or UCRZ instruction, in which case it relabels it as such."
-  (let* ((matrix (gate-matrix instr))
+  (let* ((matrix (handler-case (gate-matrix instr)
+                   (unknown-gate-parameter (c)
+                     (declare (ignore c))
+                     (give-up-compilation))))
          (dimension (magicl:matrix-rows matrix))
          (log-dimension (length (application-arguments instr)))
          angles)

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -828,7 +828,8 @@ N.B.: This routine is somewhat fragile, and highly creative compiler authors wil
   (assert (listp source))
   (multiple-value-bind (source options) (cleave-options source)
     (cond
-      ((endp (cdr source))
+      ((or (endp (cdr source))
+           (wildcard-pattern-p (second source)))
        (make-wildcard-binding :name (first source)
                               :options options))
       (t

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -904,7 +904,8 @@ FINISH-COMPILER is a local macro usable within a compiler body."
                          (setf ,x (apply #'build-gate ,xs)))
                         ;; check for an anon-gate signature
                         ((and (<= 3 (length ,xs))
-                              (typep (cadr ,xs) 'magicl:matrix))
+                              (or (typep (cadr ,xs) 'magicl:matrix)
+                                  (typep (cadr ,xs) 'gate)))
                          (setf ,x (apply #'anon-gate ,xs)))
                         (t
                          (error "INST argument pattern not recognized: ~A" ,xs)))

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -899,15 +899,15 @@ FINISH-COMPILER is a local macro usable within a compiler body."
                         ((and (= 1 (length ,xs))
                               (typep (first ,xs) 'gate-application))
                          (setf ,x (first ,xs)))
+                        ;; check for an anon-gate signature
+                        ((and (<= 3 (length ,xs))
+                              (or (typep (cadr ,xs) 'magicl:matrix)
+                                  (typep (car ,xs) 'gate)))
+                         (setf ,x (apply #'anon-gate ,xs)))
                         ;; check for a build-gate signature
                         ((and (<= 3 (length ,xs))
                               (typep (cadr ,xs) 'list))
                          (setf ,x (apply #'build-gate ,xs)))
-                        ;; check for an anon-gate signature
-                        ((and (<= 3 (length ,xs))
-                              (or (typep (cadr ,xs) 'magicl:matrix)
-                                  (typep (cadr ,xs) 'gate)))
-                         (setf ,x (apply #'anon-gate ,xs)))
                         (t
                          (error "INST argument pattern not recognized: ~A" ,xs)))
                       (rplacd ,tail (cons ,x nil))

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -208,7 +208,8 @@
                                       (m+ m (pauli-term->matrix term arguments params parameters)))
                                     terms
                                     :initial-value (magicl:make-zero-matrix size size))
-                            (complex 0d0 -1d0))))
+                            (complex 0d0 -1d0)
+                            :hermitian? t)))
         (setf (%parameterized-gate-matrix-function gate) #'matrix-function)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;; Gate Operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -372,10 +372,10 @@
   (declare (optimize (debug 3) (speed 0)))
   (with-slots (arguments parameters terms) gate-def
     (let ((size (expt 2 (length (pauli-sum-gate-definition-arguments gate-def)))))
-      (flet ((matrix-function (&optional params)
+      (flet ((matrix-function (&rest params)
                (assert (= (length parameters) (length params)))
                (matrix-expt (reduce (lambda (m term)
-                                      (m+ m (pauli-term->matrix term arguments params)))
+                                      (m+ m (pauli-term->matrix term arguments params parameters)))
                                     terms
                                     :initial-value (magicl:make-zero-matrix size size))
                             (complex 0d0 -1d0))))

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -209,8 +209,7 @@
                                     terms
                                     :initial-value (magicl:make-zero-matrix size size))
                             (complex 0d0 -1d0))))
-        (setf (%parameterized-gate-matrix-function gate)
-              #'matrix-function)))))
+        (setf (%parameterized-gate-matrix-function gate) #'matrix-function)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;; Gate Operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -369,7 +369,6 @@
                      :matrix-function (compile nil (lambda-form params dim entries))))))
 
 (defmethod gate-definition-to-gate ((gate-def pauli-sum-gate-definition))
-  (declare (optimize (debug 3) (speed 0)))
   (with-slots (arguments parameters terms) gate-def
     (let ((size (expt 2 (length (pauli-sum-gate-definition-arguments gate-def)))))
       (flet ((matrix-function (&rest params)

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -382,3 +382,11 @@ as needed so that they are the same size."
        (matrix-equality
         kroned-ref-mat
         (scale-out-matrix-phases kroned-mat kroned-ref-mat))))))
+
+(defun matrix-expt (m s)
+  "Computes EXP(M*S).  Only works for unitarily diagonalizable matrices M."
+  (multiple-value-bind (d u) (magicl:eig m)
+    (let* ((size (length d))
+           (dd (magicl:diag size size
+                            (mapcar (lambda (z) (exp (* z s))) d))))
+      (m* u dd (magicl:conjugate-transpose u)))))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -989,13 +989,12 @@ If ENSURE-VALID is T, then a memory reference such as 'foo[0]' will result in an
 (defun pauli-term->matrix (term arguments parameters parameter-names)
   (let* ((prefactor-fn
            (typecase (pauli-term-prefactor term)
-             (number (lambda (&rest args) (declare (ignore args)) (pauli-term-prefactor term)))
-             (symbol (compile nil `(lambda ,parameter-names
-                                     (declare (ignorable ,@parameter-names))
-                                     ,(pauli-term-prefactor term))))
-             (cons (compile nil `(lambda ,parameter-names
-                                   (declare (ignorable ,@parameter-names))
-                                   ,@(pauli-term-prefactor term))))))
+             (number
+              (lambda (&rest args) (declare (ignore args)) (pauli-term-prefactor term)))
+             ((or symbol cons)
+              (compile nil `(lambda ,parameter-names
+                              (declare (ignorable ,@parameter-names))
+                              ,(pauli-term-prefactor term))))))
          (arg-count (length arguments))
          (size (expt 2 arg-count))
          (m (magicl:make-zero-matrix size size)))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -963,7 +963,7 @@ If ENSURE-VALID is T, then a memory reference such as 'foo[0]' will result in an
       (setf param (parse-arithmetic-tokens param-tokens :eval t))
       ;; RPAREN
       (unless (eql ':RIGHT-PAREN (token-type (first line)))
-        )
+        (quil-parse-error "Expected a right parenthesis in parsing this Pauli term, but got ~a" (first line)))
       (pop line)
       ;; QUBIT ... QUBIT
       (setf qubit-list (mapcar (lambda (tok)


### PR DESCRIPTION
This PR extends the CL-QUIL parser and AST framework to support gates described as exponentiated Hamiltonians, themselves described by Pauli sums.

Lots still to-do. In particular, I have to spend some time thinking about the distinction between `gate-definition` and `gate` objects, as well as whether any "anonymous" variants might be useful in the course of normal compiler operation.

(Eventually) closes #422.

Some TODOs:

* [ ] Finish writing the guards on the Pauli compiler.
* [ ] Study orthogonality properties elsewhere in the compilation method chain. Consider implementing /1203.0722.
* [ ] Tests: single-qubit, two-qubit, three-qubit; parametric whole, nonparametric whole, parametric diagonal, nonparametric diagonal; random Hamiltonians, adversarial Hamiltonians.
* [ ] I think I'm abusing the parse tree. (1) Should Pauli term prefactors be delayed expressions? I'm not sure. (2) Am I really making good use of the gate-definition and gate classes?
* [ ] Investigate the dependence on the expansion qubit. I think one can even choose an ancilla qubit, which really widens the space of possible expansions. Are there expansions that do a good job of respecting the chip topology?
* [ ] Benchmark this version of diagonal expansion against tweedledum and against the FORKED compiler.