### PR TITLE
asynchronously check for version update

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -413,14 +413,6 @@
                                   (cl-syslog:syslog-log-writer "quilc" :local0)
                                   *error-output*)))
 
-  (when check-sdk-version
-    (multiple-value-bind (available-p version)
-        (sdk-update-available-p +QUILC-VERSION+ :proxy proxy)
-      (when available-p
-        (format t "An update is available to the SDK. You have version ~A. ~
-Version ~A is available from https://downloads.rigetti.com/~%"
-                +QUILC-VERSION+ version))))
-
   #-forest-sdk
   (when benchmark
     (benchmarks))
@@ -449,6 +441,9 @@ Version ~A is available from https://downloads.rigetti.com/~%"
        (*quil-stream* (make-broadcast-stream))
        (*verbose* (make-broadcast-stream))
        (*protoquil* protoquil))
+
+    (when check-sdk-version
+      (asynchronously-indicate-update-availability +QUILC-VERSION+ :proxy proxy))
     ;; at this point we know we're doing something. strap in LAPACK.
     (magicl:with-blapack
       (reload-foreign-libraries)

--- a/app/tests/faithfulness-tests.lisp
+++ b/app/tests/faithfulness-tests.lisp
@@ -25,5 +25,5 @@
                       (with-output-to-string (*error-output*)
                         (locally
                             (declare #+sbcl(sb-ext:muffle-conditions style-warning))
-                          (quilc::%entry-point (list "quilc" "-mP")))))
+                          (quilc::%entry-point (list "quilc" "-mP" "--check-sdk-version=no")))))
                     :from-end t))))))

--- a/app/tests/misc-tests.lisp
+++ b/app/tests/misc-tests.lisp
@@ -5,22 +5,19 @@
 (in-package #:quilc-tests)
 
 (deftest test-update-available ()
-  (multiple-value-bind (update-available-p update)
-      (quilc::sdk-update-available-p "0.0.0")
-    (if update-available-p
-        ;; If the network is down, then update-available-p is NIL, but
-        ;; we don't want to error in that case. Skip instead.
-        (is update)
-        (skip)))
-
   (with-mocked-function-definitions
-      ((quilc::latest-sdk-version (lambda (&rest args)
+      ((quilc::query-latest-sdk-version (lambda (&rest args)
                                     (declare (ignore args))
                                     "1.0.0")))
     (multiple-value-bind (update-available-p update)
         (quilc::sdk-update-available-p "1.5.0")
       (declare (ignore update))
-      (is (not update-available-p)))))
+      (is (not update-available-p)))
+
+    (multiple-value-bind (update-available-p update)
+        (quilc::sdk-update-available-p "0.1.0")
+      (declare (ignore update))
+      (is update-available-p))))
 
 (deftest test-process-program ()
   (let ((progm "H 0")

--- a/app/tests/misc-tests.lisp
+++ b/app/tests/misc-tests.lisp
@@ -7,8 +7,8 @@
 (deftest test-update-available ()
   (with-mocked-function-definitions
       ((quilc::query-latest-sdk-version (lambda (&rest args)
-                                    (declare (ignore args))
-                                    "1.0.0")))
+                                          (declare (ignore args))
+                                          "1.0.0")))
     (multiple-value-bind (update-available-p update)
         (quilc::sdk-update-available-p "1.5.0")
       (declare (ignore update))


### PR DESCRIPTION
This will start a thread to check the version to avoid having a delay for the network request. It will report to the log what's going on.