### PR TITLE
expose WITH-INST and friends

### DIFF
--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -1,5 +1,5 @@
 ;;;; build-gate.lisp
-;;;; 
+;;;;
 ;;;; Author: Eric Peterson
 ;;;;
 ;;;; This file collects the gate-construction routines in CL-QUIL which are

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -469,7 +469,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
                                    :permit-binding-mismatches-when *enable-approximate-compilation*)
              ,docstring
 	     ,@decls
-             (let ((,circuit (with-inst ,@body))
+             (let ((,circuit (with-inst () ,@body))
                    (,coord (mapcar #'constant-value (application-parameters ,instr-name)))
                    (,q1 (qubit-index (first (application-arguments ,instr-name))))
                    (,q0 (qubit-index (second (application-arguments ,instr-name)))))
@@ -497,7 +497,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 	 ,@decls
          (labels
              ((circuit-template (,parameter-array ,q1 ,q0)
-                (with-inst
+                (with-inst ()
                   ,@parametric-circuit))
               (run-optimizer ()
                 (multiple-value-bind (,template-values ,goodness)
@@ -617,7 +617,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
           (inst "Z"     ()              q1)
           (dolist (instr
                    (sandwich-with-local-gates
-                    (with-inst
+                    (with-inst ()
                       (inst "ISWAP" '()       q1 q0)
                       (inst "RY"    `(,alpha) q1)
                       (inst "RY"    `(,beta)  q0)

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -881,7 +881,8 @@ INST* is a local function usable within the dynamic extent of a compiler body."
 FINISH-COMPILER is a local macro usable within a compiler body."
   (error "FINISH-COMPILER can only be used in the body of a compiler."))
 
-(defmacro with-inst (&body body)
+;;; The empty list is so that options can be provided in the future.
+(defmacro with-inst (() &body body)
   "Define INST, INST*, and FINISH-COMPILER handlers extending over BODY."
   (a:with-gensyms (list tail compiler-context x xs retval-p)
     `(block ,compiler-context
@@ -959,7 +960,7 @@ FINISH-COMPILER is a local macro usable within a compiler body."
   (labels ((expand-bindings (bindings env)
              (cond
                ((endp bindings)
-                `(values (with-inst ,@body)
+                `(values (with-inst () ,@body)
                          t))
                ((typep (first bindings) 'symbol)
                 (expand-bindings (rest bindings)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -409,6 +409,20 @@
    #:quil-parse-error                   ; CONDITION
    )
 
+  ;; build-gate.lisp
+  (:export
+   #:build-gate                         ; FUNCTION
+   #:anon-gate                          ; FUNCTION
+   )
+
+  ;; define-compiler.lisp
+  (:export
+   #:with-inst                          ; MACRO
+   #:inst                               ; LOCAL FUNCTION
+   #:inst*                              ; LOCAL FUNCTION
+   #:finish-compiler                    ; LOCAL MACRO
+   )
+
   ;; desugar.lisp
   (:export
    #:qubits-needed                      ; FUNCTION


### PR DESCRIPTION
We export a few internal functions so that building Quil can be an easier affair.

This also changes the syntax of WITH-INST ever so slightly to allow future extensions and stuff.