### PR TITLE
Only disallow SSL for SDK builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ QUICKLISP_HOME=$(HOME)/quicklisp
 QUICKLISP_SETUP=$(QUICKLISP_HOME)/setup.lisp
 QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
 	--eval '(push (truename ".") asdf:*central-registry*)' \
-	--eval '(push :drakma-no-ssl *features*)' \
 	--eval "(push (truename \"$(RIGETTI_LISP_LIBRARY_HOME)\") ql:*local-project-directories*)"
 QUICKLISP_BOOTSTRAP_URL=https://beta.quicklisp.org/quicklisp.lisp
 UNAME_S=$(shell uname -s)
@@ -73,13 +72,12 @@ endif
 quilc: system-index.txt
 	$(SBCL) $(FOREST_SDK_FEATURE) \
 	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
-		--eval '(push :drakma-no-ssl *features*)' \
 		--load "build-app.lisp" \
 		$(FOREST_SDK_OPTION) \
 		$(QUILC_UNSAFE_OPTION)
 
 
-quilc-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)'
+quilc-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)' --eval ' (push :drakma-no-ssl *features*)'
 quilc-sdk-base: clean clean-cache quilc
 
 # By default, relocate shared libraries on SDK builds

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -6,7 +6,8 @@
 (unless *load-truename*
   (error "This file is meant to be loaded."))
 
-(pushnew :drakma-no-ssl *features*)
+(when (find :forest-sdk *features*)
+  (pushnew :drakma-no-ssl *features*))
 
 (require 'asdf)
 

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -6,8 +6,7 @@
 (unless *load-truename*
   (error "This file is meant to be loaded."))
 
-(when (find :forest-sdk *features*)
-  (pushnew :drakma-no-ssl *features*))
+#+forest-sdk (pushnew :drakma-no-ssl *features*)
 
 (require 'asdf)
 


### PR DESCRIPTION
This prevents the annoying situation where you've loaded e.g. drakma in your REPL with SSL enabled, and after that when you try to compile quilc you get the error about being unable to find the CL+SSL package.