### PR TITLE
Fix docstring typos for UPDATE-PRINT-PARSED-PROGRAM-GOLDEN-FILES

### DIFF
--- a/tests/printer-tests.lisp
+++ b/tests/printer-tests.lisp
@@ -25,17 +25,11 @@
     (funcall printer (funcall parser input) s)))
 
 (defun update-print-parsed-program-golden-files (&key skip-prompt)
-  "Call UPDATE-PRINT-PARSED-PROGRAM-GOLDEN-FILES on all the files in the gold-standard subdirectory
-of *PRINTER-TEST-FILES-DIRECTORY*.
+  "Call UPDATE-GOLDEN-FILE-OUTPUT-SECTIONS on all the files in the gold-standard subdirectory of *PRINTER-TEST-FILES-DIRECTORY*.
 
-We limit updating of golden files to the gold-standard directory because they are the only ones that
-can be easily updated in an automated fashion. The files in the gold-regex directory make use of
-regexes in their output sections, which makes automated update complicated. The number of
-regex-enabled tests is small, so updating them by hand shouldn't be too tedious. You can always call
-UPDATE-GOLDEN-FILE-OUTPUT-SECTIONS on them manually, then re-instate any required regexes.
+We limit updating of golden files to the gold-standard directory because they are the only ones that can be easily updated in an automated fashion. The files in the gold-regex directory make use of regexes in their output sections, which makes automated update complicated. The number of regex-enabled tests is small, so updating them by hand shouldn't be too tedious. You can always call UPDATE-GOLDEN-FILE-OUTPUT-SECTIONS on them manually, then re-instate any required regexes.
 
-See the documentation string for UPDATE-PRINT-PARSED-PROGRAM-GOLDEN-FILES for more info and an
-admonition against carelessness."
+See the documentation string for UPDATE-GOLDEN-FILE-OUTPUT-SECTIONS for more info and an admonition against carelessness."
   (update-golden-file-output-sections
    (uiop:directory-files *printer-test-files-gold-standard-directory* #P"*.quil")
    #'parse-and-print-quil-to-string
@@ -43,8 +37,7 @@ admonition against carelessness."
 
 
 (defun %golden-parse-print-tester (check-output)
-  "Return a function that can be passed to MAP-GOLDEN-FILES-AND-TEST-CASES which uses CHECK-OUTPUT
-to compare output sections.
+  "Return a function that can be passed to MAP-GOLDEN-FILES-AND-TEST-CASES which uses CHECK-OUTPUT to compare output sections.
 
 %GOLDEN-PARSE-PRINT-TESTER is a helper function for TEST-PRINT-PARSED-PROGRAM-GOLDEN-FILES."
   (check-type check-output function)

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -193,7 +193,7 @@ If SUFFIX-P is non-nil, suffix the returned string with DELIMITER."
 ;;; other means. Just keep in mind the above comments about trailing newlines.
 ;;;
 ;;;
-;;; ADDING NEW INPUT/OUTPUT pairs
+;;; ADDING NEW INPUT/OUTPUT PAIRS
 ;;;
 ;;; You can also use UPDATE-GOLDEN-FILE-OUTPUT-SECTIONS to add new outputs to a golden file without
 ;;; the need to copy/paste or fiddle with trailing-newline matching. For example, if you add the


### PR DESCRIPTION
And submit to the no-newlines-in-docstrings convention 😞.

Also, capitalize "pairs" in section heading of the golden files comment in utilities.lisp.