### PR TITLE
Fix parametric RZ agglutination

### DIFF
--- a/cl-quil-tests.asd
+++ b/cl-quil-tests.asd
@@ -7,6 +7,7 @@
   :author "Robert Smith <robert@rigetti.com>"
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:cl-quil
+               #:quilc
                (:version #:qvm "1.9.0")
                #:magicl
                #:alexandria

--- a/cl-quil-tests.asd
+++ b/cl-quil-tests.asd
@@ -7,7 +7,6 @@
   :author "Robert Smith <robert@rigetti.com>"
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:cl-quil
-               #:quilc
                (:version #:qvm "1.9.0")
                #:magicl
                #:alexandria

--- a/cl-quil-tests.asd
+++ b/cl-quil-tests.asd
@@ -40,6 +40,7 @@
                (:file "compilation-tests")
                (:file "clifford-tests")
                (:file "translator-tests")
+               (:file "rewrite-tests")
                (:file "state-prep-tests")
                (:file "compiler-hook-tests")
                (:file "benchmarking-procedures-tests")

--- a/src/analysis/simplify-arithmetic.lisp
+++ b/src/analysis/simplify-arithmetic.lisp
@@ -132,7 +132,7 @@ which fills in the COEFFICIENTS hash table with the memory references and their 
     (number
      (make-affine-representation de))
     (memory-ref
-     (make-affine-representation 0 de 1.0))
+     (make-affine-representation 0d0 de 1.0))
     (cons
      (destructuring-bind (op left &optional right) de
        (if (and (null right) (eq op '-))
@@ -173,11 +173,12 @@ AFFINE-REPRESENTATION                       (* 2.0 theta[0])
 
 (defun canonicalize-expression (de)
   "Given DE (a DELAYED-EXPRESSION), canonicalize it by converting it into its AFFINE-REPRESENTATION form and back into a DELAYED-EXPRESSION once again. Refer to the detailed documentation for the expression->affine-representation and affine-representation->expression functions for more info."
-  (make-delayed-expression (delayed-expression-params de)
-                           (delayed-expression-lambda-params de)
-                           (affine-representation->expression
-                            (expression->affine-representation
-                             (delayed-expression-expression de)))))
+  (evaluate-delayed-expression
+   (make-delayed-expression (delayed-expression-params de)
+                            (delayed-expression-lambda-params de)
+                            (affine-representation->expression
+                             (expression->affine-representation
+                              (delayed-expression-expression de))))))
 
 (defgeneric simplify-arithmetic (thing)
   (:documentation "Generic function that defines the underlying mechanics for the SIMPLIFY-ARITHMETIC transform. If this function is given a PARSED-PROGRAM, it recursively applies itself to the program's exectuable code. Otherwise, if this function is given a GATE-APPLICATION, it attempts to simplify the gate parameters by canonicalizing the arithmetic expressions they (potentially) contain.")

--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -104,7 +104,7 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
                 :when (find (second head) zipped-tail :key #'second :test #'equal)
                   :do (error "Duplicate definition of lambda-param: ~A" (second head)))
           (if (or delayedp-1 delayedp-2)
-              (canonicalize-expression
+              (simplify-arithmetic
                (make-delayed-expression (mapcar #'first params-zipped)
                                         (mapcar #'second params-zipped)
                                         `(,op ,expression-1 ,expression-2)))

--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -104,9 +104,10 @@ EXAMPLE: The Quil line \"CPHASE(pi) 2 3\" corresponds to the S-expression (build
                 :when (find (second head) zipped-tail :key #'second :test #'equal)
                   :do (error "Duplicate definition of lambda-param: ~A" (second head)))
           (if (or delayedp-1 delayedp-2)
-              (make-delayed-expression (mapcar #'first params-zipped)
-                                       (mapcar #'second params-zipped)
-                                       `(,op ,expression-1 ,expression-2))
+              (canonicalize-expression
+               (make-delayed-expression (mapcar #'first params-zipped)
+                                        (mapcar #'second params-zipped)
+                                        `(,op ,expression-1 ,expression-2)))
               (funcall op expression-1 expression-2)))))))
 
 (defun param-+ (arg1 arg2)

--- a/src/cl-quil.lisp
+++ b/src/cl-quil.lisp
@@ -6,7 +6,7 @@
 (in-package #:cl-quil)
 
 (defvar *standard-post-process-transforms*
-  '(expand-circuits type-check)
+  '(expand-circuits type-check simplify-arithmetic)
   "The standard transforms that are applied by PARSE-QUIL.")
 
 (define-condition ambiguous-definition-condition ()

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -385,5 +385,4 @@ Returns a value list: (processed-program, of type parsed-program
         (values
          processed-program
          topological-swaps
-         unpreserved-duration
-         )))))
+         unpreserved-duration)))))

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -46,11 +46,11 @@
 
 (defun full-rotation-p (param &key (full 2pi))
   "Return T if PARAM is an integer multiple of FULL. PARAM may be a DOUBLE-FLOAT, or a CONSTANT."
-  (or (and (typep param 'double-float)
-           (double= (/ param full) (round (/ param full))))
-      (and (typep param 'constant)
-           (let ((val (constant-value param)))
-             (double= (/ val full) (round (/ val full)))))))
+  (check-type param (or constant double-float))
+  (let ((val (or (and (is-constant param)
+                      (constant-value param))
+                 param)))
+    (double= (/ val full) (round (/ val full)))))
 
 (define-compiler eliminate-full-RX-rotations
     ((x ("RX" (theta) _)

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -182,7 +182,8 @@
 
 (define-compiler eliminate-half-PISWAP
     ((x ("PISWAP" (theta) p q)
-        :where (full-rotation-p theta :full 2pi)))
+        :where (and (full-rotation-p theta :full 2pi)
+                    (not (full-rotation-p theta :full 4pi)))))
   (inst "RZ" '(#.pi) p)
   (inst "RZ" '(#.pi) q))
 

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -45,11 +45,11 @@
 ;;; rewriting rules specialized to qubit types
 
 (defun full-rotation-p (param &key (full 2pi))
-  "Return T if PARAM is an integer multiple of FULL. PARAM may be a DOUBLE-FLOAT, or a CONSTANT."
-  (check-type param (or constant double-float))
-  (let ((val (or (and (is-constant param)
-                      (constant-value param))
-                 param)))
+  "Return T if PARAM is an integer multiple of FULL. PARAM may reasonably be of type CONSTANT or DOUBLE-FLOAT, otherwise return NIL."
+  (alexandria:when-let ((val (or (and (is-constant param)
+                                      (constant-value param))
+                                 (and (typep param 'double-float)
+                                      param))))
     (double= (/ val full) (round (/ val full)))))
 
 (define-compiler eliminate-full-RX-rotations

--- a/src/compressor/rewriting-rules.lisp
+++ b/src/compressor/rewriting-rules.lisp
@@ -44,10 +44,16 @@
 
 ;;; rewriting rules specialized to qubit types
 
+(defun full-rotation-p (param)
+  (or (and (typep param 'double-float)
+           (double= (/ param 2pi) (round (/ param 2pi))))
+      (and (typep param 'constant)
+           (let ((val (constant-value param)))
+             (double= (/ val 2pi) (round (/ val 2 pi)))))))
+
 (define-compiler eliminate-full-RX-rotations
     ((x ("RX" (theta) _)
-        :where (and (typep theta 'double-float)
-                    (double= (/ theta 2pi) (round (/ theta 2pi))))))
+        :where (full-rotation-p theta)))
   nil)
 
 (define-compiler normalize-RX-rotations
@@ -75,8 +81,7 @@
 
 (define-compiler eliminate-full-RZ-rotations
     ((x ("RZ" (theta) _)
-        :where (and (typep theta 'double-float)
-                    (double= (/ theta 2pi) (round (/ theta 2pi))))))
+        :where (full-rotation-p theta)))
   nil)
 
 (define-compiler normalize-RZ-rotations
@@ -300,8 +305,7 @@
 
 (define-compiler eliminate-full-CPHASE
     ((x ("CPHASE" (theta) _ _)
-        :where (and (typep theta 'double-float)
-                    (double= 0d0 (mod theta 2pi)))))
+        :where (full-rotation-p theta)))
   nil)
 
 (define-compiler normalize-CPHASE

--- a/tests/rewrite-tests.lisp
+++ b/tests/rewrite-tests.lisp
@@ -1,9 +1,5 @@
 (in-package #:cl-quil-tests)
 
-(defun %filter-halt (pp)
-  (remove-if (lambda (instr) (typep instr 'halt))
-             (parsed-program-executable-code pp)))
-
 (deftest test-rz-full-rotation-elimination ()
   ;; Test the compiler directly.
   (is (not (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list 0d0) 0))))
@@ -14,7 +10,8 @@
         (pps (list (quil::parse-quil "DECLARE theta REAL[1]; RZ(0.0) 0;")
                    (quil::parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0;"))))
     (dolist (pp pps)
-      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
+      (is (zerop (length (parsed-program-executable-code
+                          (quilc::process-program pp chip :protoquil t))))))))
 
 (deftest test-rz-agglutination ()
   (let ((chip (quil::build-nq-fully-connected-chip 2))

--- a/tests/rewrite-tests.lisp
+++ b/tests/rewrite-tests.lisp
@@ -1,5 +1,9 @@
 (in-package #:cl-quil-tests)
 
+(defun %filter-halt (pp)
+  (remove-if #'quil::haltp
+             (parsed-program-executable-code pp)))
+
 (deftest test-rz-full-rotation-elimination ()
   ;; Test the compiler directly.
   (is (null (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list 0d0) 0))))
@@ -11,8 +15,7 @@
                    (quil::parse-quil "DECLARE theta REAL[1]; RZ(2*pi) 0;")
                    (quil::parse-quil "DECLARE theta REAL[1]; RZ(-2*pi) 0;"))))
     (dolist (pp pps)
-      (is (zerop (length (parsed-program-executable-code
-                          (quilc::process-program pp chip :protoquil t))))))))
+      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
 
 (deftest test-rz-agglutination-elimination ()
   (let ((chip (quil::build-nq-fully-connected-chip 2))
@@ -20,7 +23,6 @@
               (parse-quil "RZ(1) 0; RZ(-1) 0;")
               (parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0"))))
     (dolist (pp pps)
-      (is (zerop (length (parsed-program-executable-code
-                          (quilc::process-program pp chip :protoquil t))))))))
+      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
 
 

--- a/tests/rewrite-tests.lisp
+++ b/tests/rewrite-tests.lisp
@@ -8,17 +8,19 @@
   ;; Test that the compiler takes effect via compiler-hook.
   (let ((chip (quil::build-nq-fully-connected-chip 2))
         (pps (list (quil::parse-quil "DECLARE theta REAL[1]; RZ(0.0) 0;")
-                   (quil::parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0;"))))
+                   (quil::parse-quil "DECLARE theta REAL[1]; RZ(2*pi) 0;")
+                   (quil::parse-quil "DECLARE theta REAL[1]; RZ(-2*pi) 0;"))))
     (dolist (pp pps)
       (is (zerop (length (parsed-program-executable-code
                           (quilc::process-program pp chip :protoquil t))))))))
 
-(deftest test-rz-agglutination ()
+(deftest test-rz-agglutination-elimination ()
   (let ((chip (quil::build-nq-fully-connected-chip 2))
         (pps (list
               (parse-quil "RZ(1) 0; RZ(-1) 0;")
               (parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0"))))
     (dolist (pp pps)
-      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
+      (is (zerop (length (parsed-program-executable-code
+                          (quilc::process-program pp chip :protoquil t))))))))
 
 

--- a/tests/rewrite-tests.lisp
+++ b/tests/rewrite-tests.lisp
@@ -1,0 +1,27 @@
+(in-package #:cl-quil-tests)
+
+(defun %filter-halt (pp)
+  (remove-if (lambda (instr) (typep instr 'halt))
+             (parsed-program-executable-code pp)))
+
+(deftest test-rz-full-rotation-elimination ()
+  ;; Test the compiler directly.
+  (is (not (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list 0d0) 0))))
+  (is (not (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list (quil::constant 0d0)) 0))))
+
+  ;; Test that the compiler takes effect via compiler-hook.
+  (let ((chip (quil::build-nq-fully-connected-chip 2))
+        (pps (list (quil::parse-quil "DECLARE theta REAL[1]; RZ(0.0) 0;")
+                   (quil::parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0;"))))
+    (dolist (pp pps)
+      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
+
+(deftest test-rz-agglutination ()
+  (let ((chip (quil::build-nq-fully-connected-chip 2))
+        (pps (list
+              (parse-quil "RZ(1) 0; RZ(-1) 0;")
+              (parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0"))))
+    (dolist (pp pps)
+      (is (zerop (length (%filter-halt (quil::compiler-hook pp chip))))))))
+
+

--- a/tests/rewrite-tests.lisp
+++ b/tests/rewrite-tests.lisp
@@ -2,8 +2,8 @@
 
 (deftest test-rz-full-rotation-elimination ()
   ;; Test the compiler directly.
-  (is (not (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list 0d0) 0))))
-  (is (not (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list (quil::constant 0d0)) 0))))
+  (is (null (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list 0d0) 0))))
+  (is (null (quil::eliminate-full-rz-rotations (quil::build-gate "RZ" (list (quil::constant 0d0)) 0))))
 
   ;; Test that the compiler takes effect via compiler-hook.
   (let ((chip (quil::build-nq-fully-connected-chip 2))


### PR DESCRIPTION
Closes #468.

Previously, an instruction sequence involving named parameters that might reasonably be reduced (e.g. `RZ(theta[0] - theta[0])`) would be missed by the compiler.  @karalekas introduced the `simplify-arithmetic` routine (#211) that is capable of reducing that type of parameter, but it was not installed as part of the compilation pipeline.

This PR uses some of the functionality introduced in #211 (namely `canonicalize-expression`) to simplify arithmetic expressions that involve named (delayed) parameters.

Old:
```
QUIL> (print-parsed-program
       (compiler-hook (parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0;")
                      (build-nq-fully-connected-chip 2)))
DECLARE theta REAL

RZ((theta[0]+-(theta[0]))) 0            # Entering rewiring: #(0 1)
HALT                                    # Exiting rewiring: #(0 1)
```

New:
```
QUIL> (print-parsed-program
       (compiler-hook (parse-quil "DECLARE theta REAL[1]; RZ(theta) 0; RZ(-theta) 0;")
                      (build-nq-fully-connected-chip 2)))
DECLARE theta REAL

HALT                                    # Entering/exiting rewiring: (#(0 1) . #(0 1))
```

Follow-on work: fix the peephole rewriter missing optimizations in the following program
```
QUIL> (print-parsed-program
       (compiler-hook (parse-quil "DECLARE theta REAL[1]; RX(theta) 0; RX(-theta) 0;")
                      (build-nq-fully-connected-chip 2)))
DECLARE theta REAL

RZ(pi/2) 0                              # Entering rewiring: #(0 1)
RX(pi/2) 0
RZ(theta[0]) 0
RZ(-(theta[0])) 0
RX(-pi/2) 0
RZ(-pi/2) 0
HALT                                    # Exiting rewiring: #(0 1)
```