### PR TITLE
Provide logically addressed instr to COST-FUNCTION

### DIFF
--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -60,7 +60,8 @@
         (setf instr-cost (calculate-instructions-log-fidelity instruction-expansion chip-spec))
 
         ;; then, see if there's a non-naive cost available
-        (a:when-let* ((hardware-object (lookup-hardware-object chip-spec instr))
+        (a:when-let* ((hardware-object (and (rewiring-assigned-for-instruction-qubits-p l2p instr)
+                                            (lookup-hardware-object chip-spec instr)))
                       (cost-bound (gethash hardware-object (fidelity-addresser-state-cost-bounds state))))
           (let* ((resource (apply #'make-qubit-resource
                                   (coerce (vnth 0 (hardware-object-cxns hardware-object)) 'list)))

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -312,7 +312,7 @@ BODY as an implicit PROGN."
 
 (defun rewiring-assigned-for-qubit-p (rewiring lq)
   "Test whether REWIRING contains a non-nil rewiring for logical qubit LQ."
-  (aref (rewiring-l2p rewiring) lq))
+  (and lq (aref (rewiring-l2p rewiring) lq)))
 
 (defun rewiring-assigned-for-instruction-qubits-p (rewiring instr)
   "Test whether every logical qubit in INSTR has been rewired in REWIRING."


### PR DESCRIPTION
`cost-function` expects the input instruction to be logically addressed, and it will perform the mapping in the current rewiring before handing the instruction off to `expand-to-native-instructions`.