### PR TITLE
Use "quilc" rather than argv[0] for syslog name

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -305,17 +305,6 @@
       (format *error-output* "~&! ! ! Error: ~A~%" c)
       (uiop:quit 1))))
 
-(defun clamp-syslog-name (name)
-  "Produces a name like \"<A>...<B>\" where <A> is a 15-char chunk
-from the beginning of the name, and <B> is a 30-char chunk from the
-end of the name."
-  (let ((len (length name)))
-    (if (<= len 48)
-        name
-        (format nil "~A...~A"
-                (subseq name 0 15)
-                (subseq name (- (length name) 30))))))
-
 (defun %entry-point (argv)
   (let ((*program-name* (pop argv)))
     (command-line-arguments:handle-command-line
@@ -410,7 +399,7 @@ end of the name."
 
   (setf *logger*
         (make-instance 'cl-syslog:rfc5424-logger
-                       :app-name (clamp-syslog-name *program-name*)
+                       :app-name "quilc"
                        :facility ':local0
                        :maximum-priority *log-level*
                        :log-writer
@@ -438,7 +427,7 @@ Version ~A is available from https://downloads.rigetti.com/~%"
       ((*log-level* (or (and log-level (log-level-string-to-symbol log-level))
 			*log-level*))
        (*logger* (make-instance 'cl-syslog:rfc5424-logger
-				:app-name (clamp-syslog-name *program-name*)
+				:app-name "quilc"
 				:facility ':local0
 				:maximum-priority *log-level*
 				:log-writer


### PR DESCRIPTION
As is done in QVM. Could alternatively sanitise the name, but that's more work for little gain.