### PR TITLE
wildcard ISAs

### DIFF
--- a/src/chip/chip-reader.lisp
+++ b/src/chip/chip-reader.lisp
@@ -119,6 +119,8 @@
       ((string= "MEASURE" (gethash "operator" gate-datum))
        (make-measure-binding :target (intern-if-string (gethash "target" gate-datum))
                              :qubit (intern-if-string (gethash "qubit" gate-datum))))
+      ((string= "_" (gethash "operator" gate-datum))
+       (make-wildcard-binding))
       (t
        (multiple-value-bind (operator op-p) (gethash "operator" gate-datum)
          (unless op-p (error 'missing-gates-default-value

--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -143,7 +143,7 @@ MISC-DATA is a hash-table of miscellaneous data associated to this hardware obje
 Used to be an anonymous function associated to HARDWARE-OBJECT; now computed from its GATE-INFORMATION table."
   (a:when-let ((gate-record
                 (loop :for key :being :the :hash-keys :of (hardware-object-gate-information obj)
-                      :using (hash-value value)
+                        :using (hash-value value)
                       :when (binding-subsumes-p key (get-binding-from-instr instr))
                         :do (return value))))
     (gate-record-duration gate-record)))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -596,6 +596,7 @@ other's."
         (let ((result-instructions
                 (cond
                   ((and decompiled-instructions
+                        (not (equalp decompiled-instructions reduced-decompiled-instructions))
                         (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
                            (calculate-instructions-duration reduced-instructions chip-specification)))
                    reduced-decompiled-instructions)

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -716,7 +716,7 @@ N.B.: The word \"shortest\" here is a bit fuzzy.  In practice it typically means
           (loop :for binding :being :the :hash-keys :of gateset
                 :never (wildcard-binding-p binding))
           (or
-           ;; have cleared these checks, we support two kinds of matches:
+           ;; having cleared these checks, we support two kinds of matches:
            ;; (1) a "blind" match, where we can tell just by considering bindings
            ;;     that the compiler will always have reasonable input and output
            ;; (2) an "exhaustive" match, where we instantiate different test cases

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -348,7 +348,8 @@ OPTIONS: plist of options governing applicability of the compiler binding."
   (:method ((binding gate-binding))
     (when (symbolp (gate-binding-operator binding))
       (error 'cannot-concretize-binding))
-    (when (some #'symbolp (gate-binding-parameters binding))
+    (when (or (symbolp (gate-binding-parameters binding))
+              (some #'symbolp (gate-binding-parameters binding)))
       (error 'cannot-concretize-binding))
     (when (some #'symbolp (gate-binding-arguments binding))
       (error 'cannot-concretize-binding))
@@ -589,7 +590,7 @@ N.B.: The word \"shortest\" here is a bit fuzzy.  In practice it typically means
 
 (defun compute-applicable-compilers (target-gateset qubit-count) ; h/t lisp
   "Starting from all available compilers, constructs a precedence-sorted list of those compilers which help to convert from arbitrary inputs to a particular target gateset."
-  (flet ( ;; Checks whether PATH doubles back through the occurrence table START.         
+  (flet (;; Checks whether PATH doubles back through the occurrence table START.         
          (path-has-a-loop-p (path start)
            (and (< 1 (length path))
                 (loop :for (gateset compiler) :on path :by #'cddr
@@ -707,18 +708,20 @@ N.B.: The word \"shortest\" here is a bit fuzzy.  In practice it typically means
            (compiler-does-not-apply () nil)
            (cannot-concretize-binding () nil)))
        (consider-compiler (compiler)
-         ;; certain things we will never tolerate:
-         ;; (1) unguarded matches will always result in infinite loops.
          (and
+          ;; certain things we will never tolerate:
+          ;; (1) unguarded matches will always result in infinite loops.
           (notany #'unguarded-binding-p (compiler-bindings compiler))
-          ;; have cleared these checks, we support two kinds of matches:
-          ;; (1) a "blind" match, where we can tell just by considering bindings
-          ;;     that the compiler will always have reasonable input and output
-          ;; (2) an "exhaustive" match, where we instantiate different test cases
-          ;;     to pump through the compiler, convincing ourselves that in all
-          ;;     applicable situations the compiler gives good output.
+          ;; (2) unguarded gatesets don't benefit from reduction
+          (loop :for binding :being :the :hash-keys :of gateset
+                :never (wildcard-binding-p binding))
           (or
-           ;; first try the blind match
+           ;; have cleared these checks, we support two kinds of matches:
+           ;; (1) a "blind" match, where we can tell just by considering bindings
+           ;;     that the compiler will always have reasonable input and output
+           ;; (2) an "exhaustive" match, where we instantiate different test cases
+           ;;     to pump through the compiler, convincing ourselves that in all
+           ;;     applicable situations the compiler gives good output.
            (let* ((gateset (blank-out-qubits gateset))
                   (in-fidelity 1d0)
                   (out-fidelity (occurrence-table-cost (compiler-output-gates compiler) gateset)))


### PR DESCRIPTION
Adds support for an ISA operator field to be specified as `"_"`, which permits the consumption of any gate. This leads to addresser behavior like:
```
(let ((chip (qpu-hash-table-to-chip-specification
                   (yason:parse "
{\"isa\":
 {\"1Q\":
  {\"0\":
    {\"gates\": [{\"operator\": \"_\", \"parameters\": \"_\", \"arguments\": [\"_\"]}]},
   \"1\":
    {\"gates\": [{\"operator\": \"_\", \"parameters\": \"_\", \"arguments\": [\"_\"]}]},
   \"2\":
    {\"gates\": [{\"operator\": \"_\", \"parameters\": \"_\", \"arguments\": [\"_\"]}]}},
  \"2Q\":
   {\"0-1\":
    {\"gates\": [{\"operator\": \"_\", \"parameters\": \"_\", \"arguments\": [\"_\", \"_\"]}]},
    \"1-2\":
    {\"gates\": [{\"operator\": \"_\", \"parameters\": \"_\", \"arguments\": [\"_\", \"_\"]}]},
}}}"))))
        (print-parsed-program
         (compiler-hook (parse-quil "
CZ 0 1
CZ 1 2
CZ 2 0") chip)))

CZ 2 1                                  # Entering rewiring: #(2 1 0)
CZ 1 0
SWAP 1 2
CZ 0 1
HALT                                    # Exiting rewiring: #(1 2 0)
```
which goes part of the way to satisfying a long-standing user ask. (The remaining part is to allow selective disabling of gate reduction.)