### PR TITLE
Be more tolerant of IMPOSSIBLY-FULL-RESOURCEs

### DIFF
--- a/src/addresser/astar-rewiring-search.lisp
+++ b/src/addresser/astar-rewiring-search.lisp
@@ -249,7 +249,7 @@ should stop with the given rewiring and false otherwise."
 
           ;; did we run out of time?
     :when (>= iterations max-iterations)
-      :do (format *compiler-noise-stream* "SEARCH-REWIRING: Ran out of iterations")
+      :do (format *compiler-noise-stream* "SEARCH-REWIRING: Ran out of iterations~%")
           (return (values (active-state-swaps best-state) nil))
 
           ;; update that we've visited the state

--- a/src/resource.lisp
+++ b/src/resource.lisp
@@ -311,7 +311,9 @@ REGION-COMBINER to their commonly-named regions."
 
 (defun resource-subsetp (rc1 rc2)
   "Return T if all of the resources in RC1 are contained within RC2."
-  (resource-null-p (resource-difference rc1 rc2)))
+  (or (resource-all-p rc2)
+      (and (not (resource-all-p rc1))
+           (resource-null-p (resource-difference rc1 rc2)))))
 
 
 (defun map-sorted-memory-regions (fn regions1 regions2 &key default-value)


### PR DESCRIPTION
Be more tolerant of IMPOSSIBLY-FULL-RESOURCEs in RESOURCE-DIFFERENCE and RESOURCE-SUBSETP. Previously, if RESOURCE-DIFFERENCE was given an IMPOSSIBLY-FULL-RESOURCE as it's first argument, it would signal RESOURCE-COLLECTION-UNBOUNDED-NAMES. Now it only does so if the second argument is not also "impossibly full".

RESOURCE-SUBSETP now explicitly checks for impossibly full resources, and only delegates to RESOURCE-DIFFERENCE in cases where it is guaranteed safe and returns NIL otherwise.

Closes #346