### PR TITLE
Use SAFELY-PARSE-QUIL on external input

### DIFF
--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -50,7 +50,7 @@
 (defun quil-to-native-quil-handler (request &key protoquil)
   "Traditional QUILC invocation: compiles a Quil program to native Quil, as specified by an ISA."
   (check-type request rpcq::|NativeQuilRequest|)
-  (let* ((quil-program (quil::parse-quil (rpcq::|NativeQuilRequest-quil| request)))
+  (let* ((quil-program (quil::safely-parse-quil (rpcq::|NativeQuilRequest-quil| request)))
          (target-device (rpcq::|NativeQuilRequest-target_device| request))
          (qpu-hash (a:plist-hash-table (list "isa" (rpcq::|TargetDevice-isa| target-device)
                                              "specs" (rpcq::|TargetDevice-specs| target-device))
@@ -97,11 +97,11 @@
     (let* ((cliffords (mapcar #'quil.clifford::clifford-from-quil gateset))
            (qubits-used (mapcar (a:compose
                                  #'cl-quil:qubits-used
-                                 #'cl-quil:parse-quil)
+                                 #'cl-quil:safely-parse-quil)
                                 gateset))
            (qubits-used-by-interleaver
              (when interleaver
-               (cl-quil:qubits-used (cl-quil:parse-quil interleaver))))
+               (cl-quil:qubits-used (cl-quil:safely-parse-quil interleaver))))
            (qubits (union qubits-used-by-interleaver (reduce #'union qubits-used)))
            (embedded-cliffords (loop :for clifford :in cliffords
                                      :for i :from 0
@@ -141,7 +141,7 @@
          (clifford-program (rpcq::|ConjugateByCliffordRequest-clifford| request))
          (pauli-indices (coerce (rpcq::|PauliTerm-indices| pauli) 'list))
          (pauli-terms (coerce (rpcq::|PauliTerm-symbols| pauli) 'list))
-         (clifford-indices (sort (cl-quil:qubits-used (cl-quil:parse-quil clifford-program)) #'<))
+         (clifford-indices (sort (cl-quil:qubits-used (cl-quil:safely-parse-quil clifford-program)) #'<))
          (qubits (sort (union (copy-seq pauli-indices) (copy-seq clifford-indices)) #'<))
          (pauli (quil.clifford:pauli-from-string
                  ;; XXX: the pauli-from-string and embedding orderings
@@ -167,8 +167,8 @@
 (defun rewrite-arithmetic-handler (request)
   "Rewrites the request program without arithmetic in gate parameters."
   (check-type request rpcq::|RewriteArithmeticRequest|)
-  (let ((program (quil::parse-quil (rpcq::|RewriteArithmeticRequest-quil| request)
-                                   :transforms nil)))
+  (let ((program (quil::safely-parse-quil (rpcq::|RewriteArithmeticRequest-quil| request)
+                                          :transforms nil)))
     (multiple-value-bind (rewritten-program original-memory-descriptors recalculation-table)
         (cl-quil::rewrite-arithmetic program)
       (let ((reformatted-rt (make-hash-table)))

--- a/src/analysis/process-includes.lisp
+++ b/src/analysis/process-includes.lisp
@@ -25,7 +25,7 @@
                  (when (uiop:relative-pathname-p file)
                    (setf file (merge-pathnames file originating-dir)))
                  (unless (uiop:file-exists-p file)
-                   (quil-parse-error "Could not include ~S because it does not exist." file))
+                   (quil-parse-error "Could not include ~S because it does not exist." (namestring file)))
                  ;; canonicalize the name for the sake of detecting cycles
                  (setf file (truename file))
                  (when (member file seen-files :test #'uiop:pathname-equal)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -407,6 +407,9 @@
   (:export
    #:parse-quil-into-raw-program        ; FUNCTION
    #:quil-parse-error                   ; CONDITION
+   #:resolve-safely                     ; FUNCTION
+   #:safely-read-quil                   ; FUNCTION
+   #:safely-parse-quil                  ; FUNCTION
    )
 
   ;; build-gate.lisp


### PR DESCRIPTION
For the sake of security, `SAFELY-PARSE-QUIL` restricts the `INCLUDE` command to only accept paths relative to the value of `*safe-include-directory*`.