### PR TITLE
Update Quilt Syntax

### DIFF
--- a/src/quilt/ast.lisp
+++ b/src/quilt/ast.lisp
@@ -150,7 +150,7 @@
   (:documentation "A pulse instruction."))
 
 (defmethod print-instruction-generic ((instr pulse) (stream stream))
-  (format stream "~@[NONBLOCKING ~]PULSE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
+  (format stream "~:[~;NONBLOCKING ~]PULSE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
           (nonblocking-p instr)
           (pulse-frame instr)
           (pulse-waveform instr)))
@@ -176,7 +176,7 @@
   (:documentation "An instruction expressing the readout and integration of raw IQ values, to be stored in a region of classical memory."))
 
 (defmethod print-instruction-generic ((instr capture) (stream stream))
-  (format stream "~@[NONBLOCKING ~]CAPTURE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
+  (format stream "~:[~;NONBLOCKING ~]CAPTURE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
           (nonblocking-p instr)
           (capture-frame instr)
           (capture-waveform instr)
@@ -203,7 +203,7 @@
   (:documentation "An instruction expressing the readout of raw IQ values, to be stored in a region of classical memory."))
 
 (defmethod print-instruction-generic ((instr raw-capture) (stream stream))
-  (format stream "~@[NONBLOCKING ~]RAW-CAPTURE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
+  (format stream "~:[~;NONBLOCKING ~]RAW-CAPTURE ~/quil:instruction-fmt/ ~/quil:instruction-fmt/ ~/quil:instruction-fmt/"
           (nonblocking-p instr)
           (raw-capture-frame instr)
           (raw-capture-duration instr)

--- a/src/quilt/waveform.lisp
+++ b/src/quilt/waveform.lisp
@@ -139,3 +139,16 @@ Reference: Effects of arbitrary laser or NMR pulse shapes on population inversio
        :rpcq-type complex
        :documentation "A complex number representing the in-phase (real) and quadrature (imaginary) values to hold constant."))
   :documentation "Flat pulse.")
+
+
+;;; TODO: This could probably be deprecated in favor of just having FLAT-WAVEFORMs.
+;;; Seemingly the only special thing about BOXCAR-AVERAGER-KERNEL is that it is
+;;; normalized (presumably to integrate to 1), rather than having a specified IQ value.
+(define-standard-waveform boxcar-averager-kernel "boxcar_kernel"
+  ((phase :quilt-name "phase"
+          :rpcq-type complex
+          :documentation "Phase [units of revolutions] to rotate the kernel by.")
+   (detuning :quilt-name "detuning"
+             :rpcq-type float
+             :documentation "Frequency modulation to apply to the kernel [Hz]."))
+  :documentation "A normalized flat or boxcar integration kernel.")

--- a/src/quilt/waveform.lisp
+++ b/src/quilt/waveform.lisp
@@ -85,7 +85,7 @@ Parameters:
        :rpcq-type float
        :documentation "Center time coordinate of the shape in seconds. Defaults to mid-point of pulse.")))
 
-(define-standard-waveform drag-gaussian-waveform "draggaussian"
+(define-standard-waveform drag-gaussian-waveform "drag_gaussian"
   ((fwhm :quilt-name "fwhm"
          :rpcq-type float
          :documentation "Full Width Half Max shape parameter, in seconds.")
@@ -100,7 +100,7 @@ Parameters:
           :documentation "Dimensionless DRAG parameter."))
   :documentation "A DRAG Gaussian shaped waveform envelope defined for a specific frame.")
 
-(define-standard-waveform hermite-gaussian-waveform "hermitegaussian"
+(define-standard-waveform hermite-gaussian-waveform "hermite_gaussian"
   ((fwhm :quilt-name "fwhm"
          :rpcq-type float
          :documentation "Full Width Half Max shape parameter, in seconds.")
@@ -120,7 +120,7 @@ Parameters:
 
 Reference: Effects of arbitrary laser or NMR pulse shapes on population inversion and coherence Warren S. Warren. 81, (1984); doi: 10.1063/1.447644")
 
-(define-standard-waveform erf-square-waveform "erfsquare"
+(define-standard-waveform erf-square-waveform "erf_square"
   ((risetime :quilt-name "risetime"
              :documentation "The width of the rise and fall sections in seconds."
              :rpcq-type float)

--- a/tests/quilt/good-test-files/good-quilt-measure-calibration.quil
+++ b/tests/quilt/good-test-files/good-quilt-measure-calibration.quil
@@ -1,3 +1,5 @@
+DECLARE iq REAL
+
 DEFCAL MEASURE 0 dest:
     CAPTURE 0 "out" flat(duration: 1e-6, iq: 2+3*i) iq
     LT dest iq[0] 0.5

--- a/tests/quilt/parser-tests.lisp
+++ b/tests/quilt/parser-tests.lisp
@@ -82,32 +82,34 @@ DEFWAVEFORM foo 4.0:
 
 (deftest test-parse-and-print-quilt-instructions ()
   (let ((boilerplate "
-DEFFRAME 0 \"xy\"
+DEFFRAME 0 \"rf\"
 DEFFRAME 0 \"zz\"
 DEFFRAME 0 1 \"foo\"
 DECLARE iq REAL[2]
 DEFWAVEFORM wf 1.0:
     1.0, 1.0, 1.0
-
 ")
         (instrs (list
-                 "SET-FREQUENCY 0 \"xy\" 1.0"
+                 "SET-FREQUENCY 0 \"rf\" 1.0"
                  "SET-FREQUENCY 0 1 \"foo\" 1.0"
-                 "SET-PHASE 0 \"xy\" 1.0"
+                 "SHIFT-FREQUENCY 0 \"rf\" 1.0"
+                 "SHIFT-FREQUENCY 0 1 \"foo\" 1.0"
+                 "SET-PHASE 0 \"rf\" 1.0"
                  "SET-PHASE 0 1 \"foo\" 1.0"
-                 "SHIFT-PHASE 0 \"xy\" 1.0"
+                 "SHIFT-PHASE 0 \"rf\" 1.0"
                  "SHIFT-PHASE 0 1 \"foo\" 1.0"
-                 "SET-SCALE 0 \"xy\" 1.0"
+                 "SET-SCALE 0 \"rf\" 1.0"
                  "SET-SCALE 0 1 \"foo\" 1.0"
-                 "SWAP-PHASE 0 \"xy\" 0 1 \"foo\""
-                 "PULSE 0 \"xy\" wf"
+                 "SWAP-PHASE 0 \"rf\" 0 1 \"foo\""
+                 "PULSE 0 \"rf\" wf"
                  "PULSE 0 1 \"foo\" wf"
-                 "CAPTURE 0 \"xy\" wf iq[0]"
-                 "RAW-CAPTURE 0 \"xy\" 1.0 iq[0]"
+                 "CAPTURE 0 \"rf\" wf iq[0]"
+                 "RAW-CAPTURE 0 \"rf\" 1.0 iq[0]"
                  "DELAY 0 1.0"          ; delay on qubit
-                 "DELAY 0 \"xy\" 1.0"   ; delay on frame
-                 "DELAY 0 \"xy\" \"zz\" 1.0" ; delay on frames
-                 "FENCE 0 1")))
+                 "DELAY 0 \"rf\" 1.0"   ; delay on frame
+                 "DELAY 0 \"rf\" \"zz\" 1.0" ; delay on frames
+                 "FENCE 0 1"
+                 "FENCE")))
     (dolist (instr instrs)
       (prints-as instr
                  (concatenate 'string boilerplate instr)))))
@@ -118,11 +120,12 @@ DEFWAVEFORM wf 1.0:
 (deftest test-parse-and-print-quilt-definitions ()
   (let ((boilerplate "~%DEFFRAME 0 \"rx\"") ; tacked on at end
         (frame-defns (list
-                      "DEFFRAME 0 \"xy\""
-                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%"
-                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%    INITIAL-FREQUENCY: 1.0~%"
-                      "DEFFRAME 0 \"xy\":~%    INITIAL-FREQUENCY: 1.0~%    DIRECTION: \"rx\"~%"
-                      "DEFFRAME 0 \"xy\":~%    SAMPLE-RATE: 1.0~%    DIRECTION: \"tx\"~%"))
+                      "DEFFRAME 0 1 \"xy\""
+                      "DEFFRAME 0 1 \"xy\":~%    SAMPLE-RATE: 1.0~%"
+                      "DEFFRAME 0 1 \"xy\":~%    SAMPLE-RATE: 1.0~%    INITIAL-FREQUENCY: 1.0~%"
+                      "DEFFRAME 0 1 \"xy\":~%    INITIAL-FREQUENCY: 1.0~%    DIRECTION: \"rx\"~%"
+                      "DEFFRAME 0 1 \"xy\":~%    HARDWARE-OBJECT: \"q0_q1_xy\"~%"
+                      "DEFFRAME 0 1 \"xy\":~%    SAMPLE-RATE: 1.0~%    DIRECTION: \"tx\"~%"))
         (waveform-defns (list
                          "DEFWAVEFORM foo 1.0:~%    1.0~%"
                          "DEFWAVEFORM foo 1.0:~%    1.0+1.0i, 1.0+1.0i~%"

--- a/tests/quilt/parser-tests.lisp
+++ b/tests/quilt/parser-tests.lisp
@@ -103,8 +103,11 @@ DEFWAVEFORM wf 1.0:
                  "SWAP-PHASE 0 \"rf\" 0 1 \"foo\""
                  "PULSE 0 \"rf\" wf"
                  "PULSE 0 1 \"foo\" wf"
+                 "NONBLOCKING PULSE 0 1 \"foo\" wf"
                  "CAPTURE 0 \"rf\" wf iq[0]"
+                 "NONBLOCKING CAPTURE 0 \"rf\" wf iq[0]"
                  "RAW-CAPTURE 0 \"rf\" 1.0 iq[0]"
+                 "NONBLOCKING RAW-CAPTURE 0 \"rf\" 1.0 iq[0]"
                  "DELAY 0 1.0"          ; delay on qubit
                  "DELAY 0 \"rf\" 1.0"   ; delay on frame
                  "DELAY 0 \"rf\" \"zz\" 1.0" ; delay on frames


### PR DESCRIPTION
These changes updates that are already recorded in the Quilt spec (https://github.com/rigetti/quil/tree/master/rfcs/analog).

Two new instructions
- FENCE-ALL
- SHIFT-FREQUENCY

one new frame attribute
- HARDWARE-OBJECT

and a new waveform.