### PR TITLE
Refactor %STRIP-HALTS-RESPECTING-REWIRINGS

### DIFF
--- a/app/tests/misc-tests.lisp
+++ b/app/tests/misc-tests.lisp
@@ -46,120 +46,144 @@
     (is (eq thing (quilc::special-bindings-let* ((not-special thing))
                     (bt:join-thread (bt:make-thread (lambda () not-special))))))))
 
-(deftest test-%strip-halts-respecting-rewirings ()
-  ;; empty parsed prog
-  (is (equalp #() (quilc::%strip-halts-respecting-rewirings (quil:parse-quil ""))))
+(defun attach-rewirings-at-index (pp index &rest args &key entering exiting)
+  ;; Like CL-QUIL-TESTS::ATTACH-REWIRINGS-TO-PROGRAM, but instead of attaching the rewiring on the
+  ;; first/last instr of PP, attach the rewiring at the requested INDEX.
+  (check-type entering (or null quil::integer-vector))
+  (check-type exiting (or null quil::integer-vector))
+  (assert (or entering exiting))
+  (setf (quil:comment (quil::nth-instr index pp))
+        (apply #'quil::make-rewiring-comment args))
+  pp)
 
-  (flet ((attach-rewirings-to-program (pp in-rewiring-vector out-rewiring-vector)
-           ;; Stolen from CL-QUIL-TESTS::ATTACH-REWIRINGS-TO-PROGRAM.
-           (check-type in-rewiring-vector (or null quil::integer-vector))
-           (check-type out-rewiring-vector (or null quil::integer-vector))
+(deftest test-strip-final-halt-respecting-rewirings ()
+  ;; An empty program produces an empty vector
+  (is (equalp #() (quilc::strip-final-halt-respecting-rewirings (quil:parse-quil ""))))
 
-           (unless (and (null in-rewiring-vector) (null out-rewiring-vector))
-             (let ((code (quil::parsed-program-executable-code pp)))
-               (cond
-                 ((< (length code) 1)
-                  (error "Cannot attach rewirings to program with no instructions"))
-                 ((= (length code) 1)
-                  (setf (quil::comment (aref code 0))
-                        (quil::make-rewiring-comment :entering in-rewiring-vector
-                                                     :exiting out-rewiring-vector)))
-                 (t
-                  (when (not (null in-rewiring-vector))
-                    (setf (quil::comment (aref code 0))
-                          (quil::make-rewiring-comment :entering in-rewiring-vector)))
-                  (when (not (null out-rewiring-vector))
-                    (setf (quil::comment (aref code (1- (length code))))
-                          (quil::make-rewiring-comment :exiting out-rewiring-vector)))))))
-           pp)
-         (attach-rewirings-to-halts (pp indices entering-vector exiting-vector)
-           ;; Like ATTACH-REWIRINGS-TO-PROGRAM, but instead of attaching the entering/exiting
-           ;; rewiring on the first/last instr of PP, attach the exit rewiring at each of the
-           ;; requested INDICES and the ENTERING-VECTOR on the previous instr if ENTERING-VECTOR is
-           ;; non-NIL and a previous instruction exists.
-           (check-type entering-vector (or null quil::integer-vector))
-           (check-type exiting-vector quil::integer-vector)
+  ;; Only a single final HALT is stripped.
+  (let* ((pp (quil:parse-quil "X 0; HALT; HALT"))
+         (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
+    (is (= 2 (length stripped-code)))
+    (is (quil::haltp (quil::vnth 1 stripped-code))))
 
-           (dolist (index indices pp)
-             (let ((halt-instr (quil::nth-instr index pp)))
-               (assert (quil::haltp halt-instr))
-               (setf (quil:comment halt-instr)
-                     (quil::make-rewiring-comment :exiting exiting-vector)))
+  ;; Mid-program HALTs are ignored.
+  (let* ((pp (with-output-to-quil
+               "JUMP @SKIPHALT"
+               "HALT"
+               "LABEL @SKIPHALT"
+               "HALT"))
+         (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
+    (is (= 3 (length stripped-code)))
+    (is (quil::haltp (quil::vnth 1 stripped-code)))
+    (is (not (quil::haltp (quil::vnth 2 stripped-code)))))
 
-             (when (and (plusp index) (not (null entering-vector)))
-               (setf (quil:comment (quil::nth-instr (1- index) pp))
-                     (quil::make-rewiring-comment :entering entering-vector))))))
+  ;; single non-halt instr
+  (let* ((pp (attach-rewirings-at-index (quil:parse-quil "X 0")
+                                        0
+                                        :entering #(0 1 2)
+                                        :exiting #(2 1 0)))
+         (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
+    (is (= 1 (length stripped-code)))
+    (multiple-value-bind (entering-rewiring exiting-rewiring)
+        (quil::instruction-rewirings (quil::vnth 0 stripped-code))
+      (is (equalp #(0 1 2) (quil::rewiring-l2p entering-rewiring)))
+      (is (equalp #(2 1 0) (quil::rewiring-l2p exiting-rewiring)))))
 
-    ;; Multiple HALTs in a row are not handled correctly (but should "never" happen).
-    (let* ((pp (attach-rewirings-to-program
-                (with-output-to-quil
-                  "X 0"
-                  "HALT"
-                  "HALT")
-                #(0 1 2)
-                #(2 1 0)))
-           (stripped-code (quilc::%strip-halts-respecting-rewirings pp)))
-      (is (= 1 (length stripped-code)))
-      (multiple-value-bind (entering-rewiring exiting-rewiring)
-          (quil::instruction-rewirings (quil::vnth 0 stripped-code))
-        (is (not (null entering-rewiring)))
-        (is (null exiting-rewiring))))
+  ;; single halt instr
+  (let* ((pp (attach-rewirings-at-index (quil:parse-quil "HALT")
+                                        0
+                                        :entering #(0 1 2)
+                                        :exiting #(2 1 0)))
+         (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
+    (is (equalp #() stripped-code)))
 
-    (loop :for (entering exiting) :in '((nil nil) (#(0 1 2) nil) (nil #(2 1 0)) (#(0 1 2) #(2 1 0))) :do
-      (loop :for (quil halt-locations)
-              :in `(("HALT" (0))
-                    (,(format nil "HALT~%HALT~%HALT") (0 1 2))
-                    (,(format nil "X 0") ())
-                    (,(format nil "X 0~%HALT") (1))
-                    (,(format nil "X 0~%X 1") ())
-                    (,(format nil "H 0~%H 1~%CNOT 1 0") ())
-                    (,(format nil "H 0~%H 1~%HALT") (2))
-                    (,(format nil "H 0~%HALT~%H 1~%HALT") (1 3)))
-            :for num-halts := (length halt-locations)
-            :for orig-length := (length (quil::parsed-program-executable-code (quil:parse-quil quil)))
-            :for have-entering-rewiring-p := (not (null entering))
-            :for have-exiting-rewiring-p := (not (null exiting))
-            :for have-rewiring-p := (or have-entering-rewiring-p have-exiting-rewiring-p)
-            :do (progn
-                  ;; test enter and exit rewirings on first/last instr only
-                  (let* ((pp (attach-rewirings-to-program (quil:parse-quil quil) entering exiting))
-                         (stripped-code (quilc::%strip-halts-respecting-rewirings pp)))
+  ;; 2-instr no halts, entering/exiting rewirings untouched
+  (let* ((pp (quil:parse-quil "X 0; Y 1"))
+         (pp (attach-rewirings-at-index pp 0 :entering #(0 1 2) :exiting #(2 1 0)))
+         (pp (attach-rewirings-at-index pp 1 :entering #(1 2 0) :exiting #(0 2 1)))
+         (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
+    (is (= 2 (length stripped-code)))
+    (multiple-value-bind (entering-rewiring exiting-rewiring)
+        (quil::instruction-rewirings (quil::vnth 0 stripped-code))
+      (is (equalp #(0 1 2) (quil::rewiring-l2p entering-rewiring)))
+      (is (equalp #(2 1 0) (quil::rewiring-l2p exiting-rewiring))))
+    (multiple-value-bind (entering-rewiring exiting-rewiring)
+        (quil::instruction-rewirings (quil::vnth 1 stripped-code))
+      (is (equalp #(1 2 0) (quil::rewiring-l2p entering-rewiring)))
+      (is (equalp #(0 2 1) (quil::rewiring-l2p exiting-rewiring)))))
 
-                    ;; The correct number of instrs were removed and no HALTs remain.
-                    (is (= (length stripped-code) (- orig-length num-halts)))
-                    (is (every (complement #'quil::haltp) stripped-code))
+  ;; {2,3}-instruction terminal halt
+  (dolist (quil '("X 0; HALT" "H 0; CNOT 0 1; HALT"))
+    (labels ((attach-rewirings (&key last-entering last-exiting
+                                     penultimate-entering penultimate-exiting)
+               (let* ((pp (quil:parse-quil quil))
+                      (last-index (1- (length (quil::parsed-program-executable-code pp))))
+                      (penultimate-index (1- last-index)))
 
-                    (when (and have-exiting-rewiring-p (plusp (length stripped-code)))
-                      ;; There exists at least one non-HALT instr. Ensure the final instruction of
-                      ;; STRIPPED-CODE now contains the EXITING rewiring, regardless of whether the
-                      ;; original program ended in a HALT.
-                      (let ((last-stripped-instr (quil::vnth (1- (length stripped-code)) stripped-code)))
-                        (is (not (null (quil:comment last-stripped-instr))))
-                        (let ((parsed-exiting-rewiring
-                                (nth-value 1 (quil::instruction-rewirings last-stripped-instr))))
-                          (is (not (null parsed-exiting-rewiring)))
-                          (is (equalp exiting (quil::rewiring-l2p parsed-exiting-rewiring)))))))
+                 ;; attach the rewirings
+                 (when (or last-entering last-exiting)
+                   (setf pp (attach-rewirings-at-index pp last-index
+                                                       :entering last-entering
+                                                       :exiting last-exiting)))
+                 (when (or penultimate-entering penultimate-exiting)
+                   (setf pp (attach-rewirings-at-index pp penultimate-index
+                                                       :entering penultimate-entering
+                                                       :exiting penultimate-exiting)))
+                 ;; return the parsed-program
+                 pp))
+             (test-compatible (&rest args &key last-entering last-exiting
+                                               penultimate-entering penultimate-exiting)
+               (let* ((pp (apply #'attach-rewirings args))
+                      (stripped-code (quilc::strip-final-halt-respecting-rewirings pp)))
 
-                  ;; every HALT with exit rewiring has it's rewiring preserved
-                  (when (and have-exiting-rewiring-p (plusp num-halts))
-                    (let* ((pp (attach-rewirings-to-halts (quil:parse-quil quil)
-                                                          halt-locations
-                                                          entering
-                                                          exiting))
-                           (stripped-code (quilc::%strip-halts-respecting-rewirings pp)))
+                 ;; final HALT was stripped
+                 (is (= (length stripped-code) (1- (length (quil::parsed-program-executable-code pp)))))
 
-                      ;; The correct number of instrs were removed and no HALTs remain.
-                      (is (= (length stripped-code) (- orig-length num-halts)))
-                      (is (every (complement #'quil::haltp) stripped-code))
+                 ;; rewirings were correctly copied
+                 (multiple-value-bind (stripped-entering stripped-exiting)
+                     (quil::instruction-rewirings (quil::vnth (1- (length stripped-code))
+                                                              stripped-code))
+                   (is (equalp (or last-entering penultimate-entering)
+                               (and stripped-entering (quil::rewiring-l2p stripped-entering))))
+                   (is (equalp (or last-exiting penultimate-exiting)
+                               (and stripped-exiting (quil::rewiring-l2p stripped-exiting)))))))
 
-                      (when (plusp (length stripped-code))
-                        (loop :for i :in halt-locations
-                              :for instr-preceeding-halt := (and (plusp i) (quil::nth-instr (1- i) pp))
-                              :when (not (null instr-preceeding-halt)) :do
-                                (progn
-                                  (is (not (null (quil:comment instr-preceeding-halt))))
-                                  (let ((parsed-exiting-rewiring
-                                          (nth-value 1 (quil::instruction-rewirings
-                                                        instr-preceeding-halt))))
-                                    (is (not (null parsed-exiting-rewiring)))
-                                    (is (equalp exiting (quil::rewiring-l2p parsed-exiting-rewiring))))))))))))))
+             (test-incompatible (&rest args &key last-entering last-exiting
+                                                 penultimate-entering penultimate-exiting)
+               (declare (ignore last-entering last-exiting penultimate-entering penultimate-exiting))
+               (signals error (quilc::strip-final-halt-respecting-rewirings
+                               (apply #'attach-rewirings args)))))
+
+      ;; various compatible combos of entering/exiting rewirings
+      (test-compatible)
+      (test-compatible :last-entering #(1 2 0))
+      (test-compatible :last-entering #(1 2 0) :penultimate-entering #(1 2 0))
+      (test-compatible :last-entering #(1 2 0) :penultimate-exiting #(2 1 0))
+      (test-compatible :last-exiting #(0 2 1)) ; common case (probably).
+      (test-compatible :last-exiting #(0 2 1) :penultimate-exiting #(0 2 1))
+      (test-compatible :last-exiting #(0 2 1) :penultimate-entering #(0 1 2))
+      (test-compatible :penultimate-entering #(0 1 2))
+      (test-compatible :last-entering #(1 2 0)
+                       :last-exiting #(0 2 1))
+      (test-compatible :last-entering #(1 2 0)
+                       :last-exiting #(0 2 1)
+                       :penultimate-exiting #(0 2 1))
+      (test-compatible :last-entering #(1 2 0)
+                       :last-exiting #(0 2 1)
+                       :penultimate-entering #(1 2 0))
+      (test-compatible :last-entering #(1 2 0)
+                       :last-exiting #(0 2 1)
+                       :penultimate-entering #(1 2 0)
+                       :penultimate-exiting #(0 2 1))
+      (test-compatible :penultimate-entering #(0 1 2)
+                       :penultimate-exiting #(2 1 0))
+      (test-compatible :last-entering #(0 1 2)
+                       :penultimate-entering #(0 1 2)
+                       :penultimate-exiting #(2 1 0))
+      (test-compatible :last-exiting #(2 1 0)
+                       :penultimate-entering #(0 1 2)
+                       :penultimate-exiting #(2 1 0))
+
+      ;; various incompatible combos of entering/exiting rewirings
+      (test-incompatible :last-entering #(0 1 2) :penultimate-entering #(0 1 3))
+      (test-incompatible :last-exiting #(2 1 0) :penultimate-exiting #(3 1 0)))))


### PR DESCRIPTION
Take @ecpeterson's sage advice from #375 and refactor `%STRIP-HALTS-RESPECTING-REWIRINGS` to only deal with a single HALT instruction at the end of the program, rather than stripping HALTs anywhere in the program. For starters, as [ecp mentions in the comment thread](https://github.com/rigetti/quilc/pull/375#discussion_r311787805) of #375, this function is only called in protoquil mode, so there should only be one HALT at the end. Even if there were multiple HALTs, stripping away a mid-program HALT is not likely to leave you with an equivalent program, so it doesn't seem very useful to support that, even in theory.

As noted in the original thread, this refactoring actually makes the code slightly longer and doesn't really improve big-O complexity since we still need to copy the vector to strip off the final HALT. However it does simplify (subjective) the test case since it only needs to test trailing HALTs. The test code is now slightly longer, but exhaustively tests the "interesting" cases. The `TEST-COMPATIBLE` / `TEST-INCOMPATIBLE` tests are also more declarative and therefore (imo) easier to reason about what cases are actually being tested than the previous incarnation.

This refactoring is of questionable value other than as a christmas gift to myself because the old test made me want to throw up in my mouth a little.