### PR TITLE
Pull latest Aspen devices into structured dirs

### DIFF
--- a/tests/qpu-test-files/update_aspen_qpu_files.py
+++ b/tests/qpu-test-files/update_aspen_qpu_files.py
@@ -35,7 +35,6 @@ def main():
             # "device" as a property. Hopefully it contains it as a
             # substring of its own name.
             if device in lattice.name:
-                print(lattice.__dir__())
                 print(lattice.name, file=sys.stderr)
                 with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
                     json.dump(device_to_chipspec(lattice, timestamp=now), f, indent=2)

--- a/tests/qpu-test-files/update_aspen_qpu_files.py
+++ b/tests/qpu-test-files/update_aspen_qpu_files.py
@@ -29,10 +29,16 @@ def main():
     for device in list_devices():
         os.makedirs(os.path.join(device, now), exist_ok=True)
 
-    for lattice in map(get_lattice, list_quantum_computers(qvms=False)):
-        print(lattice.name, file=sys.stderr)
-        with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
-            json.dump(device_to_chipspec(lattice, timestamp=now), f, indent=2)
+        for lattice in map(get_lattice, list_quantum_computers(qvms=False)):
+            # This is a bit hacky. The "lattice" object (really a
+            # device object) doesn't contain the name of its parent
+            # "device" as a property. Hopefully it contains it as a
+            # substring of its own name.
+            if device in lattice.name:
+                print(lattice.__dir__())
+                print(lattice.name, file=sys.stderr)
+                with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
+                    json.dump(device_to_chipspec(lattice, timestamp=now), f, indent=2)
 
     try:
         os.unlink(f"{device}/latest")

--- a/tests/qpu-test-files/update_aspen_qpu_files.py
+++ b/tests/qpu-test-files/update_aspen_qpu_files.py
@@ -25,7 +25,6 @@ qpu_dir = "{}/{}/{}.qpu"
 
 def main():
     now = str(datetime.datetime.today())
-    print(list_devices())
     for device in list_devices():
         os.makedirs(os.path.join(device, now), exist_ok=True)
 

--- a/tests/qpu-test-files/update_aspen_qpu_files.py
+++ b/tests/qpu-test-files/update_aspen_qpu_files.py
@@ -34,7 +34,11 @@ def main():
         with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
             json.dump(device_to_chipspec(lattice, timestamp=now), f, indent=2)
 
-    os.unlink(f"{device}/latest")
+    try:
+        os.unlink(f"{device}/latest")
+    except FileNotFoundError:
+        pass
+
     os.symlink(f"{now}", f"{device}/latest")
 
 

--- a/tests/qpu-test-files/update_aspen_qpu_files.py
+++ b/tests/qpu-test-files/update_aspen_qpu_files.py
@@ -8,7 +8,7 @@ import sys
 import os
 
 from pyquil.api import list_quantum_computers
-from pyquil.api._devices import get_lattice, list_devices
+from pyquil.api._devices import get_lattice, list_devices, list_lattices
 
 
 def device_to_chipspec(device, version=0.0, timestamp=None):
@@ -28,15 +28,11 @@ def main():
     for device in list_devices():
         os.makedirs(os.path.join(device, now), exist_ok=True)
 
-        for lattice in map(get_lattice, list_quantum_computers(qvms=False)):
-            # This is a bit hacky. The "lattice" object (really a
-            # device object) doesn't contain the name of its parent
-            # "device" as a property. Hopefully it contains it as a
-            # substring of its own name.
-            if device in lattice.name:
-                print(lattice.name, file=sys.stderr)
-                with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
-                    json.dump(device_to_chipspec(lattice, timestamp=now), f, indent=2)
+        for lattice in map(get_lattice, list_lattices(device_name=device)):
+            print(lattice.name, file=sys.stderr)
+            with open(qpu_dir.format(device, now, lattice.name), 'w') as f:
+                json.dump(device_to_chipspec(lattice, timestamp=now),
+                          f, indent=2)
 
     try:
         os.unlink(f"{device}/latest")


### PR DESCRIPTION
The latest e.g. Aspen-4 chip will be available under ./tests/qpu-test-files/Aspen-4/latest (symlinked appropriately).