### PR TITLE
add periods to sentences without periods

### DIFF
--- a/src/addresser/initial-rewiring.lisp
+++ b/src/addresser/initial-rewiring.lisp
@@ -38,7 +38,7 @@ impossible using that rewiring.")
 (defun chip-spec-live-qubit-bfs (chip-spec qubit-index &optional seen)
   "From a given initial qubit, find the distance to every other qubit in the connected component. SEEN is an array of T/NIL for each qubit, indicating whether that qubit has been visited yet."
   (assert (not (chip-spec-qubit-dead? chip-spec qubit-index)) (qubit-index)
-          "Cannot BFS from dead qubit ~a"
+          "Cannot BFS from dead qubit ~a."
           qubit-index)
   (loop
     :with level := 0
@@ -67,7 +67,7 @@ impossible using that rewiring.")
     :finally (return (values distances seen))))
 
 (defun chip-spec-live-qubit-cc (chip-spec)
-  "Get a list of lists of live qubits that are in the same connected component on the chip"
+  "Get a list of lists of live qubits that are in the same connected component on the chip."
   (loop
     :with n-qubits := (chip-spec-n-qubits chip-spec)
     :with seen := (make-array n-qubits :initial-element nil)
@@ -95,7 +95,7 @@ impossible using that rewiring.")
           :and :collect idx)))
 
 (defun containing-indices (list-of-lists)
-  "Given a list of lists, return a table mapping elements to the index of the last list in which they appear"
+  "Given a list of lists, return a table mapping elements to the index of the last list in which they appear."
   (let ((tbl (make-hash-table)))
     (loop
       :for i :from 0
@@ -123,7 +123,7 @@ impossible using that rewiring.")
     mapping))
 
 (defun assign-arbitrarily (source dest mapping)
-  "Assign all elements of the set source to elements of the set dest in the mapping"
+  "Assign all elements of the set source to elements of the set dest in the mapping."
   (loop
     :for logical :in source
     :for physical :in dest
@@ -131,14 +131,14 @@ impossible using that rewiring.")
   mapping)
 
 (defparameter *rewiring-adjacency-weight-decay* 2.0
-  "Rate of decay on the weight of instruction value for closeness")
+  "Rate of decay on the weight of instruction value for closeness.")
 
 (defparameter *rewiring-distance-offset* 0.0
-  "How much we should shift the distances before weighting. High values means small differences in distance have smaller effect")
+  "How much we should shift the distances before weighting. High values means small differences in distance have smaller effect.")
 
 (defun compute-adjacency-weights (n-qubits order)
   "Given the order in which to expect qubits, compute the relative benefit of
-being close to each of the n qubits"
+being close to each of the n qubits."
   (loop
     :with weights-by-qubit := (make-array n-qubits :initial-element 0d0)
     :for adj :in order
@@ -154,7 +154,7 @@ If no
 
     PRAGMA INITIAL_REWIRING \"...\"
 
-is found, then return NIL"
+is found, then return NIL."
   (loop :for inst :across (parsed-program-executable-code parsed-prog) :do
     (cond
       ((typep inst 'pragma)
@@ -212,7 +212,7 @@ NEEDED."
 
 (defun prog-initial-rewiring (parsed-prog chip-spec &key (type *initial-rewiring-default-type*))
   "Find an initial rewiring for a program that ensures that all used qubits
-appear in the same connected component of the qpu"
+appear in the same connected component of the qpu."
   (let* ((n-qubits (chip-spec-n-qubits chip-spec))
          (connected-components (chip-spec-live-qubit-cc chip-spec))
          (indices (containing-indices connected-components))
@@ -221,7 +221,7 @@ appear in the same connected component of the qpu"
     (assert (or (endp needed)
                 (<= (apply #'max needed) n-qubits))
             ()
-            "User program incompatible with chip: qubit index ~a used and ~a available"
+            "User program incompatible with chip: qubit index ~a used and ~a available."
             (apply #'max needed) n-qubits)
 
     (when (eql type ':naive)
@@ -232,11 +232,11 @@ appear in the same connected component of the qpu"
                 :when (not component)
                   :do (setf component index)
                 :always (and index (= index component)))
-        (error "User program incompatible with chip: naive rewiring crosses chip component boundaries"))
+        (error "User program incompatible with chip: naive rewiring crosses chip component boundaries."))
       (return-from prog-initial-rewiring (make-rewiring n-qubits)))
 
     (assert (<= (length needed) (length cc)) ()
-            "User program used too many qubits: ~a used and ~a available in the largest connected component"
+            "User program used too many qubits: ~a used and ~a available in the largest connected component."
             (length needed) (length cc))
 
     (when (eql type ':partial)
@@ -247,7 +247,7 @@ appear in the same connected component of the qpu"
       (return-from prog-initial-rewiring (generate-random-rewiring n-qubits)))
 
     (assert (eql type ':greedy) (type)
-            "Unexpected rewiring type: ~a" type)
+            "Unexpected rewiring type: ~a." type)
 
     ;; TODO: this assumes that the program is sequential
     (let* ((per-qubit-ins (prog-qubit-pair-order n-qubits parsed-prog))

--- a/src/addresser/outgoing-schedule.lisp
+++ b/src/addresser/outgoing-schedule.lisp
@@ -60,7 +60,7 @@ permutation record duration."
      (chip-schedule-start-time schedule inst)))
 
 (defun chip-schedule-append (schedule inst)
-  "Append an instruction INST to the chip SCHEDULE"
+  "Append an instruction INST to the chip SCHEDULE."
   (append-instruction-to-lschedule (chip-schedule-data schedule) inst)
   (setf (chip-schedule-start-time schedule inst)
         (loop
@@ -135,5 +135,5 @@ BEFORE-INST to make use of RESOURCE."
           :while inst
           :do (remhash inst needed))
         (assert (zerop (hash-table-count needed)) ()
-                "Qubit ~a did not have a single line in ~a. Missing ~a"
+                "Qubit ~a did not have a single line in ~a. Missing ~a."
                 qubit chip-sched (a:hash-table-keys needed))))))

--- a/src/addresser/path-heuristic.lisp
+++ b/src/addresser/path-heuristic.lisp
@@ -73,7 +73,7 @@ rewiring."
              (return (select-swap-by-values chip-spec link-values rewirings-tried rewiring))))
 
 (defun select-swap-path-gates (chip-spec qq-distances gates-in-waiting rewirings-tried rewiring)
-  "Search for a usable rewiring by assigning values to links"
+  "Search for a usable rewiring by assigning values to links."
   (loop
     :with n-links := (chip-spec-n-links chip-spec)
     :with link-values := (make-array n-links :initial-element 0d0)

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -305,7 +305,7 @@ BODY as an implicit PROGN."
               nil
               "Malformed rewiring pair string: length of rewirings don't match. ~@
                first:  ~A~@
-               second: ~A."
+               second: ~A"
               first-rewiring-string second-rewiring-string)
       (values (make-rewiring-from-string first-rewiring-string)
               (make-rewiring-from-string second-rewiring-string)))))

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -84,10 +84,10 @@ INVERSE."
   (let ((old-physical (aref (rewiring-l2p rewiring) logical))
         (old-logical (aref (rewiring-p2l rewiring) physical)))
     (assert (or (not old-physical) (= old-physical physical)) ()
-            "Cannot re-assign logical qubit ~A to different physical qubit ~A"
+            "Cannot re-assign logical qubit ~A to different physical qubit ~A."
             logical physical)
     (assert (or (not old-logical) (= old-logical logical)) ()
-            "Cannot assign logical qubit ~A to occupied physical qubit ~A"
+            "Cannot assign logical qubit ~A to occupied physical qubit ~A."
             logical physical)
     (setf (aref (rewiring-l2p rewiring) logical) physical
           (aref (rewiring-p2l rewiring) physical) logical)
@@ -96,7 +96,7 @@ INVERSE."
 (defun rewiring-unassign (rewiring logical)
   "Remove an assignment of the logical qubit in the rewiring."
   (assert (aref (rewiring-l2p rewiring) logical) (logical)
-          "Logical qubit ~A not assigned" logical)
+          "Logical qubit ~A not assigned." logical)
   (let ((physical (aref (rewiring-l2p rewiring) logical)))
     (setf (aref (rewiring-p2l rewiring) physical) nil
           (aref (rewiring-l2p rewiring) logical) nil)
@@ -111,7 +111,7 @@ INVERSE."
          :documentation "The wire whose assignment doesn't exist."))
   (:report (lambda (condition stream)
              (let ((*print-pretty* nil))
-               (format stream "Rewiring missing assignment for qubit ~A in rewiring ~A"
+               (format stream "Rewiring missing assignment for qubit ~A in rewiring ~A."
                        (missing-rewiring-assignment-wire condition)
                        (missing-rewiring-assignment-rewiring condition)))))
   (:documentation "An error signaled if a rewiring is being applied but an assignment is missing."))
@@ -218,9 +218,9 @@ Returns NIL. This mutates the instruction."
       (let ((loc (aref l2p j)))
         (when loc
           (assert (and (< -1 loc (length p2l))) ()
-                  "Malformed rewiring string: value ~a at position ~a is out of range" loc j)
+                  "Malformed rewiring string: value ~a at position ~a is out of range." loc j)
           (assert (null (aref p2l loc)) ()
-                  "Malformed rewiring string: repeated value ~a at position ~a" loc j)
+                  "Malformed rewiring string: repeated value ~a at position ~a." loc j)
           (setf (aref p2l loc) j))))
     (init-rewiring :l2p l2p :p2l p2l)))
 
@@ -256,7 +256,7 @@ BODY as an implicit PROGN."
                (eql #\( (aref str 1))
                (eql #\) (aref str (1- (length str)))))
           nil
-          "Malformed rewiring string: input ~a is not of the form #(...)" str)
+          "Malformed rewiring string: input ~a is not of the form #(...)." str)
   (let* ((stripped-string (string-trim "#()" str))
          (tokens (first (tokenize stripped-string)))
          (integer-vec
@@ -268,7 +268,7 @@ BODY as an implicit PROGN."
                     ((eql (token-type token) :integer)
                      (token-payload token))
                     (t
-                     (error "Malformed rewiring string: unexpected token ~a" token))))
+                     (error "Malformed rewiring string: unexpected token ~a." token))))
                 tokens)))
     (make-rewiring-from-l2p integer-vec)))
 
@@ -305,7 +305,7 @@ BODY as an implicit PROGN."
               nil
               "Malformed rewiring pair string: length of rewirings don't match. ~@
                first:  ~A~@
-               second: ~A"
+               second: ~A."
               first-rewiring-string second-rewiring-string)
       (values (make-rewiring-from-string first-rewiring-string)
               (make-rewiring-from-string second-rewiring-string)))))

--- a/src/addresser/temporal-addresser.lisp
+++ b/src/addresser/temporal-addresser.lisp
@@ -348,7 +348,7 @@ rewiring REWIRING to the TARGET-REWIRING."
           :do (rewiring-assign rewiring logical physical))
       (return-from move-to-expected-rewiring))
     (assert (> *addresser-max-swap-sequence-length* (length rewirings-tried)) ()
-            "Too many rewirings tried: ~a" (length rewirings-tried))
+            "Too many rewirings tried: ~a." (length rewirings-tried))
     ;; otherwise, pick a SWAP
     (flet ((embed (link-index)
              (embed-swap link-index
@@ -625,7 +625,7 @@ list of partially-rewired 2Q instructions for later scheduling."
          (assert (every (lambda (q) (< -1 (qubit-index q) (length 1q-queues)))
                         (application-arguments instr))
                  nil
-                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/"
+                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/."
                  instr)
          (destructuring-bind (p0 p1)
              (mapcar (lambda (q) (apply-rewiring-l2p working-l2p (qubit-index q)))
@@ -662,7 +662,7 @@ list of partially-rewired 2Q instructions for later scheduling."
          (assert (every (lambda (q) (< -1 (qubit-index q) (length 1q-queues)))
                         (application-arguments instr))
                  nil
-                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/"
+                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/."
                  instr)
          (when dry-run-escape
            (funcall dry-run-escape))
@@ -683,7 +683,7 @@ list of partially-rewired 2Q instructions for later scheduling."
          (assert (every (lambda (q) (< -1 (qubit-index q) (length 1q-queues)))
                         (application-arguments instr))
                  nil
-                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/"
+                 "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/."
                  instr)
          (format *compiler-noise-stream*
                  "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a ~dQ>2Q instruction, compiling.~%"
@@ -833,19 +833,19 @@ are ready to be scheduled."
                 ;; will fall into the bucket of instructions that are
                 ;; ready-2-go.
                 (format *compiler-noise-stream*
-                        "DEQUEUE-SOONEST-2Q-FROM-LIST: Couldn't rewire ~/quil:instruction-fmt/ because assignment is missing"
+                        "DEQUEUE-SOONEST-2Q-FROM-LIST: Couldn't rewire ~/quil:instruction-fmt/ because assignment is missing."
                         instr)
                 (loop
                   :for (logical physical) :in qubit-assignments
                   :unless (apply-rewiring-l2p working-l2p logical)
                     :do (format *compiler-noise-stream*
-                                "DEQUEUE-SOONEST-2Q-FROM-LIST: assigning logical qubit ~a to physical qubit ~a~%"
+                                "DEQUEUE-SOONEST-2Q-FROM-LIST: assigning logical qubit ~a to physical qubit ~a.~%"
                                 logical physical)
                         (rewiring-assign working-l2p logical physical))
                 (return-from dequeue-soonest-2q-from-list t))))
 
           (format *compiler-noise-stream*
-                  "DEQUEUE-SOONEST-2Q-FROM-LIST: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring~%"
+                  "DEQUEUE-SOONEST-2Q-FROM-LIST: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring.~%"
                   instr rewired-instr)
 
           ;; Figure out if we need to compile the instruction,
@@ -917,7 +917,7 @@ are ready to be scheduled."
   "Given a gate application that is unassigned or partially assigned by
 the addresser's working logical-to-physical rewiring, compute a best physical qubit
 assignment."
-  (assert (= 2 (length (application-arguments inst))) () "Expected 2-qubit gate")
+  (assert (= 2 (length (application-arguments inst))) () "Expected 2-qubit gate.")
   (with-slots (working-l2p chip-spec) *temporal-addresser-state-variables*
     (destructuring-bind (q0 q1) (mapcar #'qubit-index (application-arguments inst))
       (let ((p0 (apply-rewiring-l2p working-l2p q0))
@@ -934,7 +934,7 @@ assignment."
   (with-slots (working-l2p chip-spec qq-distances qubit-cc) *temporal-addresser-state-variables*
     (let ((locations (or locations qubit-cc)))
       (assert (not (apply-rewiring-l2p working-l2p logical)) (logical)
-              "Qubit ~a already assigned" logical)
+              "Qubit ~a already assigned." logical)
       (a:extremum
        (remove-if (lambda (p)
                     (or (apply-rewiring-p2l working-l2p p)
@@ -1043,7 +1043,7 @@ Optional arguments:
                      :do (format *compiler-noise-stream*
                                  "TEMPORAL-ADDRESSER-FSM: LSCHED unchanged, selecting a permutation.~%")
                          (assert (> *addresser-max-swap-sequence-length* (length rewirings-tried)) ()
-                                 "Too many SWAP instructions selected in a row: ~a" (length rewirings-tried))
+                                 "Too many SWAP instructions selected in a row: ~a." (length rewirings-tried))
                          (setf rewirings-tried (select-and-embed-a-permutation rewirings-tried)))))
 
           ;; build the logically parallelized schedule

--- a/src/analysis/resolve-applications.lisp
+++ b/src/analysis/resolve-applications.lisp
@@ -63,7 +63,7 @@ This also signals ambiguous definitions, which may be handled as needed."
                                          (token
                                           (token-pathname (lexical-context instr)))
                                          (t
-                                          (quil-parse-error "Unable to resolve definition context ~A" instr)))))
+                                          (quil-parse-error "Unable to resolve definition context ~A." instr)))))
                  ;; check for conflicts
                  (a:when-let ((entries (gethash signature all-seen-defns)))
                    (cerror "Continue with ambiguous definition."
@@ -88,7 +88,7 @@ This also signals ambiguous definitions, which may be handled as needed."
         ((assert-and-print-instruction (test-form &optional places datum &rest arguments)
            `(assert ,test-form
                     ,places
-                    (format nil "Error in resolving ~/quil:instruction-fmt/: ~a"
+                    (format nil "Error in resolving ~/quil:instruction-fmt/: ~a."
                             app
                             ,datum)
                     ,@arguments)))

--- a/src/analysis/type-safety.lisp
+++ b/src/analysis/type-safety.lisp
@@ -34,7 +34,7 @@
   (when (and (typep mref 'memory-ref)
              (<= (memory-descriptor-length memory-descriptor)
                  (memory-ref-position mref)))
-    (quil-type-error "Memory ref \"~/quil:instruction-fmt/\" exceeds region size ~A"
+    (quil-type-error "Memory ref \"~/quil:instruction-fmt/\" exceeds region size ~A."
                      mref
                      (memory-descriptor-length memory-descriptor))))
 
@@ -48,7 +48,7 @@
 
 (defun check-mref (obj)
   (unless (typep obj 'memory-ref)
-    (quil-type-error "Argument expected to be a memory reference, but got ~/quil:instruction-fmt/"
+    (quil-type-error "Argument expected to be a memory reference, but got ~/quil:instruction-fmt/."
                      obj)))
 
 ;;; helper functions for type-check-instr ;;;
@@ -59,7 +59,7 @@
   (let ((mdesc (find-descriptor-for-mref (classical-left-operand instr) memory-regions)))
     (when (and object-to-type
                (equalp object-to-type (memory-descriptor-type mdesc)))
-      (quil-type-error "Argument should be a binary memory reference, but got real ~/quil:instruction-fmt/"
+      (quil-type-error "Argument should be a binary memory reference, but got real ~/quil:instruction-fmt/."
                        (classical-left-operand instr)))
     (adt:match quil-type (memory-descriptor-type mdesc)
       (quil-real
@@ -73,7 +73,7 @@
                                    quil-real
                                    memory-regions)
            t
-           (quil-type-error "Expected REAL assignment based on ~/quil:instruction-fmt/, but got ~/quil:instruction-fmt/"
+           (quil-type-error "Expected REAL assignment based on ~/quil:instruction-fmt/, but got ~/quil:instruction-fmt/."
                             (classical-left-operand instr)
                             (classical-right-operand instr))))
       (quil-octet
@@ -83,7 +83,7 @@
                (and (typep (classical-right-operand instr) 'constant)
                     (equal quil-integer (constant-value-type (classical-right-operand instr)))))
            t
-           (quil-type-error "Expected OCTET assignment based on ~/quil:instruction-fmt/, but got ~/quil:instruction-fmt/"
+           (quil-type-error "Expected OCTET assignment based on ~/quil:instruction-fmt/, but got ~/quil:instruction-fmt/."
                             (classical-left-operand instr)
                             (classical-right-operand instr))))
       (quil-bit
@@ -94,24 +94,24 @@
                   (constant (coerce (constant-value (classical-right-operand instr)) 'bit)
                             quil-bit)))
            (otherwise
-            (quil-type-error "Assignment to BIT field from non-BIT literal ~A"
+            (quil-type-error "Assignment to BIT field from non-BIT literal ~A."
                              (constant-value (classical-right-operand instr))))))
        (unless (constant-or-mref-typep (classical-right-operand instr)
                                        quil-bit
                                        memory-regions)
-         (quil-type-error "Assignment to BIT field from non-BIT ~A"
+         (quil-type-error "Assignment to BIT field from non-BIT ~A."
                           (classical-right-operand instr))))
       (quil-integer
        (unless (constant-or-mref-typep (classical-right-operand instr)
                                        quil-integer
                                        memory-regions)
-         (quil-type-error "Assignment to INTEGER field from non-INTEGER ~A"
+         (quil-type-error "Assignment to INTEGER field from non-INTEGER ~A."
                           (classical-right-operand instr)))))))
 
 (defun typecheck-conditional-instruction (instr memory-regions)
   (check-mref (classical-target instr))
   (unless (constant-or-mref-typep (classical-target instr) quil-bit memory-regions)
-    (quil-type-error "Conditional tests write to BIT memory, but got ~/quil:instruction-fmt/ instead"
+    (quil-type-error "Conditional tests write to BIT memory, but got ~/quil:instruction-fmt/ instead."
                      (classical-target instr)))
   (check-mref (classical-left-operand instr))
   (let ((mdesc (find-descriptor-for-mref (classical-left-operand instr)
@@ -123,7 +123,7 @@
                      (constant-or-mref-typep (classical-right-operand instr)
                                              quil-integer
                                              memory-regions)))
-      (quil-type-error "Conditional tests require type agreement in last two terms, but got ~/quil:instruction-fmt/ and ~/quil:instruction-fmt/"
+      (quil-type-error "Conditional tests require type agreement in last two terms, but got ~/quil:instruction-fmt/ and ~/quil:instruction-fmt/."
                        (classical-left-operand instr)
                        (classical-right-operand instr)))))
 
@@ -148,7 +148,7 @@
      (let ((mdesc (find-descriptor-for-mref param memory-regions)))
        (setf (memory-ref-descriptor param) mdesc)
        (unless (equal quil-real (memory-descriptor-type mdesc))
-         (quil-type-error "Memory reference ~/quil:instruction-fmt/ is used as a gate parameter but is not a REAL value"
+         (quil-type-error "Memory reference ~/quil:instruction-fmt/ is used as a gate parameter but is not a REAL value."
                           param))))))
 
 ;;; real deal ;;;
@@ -194,7 +194,7 @@
       (adt:match quil-type (memory-descriptor-type mdesc)
         (quil-real    (call-next-method))
         (quil-integer (call-next-method))
-        (_            (quil-type-error "NEG argument should be a signed memory reference, but got ~/quil:instruction-fmt/"
+        (_            (quil-type-error "NEG argument should be a signed memory reference, but got ~/quil:instruction-fmt/."
                                        (classical-target instr))))))
 
   ;; NOT can't be REAL
@@ -203,7 +203,7 @@
     (let ((mdesc (find-descriptor-for-mref (classical-target instr) memory-regions)))
       (adt:match quil-type (memory-descriptor-type mdesc)
         (quil-real
-         (quil-type-error "NOT argument should be a binary memory reference, but got ~/quil:instruction-fmt/"
+         (quil-type-error "NOT argument should be a binary memory reference, but got ~/quil:instruction-fmt/."
                           (classical-target instr)))
         (_
          (call-next-method)))))
@@ -260,18 +260,18 @@
             (find-descriptor-for-mref (mref (memory-name-region-name (classical-left-operand instr)) 0)
                                       memory-regions)))
       (unless mdesc
-        (quil-type-error "Memory region named ~A not found"
+        (quil-type-error "Memory region named ~A not found."
                          (memory-name-region-name (classical-left-operand instr))))
       (unless (constant-or-mref-typep (classical-target instr)
                                       (memory-descriptor-type mdesc)
                                       memory-regions)
-        (quil-type-error "Memory region types do not match for ~A and ~/quil:instruction-fmt/"
+        (quil-type-error "Memory region types do not match for ~A and ~/quil:instruction-fmt/."
                          (memory-name-region-name (classical-left-operand instr))
                          (classical-target instr)))
       (unless (constant-or-mref-typep (classical-right-operand instr)
                                       quil-integer
                                       memory-regions)
-        (quil-type-error "LOAD right operand must be an integer, but got ~A"
+        (quil-type-error "LOAD right operand must be an integer, but got ~A."
                          (classical-right-operand instr)))))
 
   ;; STORE requires agreement in outer two, INT in middle
@@ -289,13 +289,13 @@
                        (constant-or-mref-typep (classical-right-operand instr)
                                                quil-integer
                                                memory-regions)))
-        (quil-type-error "Memory region types do not match for ~A and ~/quil:instruction-fmt/"
+        (quil-type-error "Memory region types do not match for ~A and ~/quil:instruction-fmt/."
                          (memory-name-region-name (classical-target instr))
                          (classical-right-operand instr)))
       (unless (constant-or-mref-typep (classical-left-operand instr)
                                       quil-integer
                                       memory-regions)
-        (quil-type-error "STORE middle operand must be an INTEGER, but got ~/quil:instruction-fmt/"
+        (quil-type-error "STORE middle operand must be an INTEGER, but got ~/quil:instruction-fmt/."
                          (classical-left-operand instr)))))
 
   ;; comparison operators require bit target in first, agreement in last two
@@ -326,7 +326,7 @@
          t)
         (_
          (quil-type-error "MEASURE instruction target must be of type ~
-                           BIT or INTEGER, but got ~/quil:instruction-fmt/ of type ~A"
+                           BIT or INTEGER, but got ~/quil:instruction-fmt/ of type ~A."
                           (measure-address instr)
                           (quil-type-string (memory-descriptor-type mdesc)))))))
 

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -244,7 +244,7 @@ If both ENTERING and EXITING are null, signal an error."
            (format nil "~A~A" +entering-rewiring-prefix+ entering))
           ((not (null exiting))
            (format nil "~A~A" +exiting-rewiring-prefix+ exiting))
-          (t (error "MAKE-REWIRING-COMMENT: Both ENTERING and EXITING cannot be NULL")))))
+          (t (error "MAKE-REWIRING-COMMENT: Both ENTERING and EXITING cannot be NULL.")))))
 
 (defun instruction-rewirings (instruction)
   "Return the pair of entering and exiting rewirings associated with instruction.

--- a/src/clifford/clifford.lisp
+++ b/src/clifford/clifford.lisp
@@ -195,7 +195,7 @@ NOTE: THERE IS NO CHECKING OF THE VALIDITY OF THE MAP. ANTICOMMUTATIVITY IS NOT 
                   (assert (string= "->" arrow))
                   (assert (pauli-string-p from-name)
                           ()
-                          "The symbol ~S is not a Pauli basis element" from)
+                          "The symbol ~S is not a Pauli basis element." from)
                   ;; Get the max dimension
                   (a:maxf num-qubits (dimension from-name) (dimension to-name))
                   ;; Record the map.

--- a/src/clifford/god-table.lisp
+++ b/src/clifford/god-table.lisp
@@ -91,7 +91,7 @@ and J-th (target) qubit."
   ((cliffords :initarg :cliffords :reader cliffords)
    (names :initarg :names :reader names)
    (inverse-names :initarg :inverse-names :reader inverse-names))
-  (:documentation "Store a gateset definition"))
+  (:documentation "Store a gateset definition."))
 
 (defun gateset= (g1 g2)
   ;; The names and other things don't matter.

--- a/src/clifford/pauli.lisp
+++ b/src/clifford/pauli.lisp
@@ -69,7 +69,7 @@
     (typep b 'base4))
 
   (defun pack-base4 (x y)
-    "Bit pack X and Y (Y must be base 4)"
+    "Bit pack X and Y (Y must be base 4)."
     (check-type y base4)
     (logxor (ash x 2) y)))
 

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -980,7 +980,7 @@ FINISH-COMPILER is a local macro usable within a compiler body."
                                               (expand-arguments binding env
                                                                 (expand-options binding env body)))))
                (t
-                (error "Malformed binding in compiler form: ~a" binding))))
+                (error "Malformed binding in compiler form: ~a." binding))))
            
            (expand-sequence (seq env rest &key gensym-name seq-accessor gate-name elt-accessor elt-type test)
              (let* ((target-length (length seq))

--- a/src/define-pragma.lisp
+++ b/src/define-pragma.lisp
@@ -77,7 +77,7 @@ elements to ELT-TYPE.
                             (length raw-elements)))
         (mapcar (lambda (raw) (coerce raw elt-type)) raw-elements))
     (alexa:lexer-match-error (c)
-      (quil-parse-error "Lexer failure: ~A." c))))
+      (quil-parse-error "Lexer failure: ~A" c))))
 
 
 ;;;;;;;;;;;;;;;;;;;; Macroexpansion-time checking ;;;;;;;;;;;;;;;;;;;;

--- a/src/define-pragma.lisp
+++ b/src/define-pragma.lisp
@@ -63,21 +63,21 @@ elements to ELT-TYPE.
 "
   (when (zerop (length operator-def))
     (quil-parse-error "Malformed element list: ~
-                       Received empty string"))
+                       Received empty string."))
   (unless (char= (char operator-def 0) #\()
-    (quil-parse-error "Malformed element list: missing open parenthesis"))
+    (quil-parse-error "Malformed element list: missing open parenthesis."))
   (unless (char= (char operator-def (1- (length operator-def))) #\))
-    (quil-parse-error "Malformed element list: missing close parenthesis"))
+    (quil-parse-error "Malformed element list: missing close parenthesis."))
   (handler-case
       (let ((raw-elements (tokenize-line #'element-list-lexer operator-def)))
         (unless (= (length raw-elements) num-elements)
           (quil-parse-error "Malformed element list: ~
-			     expected ~D matrix element~:P, got ~D"
+			     expected ~D matrix element~:P, got ~D."
                             num-elements
                             (length raw-elements)))
         (mapcar (lambda (raw) (coerce raw elt-type)) raw-elements))
     (alexa:lexer-match-error (c)
-      (quil-parse-error "Lexer failure: ~A" c))))
+      (quil-parse-error "Lexer failure: ~A." c))))
 
 
 ;;;;;;;;;;;;;;;;;;;; Macroexpansion-time checking ;;;;;;;;;;;;;;;;;;;;
@@ -99,12 +99,12 @@ contains no duplicates."
          (unknown-options (set-difference provided-options
                                           *defpragma-option-keywords*)))
     (when unknown-options
-      (error "Unknown defpragma option~P:~{ ~S~}"
+      (error "Unknown defpragma option~P:~{ ~S~}."
              (length unknown-options)
              unknown-options))
     (maplist (lambda (s)
                (when (member (first s) (rest s))
-                 (error "Duplicate defpragma option: ~S" (first s))))
+                 (error "Duplicate defpragma option: ~S." (first s))))
              provided-options)
     t))
 
@@ -118,7 +118,7 @@ contains no duplicates."
                     lambda-list))
         (rest (position '&rest lambda-list)))
     (when forbidden
-      (error "Forbidden lambda list keyword~P in pragma lambda list: ~{~S~^ ~}"
+      (error "Forbidden lambda list keyword~P in pragma lambda list: ~{~S~^ ~}."
              (length forbidden) forbidden))
     (when rest
       (unless (= rest (- (length lambda-list) 2))
@@ -130,7 +130,7 @@ contains no duplicates."
   (let ((bad-names (intersection slot-names  (cons freeform-string-name
                                                    word-names))))
     (when bad-names
-      (error "Cannot share names between slots and words/freeform-string -- ~S"
+      (error "Cannot share names between slots and words/freeform-string -- ~S."
              bad-names))))
 
 
@@ -144,7 +144,7 @@ contains no duplicates."
          (name (pdef-name pdef))
          (pragma-class (pdef-class-name pdef )))
     (flet ((error-form (message)
-             `(error ,(format nil "Malformed pragma ~A -- ~A"
+             `(error ,(format nil "Malformed pragma ~A -- ~A."
                               name message))))
       (a:with-gensyms (class words freeform-string)
         `(defmethod check-pragma-arguments ((,class (eql ',pragma-class))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -178,7 +178,7 @@ INPUT-STRING that triggered the condition."
       (alexa:lexer-match-error (c)
         (multiple-value-bind (context-line failing-char)
             (tokenization-failure-context string c)
-          (quil-parse-error "unexpected input text ~S in ~S"
+          (quil-parse-error "Unexpected input text ~S in ~S."
                             (string failing-char)
                             context-line))))))
 
@@ -534,7 +534,7 @@ result of BODY, and the (possibly null) list of remaining lines.
     (number (constant arg-tok))
     (param
      (unless *formal-arguments-allowed*
-       (quil-parse-error "Found formal parameter where not allowed: ~S"
+       (quil-parse-error "Found formal parameter where not allowed: ~S."
                          arg-tok))
      arg-tok)
     (token
@@ -542,7 +542,7 @@ result of BODY, and the (possibly null) list of remaining lines.
        (case type
          ((:PARAMETER)
           (unless *formal-arguments-allowed*
-            (quil-parse-error "Found formal parameter where not allowed: ~S"
+            (quil-parse-error "Found formal parameter where not allowed: ~S."
                               (token-payload arg-tok)))
           (token-payload arg-tok))
          ((:COMPLEX)
@@ -550,8 +550,8 @@ result of BODY, and the (possibly null) list of remaining lines.
          ((:INTEGER)
           (constant (coerce (token-payload arg-tok) 'double-float)))
          (otherwise
-          (quil-parse-error "Token doesn't represent a parameter where expected: ~S" arg-tok)))))
-    (t (quil-parse-error "Unexpected token type ~S: ~S"
+          (quil-parse-error "Token doesn't represent a parameter where expected: ~S." arg-tok)))))
+    (t (quil-parse-error "Unexpected token type ~S: ~S."
                          (type-of arg-tok)
                          arg-tok))))
 
@@ -564,7 +564,7 @@ result of BODY, and the (possibly null) list of remaining lines.
                                         :test #'string=)))
        (unless (or names-memory-region-p
                    *formal-arguments-allowed*)
-         (quil-parse-error "Found formal argument where not allowed: ~S"
+         (quil-parse-error "Found formal argument where not allowed: ~S."
                            (token-payload arg-tok)))
        (if names-memory-region-p
            (mref (token-payload arg-tok) 0)
@@ -577,7 +577,7 @@ result of BODY, and the (possibly null) list of remaining lines.
      (mref (car (token-payload arg-tok))
            (cdr (token-payload arg-tok))))
     (otherwise
-     (quil-parse-error "Token doesn't represent an argument where expected: ~S" arg-tok))))
+     (quil-parse-error "Token doesn't represent an argument where expected: ~S." arg-tok))))
 
 ;; Dear reader:
 ;;
@@ -660,7 +660,7 @@ result of BODY, and the (possibly null) list of remaining lines.
       ;; Check that we are starting out with a :NAME, representing the
       ;; name of the gate or circuit.
       (unless (eql ':NAME (token-type op))
-        (quil-parse-error "Gate/circuit application needs a name. Got ~S"
+        (quil-parse-error "Gate/circuit application needs a name. Got ~S."
                           (token-type op)))
 
       ;; Check for anything following the name.
@@ -761,7 +761,7 @@ result of BODY, and the (possibly null) list of remaining lines.
                   ;; Actual address to measure into.
                   ((eql ':AREF (token-type address))
                    (unless (find (car (token-payload address)) *memory-region-names* :test #'string=)
-                     (quil-parse-error "Bad memory region name ~a in MEASURE instruction" (car (token-payload address))))
+                     (quil-parse-error "Bad memory region name ~a in MEASURE instruction." (car (token-payload address))))
                    (mref (car (token-payload address))
                          (cdr (token-payload address))))
 
@@ -777,7 +777,7 @@ result of BODY, and the (possibly null) list of remaining lines.
                    (formal (token-payload address)))
 
                   (t
-                   (quil-parse-error "Expected address after MEASURE")))))
+                   (quil-parse-error "Expected address after MEASURE.")))))
           (make-instance 'measure
                          :qubit qubit
                          :address address-obj)))))
@@ -843,16 +843,16 @@ result of BODY, and the (possibly null) list of remaining lines.
       (destructuring-bind (op . params-args) parameter-line
         ;; Check that we are dealing with a DEFGATE.
         (unless (eql ':DEFGATE (token-type op))
-          (quil-parse-error "DEFGATE expected. Got ~S"
+          (quil-parse-error "DEFGATE expected. Got ~S."
                             (token-type op)))
 
         ;; Check that something is following the DEFGATE.
         (when (null params-args)
-          (quil-parse-error "Expected more after DEFGATE token"))
+          (quil-parse-error "Expected more after DEFGATE token."))
 
         ;; Check for a name.
         (unless (eql ':NAME (token-type (first params-args)))
-          (quil-parse-error "Expected a name for the DEFGATE"))
+          (quil-parse-error "Expected a name for the DEFGATE."))
 
         ;; We have a name. Stash it away.
         (setf name (token-payload (pop params-args)))
@@ -871,7 +871,7 @@ result of BODY, and the (possibly null) list of remaining lines.
                           params-args)
             ;; ... or error if it doesn't exist.
             (when (null rest-line)
-              (quil-parse-error "No matching right paren in DEFGATE params"))
+              (quil-parse-error "No matching right paren in DEFGATE params."))
 
             ;; Remove right paren.
             (pop rest-line)
@@ -882,12 +882,12 @@ result of BODY, and the (possibly null) list of remaining lines.
                          (loop :for c :in (rest found-params) :by #'cddr
                                :always (eql ':COMMA (token-type c))))
               ;; TODO Some printer for tokens?
-              (quil-parse-error "Malformed parameter list in DEFGATE: ~A" found-params))
+              (quil-parse-error "Malformed parameter list in DEFGATE: ~A." found-params))
             ;; Go through the supposed parameters, checking that they
             ;; are, and parsing them out.
             (setf params (loop :for p :in (remove ':comma found-params :key #'token-type)
                                :when (not (eql ':PARAMETER (token-type p)))
-                                 :do (quil-parse-error "Found something other than a parameter in a DEFGATE parameter list. ~A" p)
+                                 :do (quil-parse-error "Found something other than a parameter in a DEFGATE parameter list: ~A." p)
                                :collect (parse-parameter p)))))
 
         (when (eql ':AS (token-type (first params-args)))
@@ -1030,7 +1030,7 @@ result of BODY, and the (possibly null) list of remaining lines.
                                  modified-line)))
         (unless (every (lambda (tok) (eql ':INTEGER (token-type tok)))
                        entries)
-          (quil-parse-error "Expected integers"))
+          (quil-parse-error "Expected integers."))
         ;; Be careful to continue parsing only when a (by definition) dedented
         ;; line follows
         (values (mapcar #'token-payload entries)
@@ -1068,7 +1068,7 @@ result of BODY, and the (possibly null) list of remaining lines.
 
   ;; Check that we have tokens left to parse.
   (when (null tok-lines)
-    (quil-parse-error "EOF reached when circuit definition expected"))
+    (quil-parse-error "EOF reached when circuit definition expected."))
 
   (let (name params args)
     ;; Split off the header line from the body lines.
@@ -1077,16 +1077,16 @@ result of BODY, and the (possibly null) list of remaining lines.
       (destructuring-bind (op . params-args) parameter-line
         ;; We must be working with a DEFCIRCUIT.
         (unless (eql ':DEFCIRCUIT (token-type op))
-          (quil-parse-error "DEFCIRCUIT expected. Got ~S"
+          (quil-parse-error "DEFCIRCUIT expected. Got ~S."
                             (token-type op)))
 
         ;; Check that there are tokens following DEFCIRCUIT.
         (when (null params-args)
-          (quil-parse-error "Expected more after DEFCIRCUIT token"))
+          (quil-parse-error "Expected more after DEFCIRCUIT token."))
 
         ;; Check for name.
         (unless (eql ':NAME (token-type (first params-args)))
-          (quil-parse-error "Expected a name for the DEFCIRCUIT"))
+          (quil-parse-error "Expected a name for the DEFCIRCUIT."))
 
         ;; Stash it away.
         (setf name (token-payload (pop params-args)))
@@ -1104,7 +1104,7 @@ result of BODY, and the (possibly null) list of remaining lines.
 
             ;; Error if we didn't find a right parenthesis.
             (when (null rest-line)
-              (quil-parse-error "No matching right paren in DEFCIRCUIT params"))
+              (quil-parse-error "No matching right paren in DEFCIRCUIT params."))
 
             ;; Remove right paren and stash away params.
             (pop rest-line)
@@ -1115,11 +1115,11 @@ result of BODY, and the (possibly null) list of remaining lines.
                          (loop :for c :in (rest found-params) :by #'cddr
                                :always (eql ':COMMA (token-type c))))
               ;; TODO Some printer for tokens?
-              (quil-parse-error "Malformed parameter list in DEFCIRCUIT: ~A" found-params))
+              (quil-parse-error "Malformed parameter list in DEFCIRCUIT: ~A." found-params))
             ;; Parse out the parameters.
             (setf params (loop :for p :in (remove ':COMMA found-params :key #'token-type)
                                :when (not (eql ':PARAMETER (token-type p)))
-                                 :do (quil-parse-error "Found something other than a parameter in a DEFCIRCUIT parameter list: ~A" p)
+                                 :do (quil-parse-error "Found something other than a parameter in a DEFCIRCUIT parameter list: ~A." p)
                                :collect (parse-parameter p))
                   params-args rest-line)))
 
@@ -1127,7 +1127,7 @@ result of BODY, and the (possibly null) list of remaining lines.
         (let ((maybe-colon (last params-args)))
           (when (or (null maybe-colon)
                     (not (eql ':COLON (token-type (first maybe-colon)))))
-            (quil-parse-error "Expected a colon in DEFCIRCUIT"))
+            (quil-parse-error "Expected a colon in DEFCIRCUIT."))
           (setf params-args (butlast params-args)))
 
         ;; Collect arguments and stash them away.
@@ -1157,7 +1157,7 @@ result of BODY, and the (possibly null) list of remaining lines.
 (defun parse-memory-descriptor (tok-lines)
   "Parse a memory location declaration out of the lines of tokens TOK-LINES."
   (when (null tok-lines)
-    (quil-parse-error "Expected DECLARE, reached EOF"))
+    (quil-parse-error "Expected DECLARE, reached EOF."))
 
   (let ((line (rest (first tok-lines)))
         name
@@ -1191,7 +1191,7 @@ result of BODY, and the (possibly null) list of remaining lines.
       ;; Get the parent.
       (let ((parent-name (token-payload (pop line))))
         (unless (member parent-name *memory-region-names* :test #'string=)
-          (quil-parse-error "Unknown parent ~a of ~a" parent-name name))
+          (quil-parse-error "Unknown parent ~a of ~a." parent-name name))
         (setf sharing-parent parent-name))
       ;; Check if there's an OFFSET.
       (unless (endp line)
@@ -1250,7 +1250,7 @@ result of BODY, and the (possibly null) list of remaining lines.
           *formal-arguments-allowed*)
      (formal (token-payload tok)))
     (t
-     (quil-parse-error "Expected an address~:[~; or formal argument~], got ~S"
+     (quil-parse-error "Expected an address~:[~; or formal argument~], got ~S."
                        *formal-arguments-allowed*
                        (token-type tok)))))
 
@@ -1270,7 +1270,7 @@ result of BODY, and the (possibly null) list of remaining lines.
         (etypecase result
           (integer (constant result quil-integer))
           (real (constant result quil-real))
-          (complex (quil-parse-error "Unexpected complex number: ~A" result))))))
+          (complex (quil-parse-error "Unexpected complex number: ~A." result))))))
 
 (defun parse-memory-offset (tok)
   (cond
@@ -1283,7 +1283,7 @@ result of BODY, and the (possibly null) list of remaining lines.
   (match-line ((jump jump-type) (label :LABEL-NAME) addr) tok-lines
     (unless (or (eql ':AREF (token-type addr))
                 (eql ':NAME (token-type addr)))
-      (quil-parse-error "Expected an address~:[~; or formal argument~] for conditional jump, got ~S" *formal-arguments-allowed* (token-type addr)))
+      (quil-parse-error "Expected an address~:[~; or formal argument~] for conditional jump, got ~S." *formal-arguments-allowed* (token-type addr)))
     (make-instance (ecase jump-type
                      ((:JUMP-WHEN) 'jump-when)
                      ((:JUMP-UNLESS) 'jump-unless))
@@ -1307,7 +1307,7 @@ result of BODY, and the (possibly null) list of remaining lines.
       (when (and (member (token-type instr) '(:EXCHANGE :CONVERT))
                  (not (or (typep right 'memory-ref)
                           (typep right 'formal))))
-        (quil-parse-error "Second argument of EXCHANGE/CONVERT command expected to be a memory address, but got ~S"
+        (quil-parse-error "Second argument of EXCHANGE/CONVERT command expected to be a memory address, but got ~S."
                           (type-of right)))
       (ecase tok-type
         (:AND (make-instance 'classical-and :left left :right right))
@@ -1327,10 +1327,10 @@ result of BODY, and the (possibly null) list of remaining lines.
     (setf right (cons right rest))
     (flet ((parse-memory-region-name (tok)
                (unless (eql ':NAME (token-type tok))
-                 (quil-parse-error "Expected a memory region name, but got token of type ~S"
+                 (quil-parse-error "Expected a memory region name, but got token of type ~S."
                                    (token-type tok)))
                (unless (find (token-payload tok) *memory-region-names* :test #'string=)
-                 (quil-parse-error "Unknown memory region name ~S"
+                 (quil-parse-error "Unknown memory region name ~S."
                                    (token-payload tok)))
              (memory-name (token-payload tok))))
       (ecase tok-type
@@ -1543,7 +1543,7 @@ result of BODY, and the (possibly null) list of remaining lines.
   (defun validate-function (func-name)
     "Return the lisp symbol that corresponds to the Quil function named FUNC-NAME, or signal a QUIL-PARSE-ERROR if FUNC-NAME is invalid."
     (or (quil-function->lisp-symbol func-name)
-        (quil-parse-error "Invalid function name: ~A" func-name)))
+        (quil-parse-error "Invalid function name: ~A." func-name)))
 
   (defun find-or-make-parameter-symbol (param)
     (let ((found (assoc (param-name param)
@@ -1561,7 +1561,7 @@ result of BODY, and the (possibly null) list of remaining lines.
     (let ((region-name (car aref))
           (region-position (cdr aref)))
       (unless (find region-name *memory-region-names* :test #'string=)
-        (error "Reference to unknown memory region ~a" region-name))
+        (error "Reference to unknown memory region ~a." region-name))
       (setf *segment-encountered* t)
       (mref region-name region-position))))
 

--- a/src/transformable-mixin.lisp
+++ b/src/transformable-mixin.lisp
@@ -68,7 +68,7 @@
 
 If any of its predecessors have not been performed, return NIL and the first one found that hasn't been performed."
   (let ((descr (find-transform xform)))
-    (assert (not (null descr)) (xform) "Unknown transform ~S" xform)
+    (assert (not (null descr)) (xform) "Unknown transform ~S." xform)
     (dolist (pred (transform-description-predecessors descr)
              ;; Return T on success
              (values t nil))


### PR DESCRIPTION
There seem to be three general options at the end of a sentence: a question mark, an exclamation mark, or a period. This PR adopts the latter as the "default" option in several error messages and docstrings. I doubt that we have 100% coverage here, but that's just how it goes.

In the process of adding periods, I spotted some questionable multi-line docstrings. I will leave these for a later PR.