### PR TITLE
Remove stray (BREAK) when parsing U-gate application in qasm.lisp

### DIFF
--- a/src/qasm.lisp
+++ b/src/qasm.lisp
@@ -616,8 +616,6 @@ Note: the above \"expansion\" is not performed when in a gate body."
 
           ((string= name "U")
            (check-number-of-parameters params 3)
-           (unless *gate-applications-are-formal*
-             (break))
            (destructuring-bind (θ ϕ λ) params
              (values (apply #'map-registers (lambda (tgt) (build-u-gate θ ϕ λ tgt))
                             registers)


### PR DESCRIPTION
This caused the compiler to try to enter the debugger when parsing a direct `U`-gate application in program like so:

```
OPENQASM 2.0
qreg q[1]
U(0,0,0) q[0]
```