### PR TITLE
Prefer format string for printing AST objects

### DIFF
--- a/src/addresser/logical-schedule.lisp
+++ b/src/addresser/logical-schedule.lisp
@@ -193,18 +193,18 @@
 (defun print-lschedule (lschedule &optional (stream *standard-output*))
   (format stream "First instructions:~%")
   (dolist (instr (lscheduler-first-instrs lschedule))
-    (format stream "    ~a~%"
-            (print-instruction instr nil)))
+    (format stream "    ~/quil:instruction-fmt/~%" instr))
   (format stream "Last instructions:~%")
   (dolist (instr (lscheduler-last-instrs lschedule))
-    (format stream "    ~a~%"
-            (print-instruction instr nil)))
+    (format stream "    ~/quil:instruction-fmt/~%" instr))
   (dohash ((key val) (lscheduler-later-instrs lschedule))
-    (format stream "Instrs beneath ~a: ~{~a~^, ~}~%" (print-instruction key nil)
-            (mapcar (lambda (i) (print-instruction i nil)) val)))
+    (format stream "Instrs beneath ~/quil:instruction-fmt/: ~{~/quil:instruction-fmt/~^, ~}~%"
+            key
+            val))
   (dohash ((key val) (lscheduler-earlier-instrs lschedule))
-    (format stream "Instrs above ~a: ~{~a~^, ~}~%" (print-instruction key nil)
-            (mapcar (lambda (i) (print-instruction i nil)) val))))
+    (format stream "Instrs above ~/quil:instruction-fmt/: ~{~/quil:instruction-fmt/~^, ~}~%"
+            key
+            val)))
 
 ;;;
 ;;; routines for incrementally forming a logical-scheduler object
@@ -604,8 +604,8 @@ mapping instructions to their tags. "
            (fidelity-bumper (instr value)
              (flet ((warn-and-skip (instr)
                       (format *compiler-noise-stream*
-                              "Fidelity not known for the following gate: ~a. Assuming ideal.~%"
-                              (print-instruction instr nil))
+                              "Fidelity not known for the following gate: ~/quil:instruction-fmt/. Assuming ideal.~%"
+                              instr)
                       (return-from fidelity-bumper value)))
                (let (fidelity)
                  (typecase instr

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -206,8 +206,8 @@ Returns NIL. This mutates the instruction."
                                       (qubit-index (reset-qubit-target instr))
                                       :assert-wired t))))
     (otherwise
-     (error "Requested to rewire ~a, but we don't know how to do this."
-            (print-instruction instr nil))))
+     (error "Requested to rewire ~/quil:instruction-fmt/, but we don't know how to do this."
+            instr)))
   ;; Return nil to emphasize side effect.
   nil)
 

--- a/src/analysis/expand-circuits.lisp
+++ b/src/analysis/expand-circuits.lisp
@@ -127,8 +127,8 @@ explicitly allowed by setting *ALLOW-UNRESOLVED-APPLICATIONS* to T."
             (circuit-definition-body (circuit-application-definition instr))))
     (unresolved-application
      (unless *allow-unresolved-applications*
-       (error "Unable to determine if the unresolved application is unitary:~%    ~A"
-              (print-instruction instr nil)))
+       (error "Unable to determine if the unresolved application is unitary:~%    ~/quil:instruction-fmt/"
+              instr))
      t)))
 
 (defgeneric instantiate-instruction (instr param-value arg-value)
@@ -149,8 +149,8 @@ explicitly allowed by setting *ALLOW-UNRESOLVED-APPLICATIONS* to T."
                                               args)))
              (dolist (instr instrs)
                (unless (unitary-instruction-p instr)
-                 (error "DAGGER cannot be applied to the impure instruction ~S"
-                        (print-instruction instr nil)))
+                 (error "DAGGER cannot be applied to the impure instruction ~/quil:instruction-fmt/"
+                        instr))
                (setf (application-operator instr)
                      (involutive-dagger-operator (application-operator instr))))
              ;; The Hermitian transpose reverses the order of operator
@@ -161,8 +161,8 @@ explicitly allowed by setting *ALLOW-UNRESOLVED-APPLICATIONS* to T."
                                 params
                                 args))
           (t
-           (error "Unable to instantiate the modifiers in the complex instruction ~S."
-                  (print-instruction instr nil)))))))
+           (error "Unable to instantiate the modifiers in the complex instruction ~/quil:instruction-fmt/."
+                  instr))))))
 
   (:method ((instr application) param-value arg-value)
     (let ((remake nil))

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -88,8 +88,8 @@ This also signals ambiguous definitions, which may be handled as needed."
         ((assert-and-print-instruction (test-form &optional places datum &rest arguments)
            `(assert ,test-form
                     ,places
-                    (format nil "Error in resolving ~s: ~a"
-                            (print-instruction app nil)
+                    (format nil "Error in resolving ~/quil:instruction-fmt/: ~a"
+                            app
                             ,datum)
                     ,@arguments)))
       (let* ((operator (application-operator app))

--- a/src/cfg.lisp
+++ b/src/cfg.lisp
@@ -619,7 +619,7 @@ Return the following values:
     (when (slot-boundp blk 'outgoing)
       (adt:match outgoing-edge (outgoing blk)
         ((conditional-edge instr _ _)
-         (format s "\\nConditioned on ~a" (print-instruction instr nil))
+         (format s "\\nConditioned on ~/quil:instruction-fmt/" instr)
          (format s "\\l"))
         (_ nil)))))
 

--- a/src/chip-reader.lisp
+++ b/src/chip-reader.lisp
@@ -419,6 +419,6 @@ touch any qubits marked as dead in CHIP-SPECIFICATION."
                                                        dead-qubits)))
                   (assert (endp instr-dead-qubits)
                           nil
-                          "Program instruction '~A' attempts to use illegal qubits: ~{~A~^, ~}. Illegal qubits on this QPU: ~{~A~^, ~}."
-                          (print-instruction instr nil) instr-dead-qubits dead-qubits))))))
+                          "Program instruction '~/quil:instruction-fmt/' attempts to use illegal qubits: ~{~A~^, ~}. Illegal qubits on this QPU: ~{~A~^, ~}."
+                          instr instr-dead-qubits dead-qubits))))))
 

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -25,11 +25,10 @@
   nil)
 
 (defmethod print-instruction-generic ((thing state-prep-application) (s stream))
-  (format s "STATE-PREP[(~{~5$~^, ~}) -> (~{~5$~^, ~})] ~{~a~^ ~}"
+  (format s "STATE-PREP[(~{~5$~^, ~}) -> (~{~5$~^, ~})] ~{~/quil:instruction-fmt/~^ ~}"
           (coerce (state-prep-application-source-wf thing) 'list)
           (coerce (state-prep-application-target-wf thing) 'list)
-          (mapcar (lambda (arg) (print-instruction arg nil))
-                  (application-arguments thing))))
+          (application-arguments thing)))
 
 
 ;; first we do base case work.


### PR DESCRIPTION
People have expressed a preference for using `instruction-fmt` for printing AST objects, as opposed to e.g. `(print-instruction obj nil)` which allocates a string and relies on a method specialized on the null class. I'm just applying this uniformly here. This is a spillover from the quilt PR, since that is already too large.