### PR TITLE
wrap occurrence tables in a struct

### DIFF
--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -60,8 +60,8 @@ DURATION is the time duration in nanoseconds of this gate application."
 FIDELITY stores the measured gate fidelity.
 
 DURATION stores the measured gate duration (in nanoseconds)."
-  (fidelity +near-perfect-fidelity+ :type real)
-  (duration 1/100 :type real))
+  (fidelity +near-perfect-fidelity+ :type (or null real))
+  (duration 1/100 :type (or null real)))
 
 (defun copy-gate-record (record &key fidelity duration)
   (make-gate-record :fidelity (or fidelity (gate-record-fidelity record))

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -457,8 +457,9 @@ OPTIONS: plist of options governing applicability of the compiler binding."
   (map (make-hash-table :test #'equalp) :read-only t :type hash-table))
 
 (defmethod print-object ((object occurrence-table) stream)
-  (dohash ((binding count) (occurrence-table-map object))
-    (format stream "~/cl-quil::binding-fmt/ -> ~a~%" binding count)))
+  (print-unreadable-object (object stream :type 'occurrence-table)
+    (dohash ((binding count) (occurrence-table-map object))
+      (format stream "~&  ~/cl-quil::binding-fmt/ -> ~a" binding count))))
 
 (defun add-entry-to-occurrence-table (table binding count &optional (scalar 1))
   "Destructively increment a binding's value in an occurrence table."


### PR DESCRIPTION
Closes #404 , leading to pleasant output like:
```
QUIL> (compiler-output-gates #'euler-zyz-compiler)
RZ (_) _ -> 2
RY (_) _ -> 1
```

A thought: should `gateset`s also be first-class types?