### PR TITLE
make QASM benchmark code prettier

### DIFF
--- a/cl-quil-benchmarking.asd
+++ b/cl-quil-benchmarking.asd
@@ -1,7 +1,8 @@
 (asdf:defsystem #:cl-quil-benchmarking
   :depends-on (#:cl-quil
                #:trivial-benchmark
-               #:bordeaux-threads)
+               #:bordeaux-threads
+               #:trivial-garbage)
   :license "Apache License 2.0 (See LICENSE.txt)"
   :pathname "benchmarking/"
   :serial t


### PR DESCRIPTION
This commit:

    * Prints the timed out benchmarks at the end in Lisp-readable form

    * uses TG:GC instead of SBCL internals

    * abridges length and depth of configuration printing

    * doesn't include GC and file slurpage in timeout