### PR TITLE
Allow XY in deprecated ISA gates field

### DIFF
--- a/src/chip/chip-reader.lisp
+++ b/src/chip/chip-reader.lisp
@@ -244,6 +244,7 @@
                             ((string= "ISWAP" string) ':iswap)
                             ((string= "CPHASE" string) ':cphase)
                             ((string= "PISWAP" string) ':piswap)
+                            ((string= "XY" string) ':xy)
                             (t (error "Unknown link type in QPU descriptor on link ~A: ~A."
                                       (list q0 q1) string)))))
                  (setf link (build-link q0 q1


### PR DESCRIPTION
Purely for ease-of-use, shouldn't affect end-users.