### PR TITLE
add manually-specified fuzzers

### DIFF
--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -109,6 +109,12 @@ Comes in two flavors:
                arg-lambda-params
                arg-expression
                t))
+             ((memory-ref)
+              (values
+               nil
+               nil
+               arg
+               t))
              ((constant (value val))
               (values nil nil val nil))
              (_

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -988,6 +988,10 @@ If ENSURE-VALID is T, then a memory reference such as 'foo[0]' will result in an
            (typecase (pauli-term-prefactor term)
              (number
               (lambda (&rest args) (declare (ignore args)) (pauli-term-prefactor term)))
+             (delayed-expression
+              (compile nil `(lambda ,parameter-names
+                              (declare (ignorable ,@parameter-names))
+                              ,(delayed-expression-expression (pauli-term-prefactor term)))))
              ((or symbol cons)
               (compile nil `(lambda ,parameter-names
                               (declare (ignorable ,@parameter-names))


### PR DESCRIPTION
This PR adds support for manually specifying compiler fuzzers for use during `test-translators`. The fuzzers this includes brings the automatic testing from ~50% to ~70% of all compilers.

Two things left undone, which are each beyond the scope of this PR:

* I haven't written fuzzers for the state preparation routines. Some of these depend on knowing a wavefunction context, which isn't readily available; and some of these depend on the tester knowing to use a particular sort of matrix equality check, which it's currently ignorant of.
* I haven't written fuzzers for the guarded compilers whose only guard is "someone's qubits need to subsume someone else's qubits". This is a common enough pattern that we should augment the automated fuzzer to handle this case.

A separate concerning thing:

* I had to tweak some of the routines that process memory references / delayed expressions. I suspected that the `AS PAULI-SUM` PR had some AST abuses that escaped notice, and I think those are re-appearing now. It's probably better to fix them—in a separate PR—rather than work around them here.

Partially addresses #368.