### PR TITLE
Rewire INSTR before EXPAND-TO-NATIVE-INSTRUCTIONS in COST-FUNCTION

### DIFF
--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -515,7 +515,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
     new-state))
 
 (defun next-best-instruction (state instrs)
-  "Find the instruction from the given INSTRS which has the best COST-FUNCTION valuatiuon. Returns three values: the instruction, the index of the hardware object it lies on, and the optional qubit assignments if the selected instruction was only partially assigned."
+  "Find the instruction from the given INSTRS which has the best COST-FUNCTION valuation. Returns three values: the instruction, the index of the hardware object it lies on, and the optional qubit assignments if the selected instruction was only partially assigned."
   (with-slots (chip-spec chip-sched lschedule) state
     (let ((best-cost (build-worst-cost state))
           instr

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -492,16 +492,16 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
         (when dirty-flag
           (assert (not dry-run) () "Got dirty when the scheduler was supposed to be dry.")
           (return-from dequeue-logical-to-physical t))
-
+        
         ;; if we didn't dirty up the schedule, see if we collected any
         ;; 2Q gates along the way
         (cond
-          ((dequeue-best-instr state
+          (instrs-ready-for-scheduling
+           (dequeue-best-instr state
                                instrs-ready-for-scheduling
-                               :dry-run dry-run)
-           t)
-          ((try-to-assign-qubits state instrs-partially-assigned)
-           t)
+                               :dry-run dry-run))
+          (instrs-partially-assigned
+           (try-to-assign-qubits state instrs-partially-assigned))
           (t
            nil))))))
 

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -393,7 +393,7 @@ Two other values are returned: a list of fully rewired instructions for later sc
                                       initial-l2p
                                       *addresser-use-free-swaps*)
            (setf dirty-flag t))
-          
+
           ;; is it a small-Q gate?
           ((<= (length (application-arguments instr))
                (length (chip-specification-objects chip-spec)))
@@ -492,7 +492,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
         (when dirty-flag
           (assert (not dry-run) () "Got dirty when the scheduler was supposed to be dry.")
           (return-from dequeue-logical-to-physical t))
-        
+
         ;; if we didn't dirty up the schedule, see if we collected any
         ;; 2Q gates along the way
         (cond
@@ -520,7 +520,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
     (let ((best-cost (build-worst-cost state))
           instr
           hardware-index)
-      
+
       (loop
         :for (candidate-hardware-index candidate-instr) :in instrs
         :for physical-qubits := (coerce (vnth 0
@@ -529,9 +529,9 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
                                                                                            candidate-instr)))
                                                                     candidate-hardware-index)))
                                         'list)
-        
+
         :for candidate-cost := (cost-function state :instr candidate-instr)
-             
+
         :when (cost-< candidate-cost best-cost)
           :do (setf best-cost candidate-cost
                     instr candidate-instr
@@ -555,7 +555,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
 
       ;; from now on, we would schedule something, so bail if on a dry run
       (when dry-run (return-from dequeue-best-instr t))
-      
+
       ;; threads always need expansion
       (when (typep instr 'application-thread-invocation)
         (lscheduler-replace-instruction lschedule instr (apply-translation-compilers
@@ -633,7 +633,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
     (let ((locations (or locations qubit-cc)))
       (assert (not (apply-rewiring-l2p working-l2p logical)) (logical)
               "Qubit ~a already assigned" logical)
-      
+
       (let ((best-cost (build-worst-cost state))
             (best-physical nil))
         (dolist (physical locations)
@@ -666,7 +666,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
           (unless (or (apply-rewiring-l2p working-l2p qubit)
                       (member qubit unassigned-qubits))
             (push qubit unassigned-qubits))))
-      
+
       ;; maximize over best-qubit-position
       (let (best-logical-qubit
             best-physical-qubit
@@ -678,7 +678,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
               (setf best-logical-qubit logical-qubit
                     best-physical-qubit physical-qubit
                     best-cost cost))))
-        
+
         (cond
           (best-logical-qubit
            (rewiring-assign working-l2p best-logical-qubit best-physical-qubit)

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -40,7 +40,7 @@
              (instr-copy (copy-instance instr))
              (instruction-expansion
                (let ((*compress-carefully* nil))
-                 (when (rewiring-available-for-instruction-p l2p instr)
+                 (when (rewiring-assigned-for-instruction-qubits-p l2p instr)
                    (rewire-l2p-instruction l2p instr-copy))
                  (expand-to-native-instructions (list instr-copy) chip-spec))))
         (setf instr-cost (calculate-instructions-log-fidelity instruction-expansion chip-spec))

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -36,9 +36,12 @@
     ;;   + use only the additional infidelity penalty
     (when (and instr (typep instr 'gate-application))
       (let* ((chip-spec (addresser-state-chip-specification state))
+             (instr-copy (copy-instance instr))
              (instruction-expansion
                (let ((*compress-carefully* nil))
-                 (expand-to-native-instructions (list instr) chip-spec))))
+                 (rewire-l2p-instruction (addresser-state-working-l2p state)
+                                         instr-copy)
+                 (expand-to-native-instructions (list instr-copy) chip-spec))))
         (setf instr-cost (calculate-instructions-log-fidelity instruction-expansion chip-spec))
         
         ;; then, see if there's a non-naive cost available

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -56,8 +56,8 @@
                  (subschedule (chip-schedule-from-carving-point
                                (addresser-state-chip-schedule state) resource carving-point))
                  (preceding-fidelity
-                       (calculate-instructions-log-fidelity subschedule
-                                                            (addresser-state-chip-specification state))))
+                   (calculate-instructions-log-fidelity subschedule
+                                                        (addresser-state-chip-specification state))))
             (when (<= cost-bound (+ preceding-fidelity instr-cost))
               (setf instr-cost (- cost-bound preceding-fidelity)))))))
 

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -36,11 +36,12 @@
     ;;   + use only the additional infidelity penalty
     (when (and instr (typep instr 'gate-application))
       (let* ((chip-spec (addresser-state-chip-specification state))
+             (l2p (addresser-state-working-l2p state))
              (instr-copy (copy-instance instr))
              (instruction-expansion
                (let ((*compress-carefully* nil))
-                 (rewire-l2p-instruction (addresser-state-working-l2p state)
-                                         instr-copy)
+                 (when (rewiring-available-for-instruction-p l2p instr)
+                   (rewire-l2p-instruction l2p instr-copy))
                  (expand-to-native-instructions (list instr-copy) chip-spec))))
         (setf instr-cost (calculate-instructions-log-fidelity instruction-expansion chip-spec))
         

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -29,7 +29,7 @@
 (defmethod cost-function ((state fidelity-addresser-state) &key gate-weights instr)
   (let ((instr-cost 0d0)
         (gate-weights-cost 0d0))
-    
+
     ;; calculate log-infidelity coming from INSTR, using recombination:
     ;;   + calculate the cut point
     ;;   + calculate the infidelity of instructions since the cut point
@@ -44,7 +44,7 @@
                    (rewire-l2p-instruction l2p instr-copy))
                  (expand-to-native-instructions (list instr-copy) chip-spec))))
         (setf instr-cost (calculate-instructions-log-fidelity instruction-expansion chip-spec))
-        
+
         ;; then, see if there's a non-naive cost available
         (a:when-let* ((hardware-object (lookup-hardware-object chip-spec instr))
                       (cost-bound (gethash hardware-object (fidelity-addresser-state-cost-bounds state))))
@@ -60,7 +60,7 @@
                                                             (addresser-state-chip-specification state))))
             (when (<= cost-bound (+ preceding-fidelity instr-cost))
               (setf instr-cost (- cost-bound preceding-fidelity)))))))
-    
+
     ;; conglomerate the log-infidelities in GATE-WEIGHTS, depressed by some decay factor
     (when gate-weights
       (let ((qq-distances (addresser-state-qq-distances state)) ; populated with log-infidelities

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -309,3 +309,13 @@ BODY as an implicit PROGN."
               first-rewiring-string second-rewiring-string)
       (values (make-rewiring-from-string first-rewiring-string)
               (make-rewiring-from-string second-rewiring-string)))))
+
+(defun rewiring-available-p (rewiring lq)
+  "Test whether REWIRING contains a non-nil rewiring for logical qubit LQ."
+  (aref (rewiring-l2p rewiring) lq))
+
+(defun rewiring-available-for-instruction-p (rewiring instr)
+  "Test whether every logical qubit in INSTR has been rewired in REWIRING."
+  (every (a:curry #'rewiring-available-p rewiring)
+         (mapcar #'qubit-index
+                 (application-arguments instr))))

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -310,12 +310,12 @@ BODY as an implicit PROGN."
       (values (make-rewiring-from-string first-rewiring-string)
               (make-rewiring-from-string second-rewiring-string)))))
 
-(defun rewiring-available-p (rewiring lq)
+(defun rewiring-assigned-for-qubit-p (rewiring lq)
   "Test whether REWIRING contains a non-nil rewiring for logical qubit LQ."
   (aref (rewiring-l2p rewiring) lq))
 
-(defun rewiring-available-for-instruction-p (rewiring instr)
+(defun rewiring-assigned-for-instruction-qubits-p (rewiring instr)
   "Test whether every logical qubit in INSTR has been rewired in REWIRING."
-  (every (a:curry #'rewiring-available-p rewiring)
-         (mapcar #'qubit-index
-                 (application-arguments instr))))
+  (every (a:compose #'qubit-index
+                    (a:curry #'rewiring-assigned-for-qubit-p rewiring))
+         (application-arguments instr)))

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -316,6 +316,6 @@ BODY as an implicit PROGN."
 
 (defun rewiring-assigned-for-instruction-qubits-p (rewiring instr)
   "Test whether every logical qubit in INSTR has been rewired in REWIRING."
-  (every (a:compose #'qubit-index
-                    (a:curry #'rewiring-assigned-for-qubit-p rewiring))
+  (every (a:compose (a:curry #'rewiring-assigned-for-qubit-p rewiring)
+                    #'qubit-index)
          (application-arguments instr)))

--- a/src/compilers/translators.lisp
+++ b/src/compilers/translators.lisp
@@ -252,7 +252,7 @@ Note that if (= START-NODE TARGET-NODE) then (list START-NODE) is returned."
                                                           :arguments (_ _)) 1))
   ;; find a shortest path between the two qubits in the swap gate
   (let* ((computed-path (find-shortest-path-on-chip-spec chip-spec q1 q0)))
-    (when (= 2 (length computed-path))
+    (when (>= 2 (length computed-path))
       (give-up-compilation))
     (labels
         ((build-CNOT-string (qubit-string)

--- a/src/compilers/translators.lisp
+++ b/src/compilers/translators.lisp
@@ -250,7 +250,7 @@ Note that if (= START-NODE TARGET-NODE) then (list START-NODE) is returned."
                                        :chip-specification chip-spec
                                        :output-gateset `((:operator ,(named-operator "CNOT")
                                                           :arguments (_ _)) 1))
-  ;; find a shortest path between the two qubits in the swap gate
+  ;; find a shortest path between the two qubits in the CNOT gate
   (let* ((computed-path (find-shortest-path-on-chip-spec chip-spec q1 q0)))
     (when (>= 2 (length computed-path))
       (give-up-compilation))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -167,3 +167,7 @@ CNOT 0 2"))
     ;; NOTE: Decomposing into fewer 2q gates is more of a regression
     ;; test on quality of compilation, and not on correctness.
     (is (>= 6 (length 2q-code)))))
+
+(deftest test-sohaib-fidelity-rewiring-regression ()
+  (is (compiler-hook (parse "CZ 0 1")
+                     (quil::build-chip-from-digraph '((2 3) (3 2))))))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -171,5 +171,5 @@ CNOT 0 2"))
 (deftest test-sohaib-fidelity-rewiring-regression ()
   (not-signals bt:timeout
     (bt:with-timeout (1)
-      (is (compiler-hook (parse "CZ 0 1")
-                         (quil::build-chip-from-digraph '((2 3) (3 2))))))))
+      (compiler-hook (parse "CZ 0 1")
+                     (quil::build-chip-from-digraph '((2 3) (3 2)))))))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -169,5 +169,7 @@ CNOT 0 2"))
     (is (>= 6 (length 2q-code)))))
 
 (deftest test-sohaib-fidelity-rewiring-regression ()
-  (is (compiler-hook (parse "CZ 0 1")
-                     (quil::build-chip-from-digraph '((2 3) (3 2))))))
+  (not-signals bt:timeout
+    (bt:with-timeout (1)
+      (is (compiler-hook (parse "CZ 0 1")
+                         (quil::build-chip-from-digraph '((2 3) (3 2))))))))


### PR DESCRIPTION
`cost-function` expands its input instruction into a list of native instructions. If the instruction is not first rewired, then `expand-to-native-instructions` will get confused and infiniloop. For example, if a chip has live physical qubits 3 and 4, then the instruction `CZ 0 1` will be expanded into `CAN ... 0 1` will be expanded into `CZ 0 1` will be expanded into `CAN ... 0 1` ... etc.

My first thought was that `expand-to-native-instructions` should be aware of the current rewiring by providing it a `addresser-state` object containing the rewiring, or even just the rewiring itself. Until now, however, that hasn't been required and so maybe isn't the best solution.

Second (and current) solution, is to temporarily apply the current rewiring to the instruction in `cost-function` (being careful not to mutate the instruction beyond the invocation of `expand-to-...`).

Closes #511 and closes #458.