### PR TITLE
Elide circuit definitions during printing if circuits expanded

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1687,7 +1687,8 @@ Examples:
       (unless (endp (parsed-program-memory-definitions pp))
         (terpri stream))
       (print-definitions (parsed-program-gate-definitions pp))
-      (print-definitions (parsed-program-circuit-definitions pp))
+      (unless (find 'expand-circuits (transforms-performed pp))
+        (print-definitions (parsed-program-circuit-definitions pp)))
 
       (print-instruction-sequence (parsed-program-executable-code pp) :stream stream))))
 

--- a/tests/printer-test-files/gold-regex/plundered-regex-gold.quil
+++ b/tests/printer-test-files/gold-regex/plundered-regex-gold.quil
@@ -105,20 +105,6 @@ TELEPORT 0 1 5
 # Output
 DECLARE ro BIT\[2\]
 
-DEFCIRCUIT TELEPORT A q B:
-    H A
-    CNOT A B
-    CNOT q A
-    H q
-    MEASURE q ro\[0\]
-    MEASURE A ro\[1\]
-    JUMP-UNLESS @SKIP ro\[1\]
-    X B
-    LABEL @SKIP
-    JUMP-UNLESS @END ro\[0\]
-    Z B
-    LABEL @END
-
 H 0
 CNOT 0 5
 CNOT 1 0

--- a/tests/printer-test-files/gold-standard/decomposed-ccnot.quil
+++ b/tests/printer-test-files/gold-standard/decomposed-ccnot.quil
@@ -20,23 +20,6 @@ DEFCIRCUIT DECOMPOSED-CCNOT q1 q2 q3:
 DECOMPOSED-CCNOT 0 1 2
 
 # Output
-DEFCIRCUIT CNOT-DT-T-CNOT-T p1 p2 p3:
-    CNOT p2 p3
-    DAGGER T p3
-    CNOT p1 p3
-    T p3
-
-DEFCIRCUIT DECOMPOSED-CCNOT q1 q2 q3:
-    H q3
-    CNOT-DT-T-CNOT-T q1 q2 q3
-    CNOT-DT-T-CNOT-T q1 q2 q3
-    T q2
-    H q3
-    CNOT q1 q2
-    T q1
-    DAGGER T q2
-    CNOT q1 q2
-
 H 2
 CNOT 1 2
 DAGGER T 2

--- a/tests/printer-test-files/gold-standard/delayed-expressions.quil
+++ b/tests/printer-test-files/gold-standard/delayed-expressions.quil
@@ -100,9 +100,6 @@ DEFCIRCUIT TEST-CIRCUIT-EXPANSION(%arg1, %arg2) p:
 TEST-CIRCUIT-EXPANSION(pi, pi*SIN(pi/2)) 0
 
 # Output
-DEFCIRCUIT TEST-CIRCUIT-EXPANSION(%arg1, %arg2) p:
-    RX((%arg1-%arg2)) p
-
 RX(0.0) 0
 
 # Input

--- a/tests/printer-test-files/gold-standard/plundered-gold.quil
+++ b/tests/printer-test-files/gold-standard/plundered-gold.quil
@@ -94,13 +94,6 @@ TEST ro[0] ro[1]
 # Output
 DECLARE ro BIT[2]
 
-DEFCIRCUIT TEST a b:
-    NOT a
-    AND a b
-    IOR a b
-    MOVE a b
-    EXCHANGE a b
-
 NOT ro[0]
 AND ro[0] ro[1]
 IOR ro[0] ro[1]
@@ -240,11 +233,6 @@ DEFCIRCUIT EULER(%alpha, %beta, %gamma) q:
 
 EULER(pi, 2*pi, 3*pi/2) 0
 # Output
-DEFCIRCUIT EULER(%alpha, %beta, %gamma) q:
-    RX(%alpha) q
-    RY(%beta) q
-    RZ(%gamma) q
-
 RX(pi) 0
 RY(2*pi) 0
 RZ(3*pi/2) 0


### PR DESCRIPTION
Closes #540. This doesn't strip the program object of its circuit definitions, but instead opts-out of printing those circuit definitions if the program has undergone the circuit expansion transformation.