### PR TITLE
Add DIRECTION as frame attribute

### DIFF
--- a/src/quilt/ast.lisp
+++ b/src/quilt/ast.lisp
@@ -259,6 +259,9 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Definitions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(deftype frame-direction ()
+  `(member :TX :RX))
+
 (defclass frame-definition ()
   ((frame :initarg :frame
           :reader frame-definition-frame
@@ -274,6 +277,11 @@
                       :reader frame-definition-initial-frequency
                       :type (or null constant)
                       :documentation "The initial frequency of the frame. If specified, this should be a positive constant.")
+   (direction :initarg :direction
+              :initform nil
+              :reader frame-definition-direction
+              :type (or null frame-direction)
+              :documentation "The associated frame direction, indicating usage for transmission or reception.")
    (context :initarg :context
             :type lexical-context
             :accessor lexical-context
@@ -281,17 +289,21 @@
 
 (defmethod print-instruction-generic ((defn frame-definition) (stream stream))
   (let ((sample-rate (frame-definition-sample-rate defn))
-        (frequency (frame-definition-initial-frequency defn)))
+        (frequency (frame-definition-initial-frequency defn))
+        (direction (frame-definition-direction defn)))
     (format stream "DEFFRAME ~/quil:instruction-fmt/"
             (frame-definition-frame defn))
     (when (or sample-rate frequency)
       (format stream ":")
       (when sample-rate
-        (format stream "~%    SAMPLE-RATE: ~/quil:instruction-fmt/"
-                sample-rate))
+        (format stream "~%    SAMPLE-RATE: ~/quil:instruction-fmt/" sample-rate))
       (when frequency
-        (format stream "~%    INITIAL-FREQUENCY: ~/quil:instruction-fmt/"
-                frequency))
+        (format stream "~%    INITIAL-FREQUENCY: ~/quil:instruction-fmt/" frequency))
+      (when direction
+        (format stream "~%    DIRECTION: \"~S\""
+                (ecase direction
+                  (:TX "tx")
+                  (:RX "rx"))))
       (terpri stream))))
 
 (defclass waveform-definition ()

--- a/src/quilt/parser.lisp
+++ b/src/quilt/parser.lisp
@@ -325,13 +325,21 @@
   (case property-name
     ((:SAMPLE-RATE)
      (parse-sample-rate value-toks))
+    ((:DIRECTION)
+     (unless (and (= 1 (length value-toks))
+                  (eq ':STRING (quil::token-type (first value-toks))))
+       (quil-parse-error "Expected DIRECTION to be a string literal, but got ~{ ~A~}." value-toks))
+     (let ((direction (quil::token-payload (first value-toks))))
+       (cond ((string= "tx" direction) ':TX)
+             ((string= "rx" direction) ':RX)
+             (t
+              (quil-parse-error "Expected DIRECTION to be one of \"tx\" or \"rx\", but got \"~S.\"" direction)))))
     ((:INITIAL-FREQUENCY)
      (let ((freq (quil::parse-parameter-or-expression value-toks)))
        (unless (and (is-constant freq)
                     (realp (constant-value freq)))
          (quil-parse-error "Expected INITIAL-FREQUENCY to be a real number, but got ~/quil:instruction-fmt/."
                            freq))
-       ;; TODO: Can the frame frequency reasonably be negative? Should we allow this?
        (unless (plusp (constant-value freq))
          (warn "Expected INITIAL-FREQUENCY to be positive, but got ~/quil:instruction-fmt/."
                freq))

--- a/tests/quilt/bad-test-files/bad-quilt-defframe-direction.quil
+++ b/tests/quilt/bad-test-files/bad-quilt-defframe-direction.quil
@@ -1,0 +1,4 @@
+DEFFRAME 0 "xy":
+    DIRECTION: "lol"
+
+HALT

--- a/tests/quilt/good-test-files/good-quilt-defframe.quil
+++ b/tests/quilt/good-test-files/good-quilt-defframe.quil
@@ -2,6 +2,7 @@ DEFFRAME 0 1 "foo"
 
 DEFFRAME 0 1 "bar":
     SAMPLE-RATE: 1.0
+    DIRECTION: "tx"
 
 DEFFRAME 0 1 "baz":
     INITIAL-FREQUENCY: 1e8

--- a/tests/quilt/parser-tests.lisp
+++ b/tests/quilt/parser-tests.lisp
@@ -120,7 +120,9 @@ DEFWAVEFORM wf 1.0:
         (frame-defns (list
                       "DEFFRAME 0 \"xy\""
                       "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%"
-                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%    INITIAL-FREQUENCY: 1.0~%"))
+                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%    INITIAL-FREQUENCY: 1.0~%"
+                      "DEFFRAME 0 \"xy\":~%    INITIAL-FREQUENCY: 1.0~%    DIRECTION: \"rx\"~%"
+                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%    DIRECTION: \"tx\"~%"))
         (waveform-defns (list
                          "DEFWAVEFORM foo 1.0:~%    1.0~%"
                          "DEFWAVEFORM foo 1.0:~%    1.0+1.0i, 1.0+1.0i~%"


### PR DESCRIPTION
This is related to https://github.com/rigetti/quil/pull/37

Basically, we let frame directions be explicitly annotated in Quilt source, rather than implicitly floating around inside (whatever machine is responsible for compiling this).