### PR TITLE
encapsulate noise formatting

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -452,7 +452,6 @@
        ;; before calling run-CLI-mode, below.
        (*human-readable-stream* (make-broadcast-stream))
        (*quil-stream* (make-broadcast-stream))
-       (*verbose* (make-broadcast-stream))
        (*protoquil* protoquil)
        (quil::*safe-include-directory* safe-include-directory))
 

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -481,9 +481,6 @@
          (setf *human-readable-stream* *error-output*)
          (setf *quil-stream* *standard-output*)
 
-         (when verbose
-           (setf *verbose* *human-readable-stream*))
-
          (let* ((program-text (slurp-lines))
                 (program (safely-parse-quil program-text))
                 (original-matrix (when (and protoquil compute-matrix-reps)
@@ -491,6 +488,7 @@
            (multiple-value-bind (processed-program statistics)
                (process-program program (lookup-isa-descriptor-for-name isa)
                                 :protoquil protoquil
+                                :verbose verbose
                                 :gate-whitelist (and gate-whitelist
                                                      (split-sequence:split-sequence
                                                       #\,
@@ -513,13 +511,14 @@
 (defun process-program (program chip-specification
                         &key
                           protoquil
+                          verbose
                           gate-whitelist
                           gate-blacklist)
   "Compile PROGRAM for the chip CHIP-SPECIFICATION. Optionally calculate statistics described by the keyword arguments. All require :PROTOQUIL T.
 
 Returns a values tuple (PROCESSED-PROGRAM, STATISTICS), where PROCESSED-PROGRAM is the compiled program, and STATISTICS is a HASH-TABLE whose keys are the slots of the RPCQ::|NativeQuilMetadata| class."
   (let* ((statistics (make-hash-table :test #'equal))
-         (quil::*compiler-noise-stream* *verbose*)
+         (quil::*compiler-noise* (and verbose *human-readable-stream*))
          (*random-state* (make-random-state t)))
     ;; do the compilation
     (multiple-value-bind (processed-program topological-swaps)

--- a/app/src/globals.lisp
+++ b/app/src/globals.lisp
@@ -2,7 +2,6 @@
 
 (defparameter *program-name* "quilc")
 (defparameter *without-pretty-printing* nil)
-(defparameter *verbose* (make-broadcast-stream))
 (defparameter *log-level* ':info)
 (defparameter *protoquil* nil)
 

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -249,7 +249,7 @@ cost-function associated to the current lschedule.")
   (:method (state rewirings-tried)
     (with-slots (lschedule initial-l2p working-l2p chip-sched chip-spec qq-distances)
         state
-      (format *compiler-noise-stream*
+      (format *compiler-noise*
               "SELECT-AND-EMBED-A-PERMUTATION: entering SWAP selection phase.~%")
       (let ((gates-in-waiting (assign-weights-to-gates state)))
         (ecase *addresser-swap-search-type*
@@ -562,7 +562,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
       (let ((rewired-instr (copy-instance instr)))
         (rewire-l2p-instruction working-l2p rewired-instr)
         (format-noise
-         "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring"
+         "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring."
          instr rewired-instr)
 
         ;; Figure out if we need to compile the instruction,

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -430,8 +430,8 @@ Two other values are returned: a list of fully rewired instructions for later sc
                    nil
                    "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/"
                    instr)
-           (format *compiler-noise-stream*
-                   "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a ~dQ>2Q instruction, compiling.~%"
+           (format-noise
+                   "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a ~dQ>2Q instruction, compiling."
                    instr
                    (length (application-arguments instr)))
            ;; then we know we can't find a hardware object to support
@@ -451,7 +451,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
   ;; Allow for early exit if we are doing a dry run
   (catch 'dry-run-succeeded
     (with-slots (lschedule chip-sched chip-spec working-l2p qq-distances initial-l2p) state
-      (format *compiler-noise-stream* "DEQUEUE-LOGICAL-TO-PHYSICAL: entering dequeueing phase.~%")
+      (format-noise "DEQUEUE-LOGICAL-TO-PHYSICAL: entering dequeueing phase.")
       (let ((dirty-flag nil)
             (instrs-ready-for-scheduling nil)
             (instrs-partially-assigned nil)
@@ -556,13 +556,13 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
         (return-from dequeue-best-instr t))
 
       ;; ... and dispatch it.
-      (format *compiler-noise-stream*
-              "DEQUEUE-BEST-INSTR: Elected to schedule ~/quil:instruction-fmt/.~%"
+      (format-noise
+              "DEQUEUE-BEST-INSTR: Elected to schedule ~/quil:instruction-fmt/."
               instr)
       (let ((rewired-instr (copy-instance instr)))
         (rewire-l2p-instruction working-l2p rewired-instr)
-        (format *compiler-noise-stream*
-                "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring~%"
+        (format-noise
+                "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring"
                 instr rewired-instr)
 
         ;; Figure out if we need to compile the instruction,
@@ -570,8 +570,8 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
         (cond
           ;; if we found a link and the instruction is native...
           ((hardware-object-native-instruction-p (lookup-hardware-object chip-spec rewired-instr) rewired-instr)
-           (format *compiler-noise-stream*
-                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is native in l2p rewiring ~A, flushing 1Q lines and dequeueing.~%"
+           (format-noise
+                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is native in l2p rewiring ~A, flushing 1Q lines and dequeueing."
                    instr
                    (rewiring-l2p working-l2p))
            ;; dequeue the instruction so we can push the
@@ -582,8 +582,8 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
 
           ;; otherwise, we found a link but the instruction is not native
           (t
-           (format *compiler-noise-stream*
-                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is non-native in the current rewiring, compiling.~%"
+           (format-noise
+                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is non-native in the current rewiring, compiling."
                    instr)
 
            ;; ...release the hounds
@@ -690,8 +690,8 @@ Optional arguments:
    If INITIAL-REWIRING is not provided this option has no effect.
 ")
   (:method (state instrs &key (initial-rewiring nil) (use-free-swaps nil))
-    (format *compiler-noise-stream*
-            "DO-GREEDY-ADDRESSING: entrance.~%")
+    (format-noise
+            "DO-GREEDY-ADDRESSING: entrance.")
     (let ((*addresser-use-free-swaps* (or use-free-swaps (not initial-rewiring))))
       (with-slots (lschedule working-l2p chip-sched initial-l2p) state
         ;; This is governed by an FSM of the shape
@@ -725,13 +725,13 @@ Optional arguments:
                  (loop
                    :with rewirings-tried := nil
                    :while (lscheduler-first-instrs lschedule)
-                   :do (format *compiler-noise-stream* "ADDRESSER-FSM: New pass.~%")
+                   :do (format-noise "ADDRESSER-FSM: New pass.")
                    :when (dequeue-logical-to-physical state)
-                     :do (format *compiler-noise-stream* "ADDRESSER-FSM: LSCHED changed, retrying.~%")
+                     :do (format-noise "ADDRESSER-FSM: LSCHED changed, retrying.")
                          (setf rewirings-tried nil)
                    :else
-                     :do (format *compiler-noise-stream*
-                                 "ADDRESSER-FSM: LSCHED unchanged, selecting a permutation.~%")
+                     :do (format-noise
+                                 "ADDRESSER-FSM: LSCHED unchanged, selecting a permutation.")
                          (assert (> *addresser-max-swap-sequence-length* (length rewirings-tried)) ()
                                  "Too many SWAP instructions selected in a row: ~a" (length rewirings-tried))
                          (setf rewirings-tried (select-and-embed-a-permutation state rewirings-tried)))))
@@ -748,6 +748,6 @@ Optional arguments:
           (dolist (instr (nreverse (chip-schedule-to-straight-quil chip-sched)))
             (when (swap-application-p instr)
               (apply #'update-rewiring initial-l2p (mapcar #'qubit-index (application-arguments instr)))))
-          (format *compiler-noise-stream* "DO-GREEDY-ADDRESSING: departure.~%")
+          (format-noise "DO-GREEDY-ADDRESSING: departure.")
           ;; finally, return what we've constructed
           (values chip-sched initial-l2p working-l2p))))))

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -431,9 +431,9 @@ Two other values are returned: a list of fully rewired instructions for later sc
                    "Instruction qubit indices are out of bounds for target QPU: ~/quil:instruction-fmt/"
                    instr)
            (format-noise
-                   "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a ~dQ>2Q instruction, compiling."
-                   instr
-                   (length (application-arguments instr)))
+            "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a ~dQ>2Q instruction, compiling."
+            instr
+            (length (application-arguments instr)))
            ;; then we know we can't find a hardware object to support
            ;; it, so pass it to the chip compiler
            (let ((compilation-result (apply-translation-compilers instr chip-spec nil)))
@@ -557,13 +557,13 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
 
       ;; ... and dispatch it.
       (format-noise
-              "DEQUEUE-BEST-INSTR: Elected to schedule ~/quil:instruction-fmt/."
-              instr)
+       "DEQUEUE-BEST-INSTR: Elected to schedule ~/quil:instruction-fmt/."
+       instr)
       (let ((rewired-instr (copy-instance instr)))
         (rewire-l2p-instruction working-l2p rewired-instr)
         (format-noise
-                "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring"
-                instr rewired-instr)
+         "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is ~/quil:instruction-fmt/ in the current rewiring"
+         instr rewired-instr)
 
         ;; Figure out if we need to compile the instruction,
         ;; or if we can add it to the schedule.
@@ -571,9 +571,9 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
           ;; if we found a link and the instruction is native...
           ((hardware-object-native-instruction-p (lookup-hardware-object chip-spec rewired-instr) rewired-instr)
            (format-noise
-                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is native in l2p rewiring ~A, flushing 1Q lines and dequeueing."
-                   instr
-                   (rewiring-l2p working-l2p))
+            "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is native in l2p rewiring ~A, flushing 1Q lines and dequeueing."
+            instr
+            (rewiring-l2p working-l2p))
            ;; dequeue the instruction so we can push the
            ;; modified instruction onto the schedule.
            (lscheduler-dequeue-instruction lschedule instr)
@@ -583,8 +583,8 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
           ;; otherwise, we found a link but the instruction is not native
           (t
            (format-noise
-                   "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is non-native in the current rewiring, compiling."
-                   instr)
+            "DEQUEUE-BEST-INSTR: ~/quil:instruction-fmt/ is non-native in the current rewiring, compiling."
+            instr)
 
            ;; ...release the hounds
            ;;
@@ -690,8 +690,7 @@ Optional arguments:
    If INITIAL-REWIRING is not provided this option has no effect.
 ")
   (:method (state instrs &key (initial-rewiring nil) (use-free-swaps nil))
-    (format-noise
-            "DO-GREEDY-ADDRESSING: entrance.")
+    (format-noise "DO-GREEDY-ADDRESSING: entrance.")
     (let ((*addresser-use-free-swaps* (or use-free-swaps (not initial-rewiring))))
       (with-slots (lschedule working-l2p chip-sched initial-l2p) state
         ;; This is governed by an FSM of the shape
@@ -730,8 +729,7 @@ Optional arguments:
                      :do (format-noise "ADDRESSER-FSM: LSCHED changed, retrying.")
                          (setf rewirings-tried nil)
                    :else
-                     :do (format-noise
-                                 "ADDRESSER-FSM: LSCHED unchanged, selecting a permutation.")
+                     :do (format-noise "ADDRESSER-FSM: LSCHED unchanged, selecting a permutation.")
                          (assert (> *addresser-max-swap-sequence-length* (length rewirings-tried)) ()
                                  "Too many SWAP instructions selected in a row: ~a" (length rewirings-tried))
                          (setf rewirings-tried (select-and-embed-a-permutation state rewirings-tried)))))

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -249,8 +249,7 @@ cost-function associated to the current lschedule.")
   (:method (state rewirings-tried)
     (with-slots (lschedule initial-l2p working-l2p chip-sched chip-spec qq-distances)
         state
-      (format *compiler-noise*
-              "SELECT-AND-EMBED-A-PERMUTATION: entering SWAP selection phase.~%")
+      (format-noise "SELECT-AND-EMBED-A-PERMUTATION: entering SWAP selection phase.")
       (let ((gates-in-waiting (assign-weights-to-gates state)))
         (ecase *addresser-swap-search-type*
           (:a*

--- a/src/addresser/astar-rewiring-search.lisp
+++ b/src/addresser/astar-rewiring-search.lisp
@@ -241,7 +241,7 @@ should stop with the given rewiring and false otherwise."
 
         ;; the successful termination point: did we find a good-enough rewiring?
     :when (active-state-done active-state done-fn)
-      :do (format *compiler-noise-stream* "SEARCH-REWIRING: Iterations ~A.~%" iterations)
+      :do (format-noise "SEARCH-REWIRING: Iterations ~A." iterations)
           (return (values (active-state-swaps active-state) t))
 
     :when (or (not best-state) (active-state< active-state best-state))
@@ -249,7 +249,7 @@ should stop with the given rewiring and false otherwise."
 
           ;; did we run out of time?
     :when (>= iterations max-iterations)
-      :do (format *compiler-noise-stream* "SEARCH-REWIRING: Ran out of iterations.~%")
+      :do (format-noise "SEARCH-REWIRING: Ran out of iterations.")
           (return (values (active-state-swaps best-state) nil))
 
           ;; update that we've visited the state

--- a/src/addresser/embed-swap.lisp
+++ b/src/addresser/embed-swap.lisp
@@ -99,11 +99,11 @@ instruction if it exists, and errors otherwise."
             nil
             "Failed to select a SWAP instruction. This can be caused by a disconnected qubit graph, a program with a lot of symmetry, or even random chance. You might simply try again, or you might try requesting a different addressing strategy.")
     (format-noise
-            "SELECT-COST-LOWERING-SWAP: SWAP ~d ~d is best, lowering cost from ~d to ~d."
-            (vnth 0 (chip-spec-qubits-on-link chip-spec link-index))
-            (vnth 1 (chip-spec-qubits-on-link chip-spec link-index))
-            (funcall cost-function rewiring)
-            best-cost-so-far)
+     "SELECT-COST-LOWERING-SWAP: SWAP ~d ~d is best, lowering cost from ~d to ~d."
+     (vnth 0 (chip-spec-qubits-on-link chip-spec link-index))
+     (vnth 1 (chip-spec-qubits-on-link chip-spec link-index))
+     (funcall cost-function rewiring)
+     best-cost-so-far)
     link-index))
 
 (defun move-to-expected-rewiring (rewiring target-rewiring qq-distances chip-spec chip-sched initial-l2p use-free-swaps
@@ -111,8 +111,7 @@ instruction if it exists, and errors otherwise."
                                     (rewirings-tried nil))
   "This function inserts the necessary SWAP instructions to move from the working logical-to-physical
 rewiring REWIRING to the TARGET-REWIRING."
-  (format-noise "MOVE-TO-EXPECTED-REWIRING: Moving~%~a~%~a"
-          rewiring target-rewiring)
+  (format-noise "MOVE-TO-EXPECTED-REWIRING: Moving~%~a~%~a" rewiring target-rewiring)
   (flet ((cost-function (rewiring &key instr gate-weights)
            (declare (ignore instr gate-weights))
            (rewiring-distance rewiring target-rewiring qq-distances))
@@ -168,16 +167,14 @@ rewiring REWIRING to the TARGET-REWIRING."
       (update-rewiring initial-l2p q0 q1)
       (update-rewiring working-l2p q0 q1)
       (format-noise
-              "EMBED-SWAP: This is a free swap. :)~%~
-               EMBED-SWAP: New rewiring: ~a~%~
-               EMBED-SWAP: New initial rewiring: ~a"
-              working-l2p initial-l2p))
+       "EMBED-SWAP: This is a free swap. :)~%~
+        EMBED-SWAP: New rewiring: ~a~%~
+        EMBED-SWAP: New initial rewiring: ~a"
+       working-l2p initial-l2p))
      (t
       ;; in this case, this swap has to be performed by the QPU.
       ;; apply the link swap to working-l2p
       (update-rewiring working-l2p q0 q1)
-      (format-noise
-              "EMBED-SWAP: New rewiring: ~a"
-              working-l2p)
+      (format-noise "EMBED-SWAP: New rewiring: ~a" working-l2p)
       ;; insert the relevant 2q instruction
       (chip-schedule-append chip-sched (build-gate "SWAP" '() q0 q1))))))

--- a/src/addresser/embed-swap.lisp
+++ b/src/addresser/embed-swap.lisp
@@ -66,7 +66,7 @@ the cost of the rewiring is reduced."
                                     (depth *addresser-swap-lookahead-depth*))
   "Seaches for a 'SWAP' instruction that lowers the objective COST-FUNCTION. Returns such an
 instruction if it exists, and errors otherwise."
-  (format *compiler-noise-stream* "SELECT-COST-LOWERING-SWAP: Entrance.~%")
+  (format-noise "SELECT-COST-LOWERING-SWAP: Entrance.")
   (let* ((best-cost-so-far nil)
          (potential-first-links (cost-lowering-candidates rewiring
                                                           cost-function
@@ -98,8 +98,8 @@ instruction if it exists, and errors otherwise."
     (assert link-index
             nil
             "Failed to select a SWAP instruction. This can be caused by a disconnected qubit graph, a program with a lot of symmetry, or even random chance. You might simply try again, or you might try requesting a different addressing strategy.")
-    (format *compiler-noise-stream*
-            "SELECT-COST-LOWERING-SWAP: SWAP ~d ~d is best, lowering cost from ~d to ~d.~%"
+    (format-noise
+            "SELECT-COST-LOWERING-SWAP: SWAP ~d ~d is best, lowering cost from ~d to ~d."
             (vnth 0 (chip-spec-qubits-on-link chip-spec link-index))
             (vnth 1 (chip-spec-qubits-on-link chip-spec link-index))
             (funcall cost-function rewiring)
@@ -111,7 +111,7 @@ instruction if it exists, and errors otherwise."
                                     (rewirings-tried nil))
   "This function inserts the necessary SWAP instructions to move from the working logical-to-physical
 rewiring REWIRING to the TARGET-REWIRING."
-  (format *compiler-noise-stream* "MOVE-TO-EXPECTED-REWIRING: Moving~%~a~%~a~%"
+  (format-noise "MOVE-TO-EXPECTED-REWIRING: Moving~%~a~%~a"
           rewiring target-rewiring)
   (flet ((cost-function (rewiring &key instr gate-weights)
            (declare (ignore instr gate-weights))
@@ -167,17 +167,17 @@ rewiring REWIRING to the TARGET-REWIRING."
       ;; yes, we can. apply the link swap to initial-l2p and to working-l2p
       (update-rewiring initial-l2p q0 q1)
       (update-rewiring working-l2p q0 q1)
-      (format *compiler-noise-stream*
+      (format-noise
               "EMBED-SWAP: This is a free swap. :)~%~
                EMBED-SWAP: New rewiring: ~a~%~
-               EMBED-SWAP: New initial rewiring: ~a~%"
+               EMBED-SWAP: New initial rewiring: ~a"
               working-l2p initial-l2p))
      (t
       ;; in this case, this swap has to be performed by the QPU.
       ;; apply the link swap to working-l2p
       (update-rewiring working-l2p q0 q1)
-      (format *compiler-noise-stream*
-              "EMBED-SWAP: New rewiring: ~a~%"
+      (format-noise
+              "EMBED-SWAP: New rewiring: ~a"
               working-l2p)
       ;; insert the relevant 2q instruction
       (chip-schedule-append chip-sched (build-gate "SWAP" '() q0 q1))))))

--- a/src/addresser/logical-schedule.lisp
+++ b/src/addresser/logical-schedule.lisp
@@ -570,7 +570,7 @@ mapping instructions to their tags. "
   (labels
       ((get-fidelity (instr)
          (labels ((warn-and-skip (instr)
-                    (format *compiler-noise-stream* "Unknown fidelity for ~/cl-quil::instruction-fmt/. Skipping." instr)
+                    (format-noise "Unknown fidelity for ~/cl-quil::instruction-fmt/. Skipping." instr)
                     (return-from get-fidelity 0d0)))
            (let (fidelity)
              (typecase instr

--- a/src/addresser/path-heuristic.lisp
+++ b/src/addresser/path-heuristic.lisp
@@ -69,7 +69,7 @@ rewiring."
                                 link-values
                                 :weight-on (+ (random 0.01) 1.0d0)
                                 :weight-off (if (= src dst) 0.2d0 0.6d0))
-    :finally (format *compiler-noise-stream* "SELECT-SWAP-PATH-TARGET: Link-values ~A~%" link-values)
+    :finally (format-noise "SELECT-SWAP-PATH-TARGET: Link-values ~A" link-values)
              (return (select-swap-by-values chip-spec link-values rewirings-tried rewiring))))
 
 (defun select-swap-path-gates (chip-spec qq-distances gates-in-waiting rewirings-tried rewiring)

--- a/src/addresser/temporal-addresser.lisp
+++ b/src/addresser/temporal-addresser.lisp
@@ -374,9 +374,9 @@ following swaps."
              instr)
      (when dry-run-escape
        (funcall dry-run-escape))
-     (format *compiler-noise-stream*
+     (format-noise
              "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a 1Q ~
-instruction, adding to logical queue.~%"
+instruction, adding to logical queue."
              instr)
      ;; dequeue and set the dirty bit  
      (lscheduler-dequeue-instruction (addresser-state-logical-schedule state) instr)

--- a/src/addresser/temporal-addresser.lisp
+++ b/src/addresser/temporal-addresser.lisp
@@ -375,9 +375,9 @@ following swaps."
      (when dry-run-escape
        (funcall dry-run-escape))
      (format-noise
-             "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a 1Q ~
+      "DEQUEUE-GATE-APPLICATION: ~/quil:instruction-fmt/ is a 1Q ~
 instruction, adding to logical queue."
-             instr)
+      instr)
      ;; dequeue and set the dirty bit  
      (lscheduler-dequeue-instruction (addresser-state-logical-schedule state) instr)
      (push instr (aref (temporal-addresser-state-1q-queues state)

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -63,8 +63,8 @@
                    (handler-case
                        (let ((result (funcall compilation-method instruction :context context)))
                          (let ((*print-pretty* nil))
-                           (format *compiler-noise-stream*
-                                   "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/.~%"
+                           (format-noise
+                                   "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
                                    compilation-method instruction))
                          (dolist (instr result)
                            (write-string "    " *compiler-noise-stream*)
@@ -84,8 +84,8 @@
       ;; if those fail, try the global compilers
       (map nil #'try-compiler (chip-specification-generic-compilers chip-spec))
       ;; if those failed too, there's really nothing more to do.
-      (format *compiler-noise-stream*
-              "APPLY-TRANSLATION-COMPILERS: Could not find a compiler for ~/quil:instruction-fmt/.~%"
+      (format-noise
+              "APPLY-TRANSLATION-COMPILERS: Could not find a compiler for ~/quil:instruction-fmt/."
               instruction)
       (give-up-compilation))))
 
@@ -159,7 +159,7 @@
 Returns a value list: (processed-program, of type parsed-program
                        topological-swaps, of type integer
                        unpreserved-block-duration, of type real)"
-  (format *compiler-noise-stream* "COMPILER-HOOK: entrance.~%")
+  (format-noise "COMPILER-HOOK: entrance.")
 
   (warm-chip-spec-lookup-cache chip-specification)
 
@@ -190,7 +190,7 @@ Returns a value list: (processed-program, of type parsed-program
     (check-preserved-blocks-skip-dead-qubits cfg chip-specification)
 
     (let ((*print-pretty* nil))
-      (format *compiler-noise-stream* "COMPILER-HOOK: initial rewiring ~A~%" initial-rewiring))
+      (format-noise "COMPILER-HOOK: initial rewiring ~A" initial-rewiring))
 
     ;; if we are expecting to manipulate protoquil, we segment the program-final
     ;; sequence of MEASURE instructions out into a separate CFG block, so that
@@ -241,7 +241,7 @@ Returns a value list: (processed-program, of type parsed-program
                    (redirect-edge blk fresh-block (outgoing registrant)))
              ;; try again, but with this new jump
              (push (list fresh-block registrant) block-stack)
-             (format *compiler-noise-stream* "COMPILER-HOOK: Introduced ~A to deal with the rewiring.~%"
+             (format-noise "COMPILER-HOOK: Introduced ~A to deal with the rewiring."
                      (basic-block-name fresh-block))))
 
          (touch-preserved-block (blk)
@@ -272,7 +272,7 @@ Returns a value list: (processed-program, of type parsed-program
                     (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
                     (processed-quil fully-native-quil))
                (dotimes (n *compressor-passes*)
-                 (format *compiler-noise-stream* "COMPILER-HOOK: Compressing, pass ~D/~D.~%" (1+ n) *compressor-passes*)
+                 (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
                  (setf processed-quil
                        (compress-instructions processed-quil chip-specification
                                               :protoquil (null registrant))))
@@ -282,7 +282,7 @@ Returns a value list: (processed-program, of type parsed-program
                (setf (basic-block-out-rewiring blk) final-l2p)
                (incf topological-swaps local-topological-swaps)
                (incf unpreserved-duration duration)
-               (format *compiler-noise-stream* "COMPILER-HOOK: Done processing block ~A.~%" (basic-block-name blk)))))
+               (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
 
          (touch-reset-block (blk)
            ;; actually process this block
@@ -301,7 +301,7 @@ Returns a value list: (processed-program, of type parsed-program
                     (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
                     (processed-quil fully-native-quil))
                (dotimes (n *compressor-passes*)
-                 (format *compiler-noise-stream* "COMPILER-HOOK: Compressing, pass ~D/~D.~%" (1+ n) *compressor-passes*)
+                 (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
                  (setf processed-quil
                        (compress-instructions processed-quil chip-specification
                                               :protoquil t)))
@@ -311,7 +311,7 @@ Returns a value list: (processed-program, of type parsed-program
                (setf (basic-block-out-rewiring blk) final-l2p)
                (incf topological-swaps local-topological-swaps)
                (incf unpreserved-duration duration)
-               (format *compiler-noise-stream* "COMPILER-HOOK: Done processing block ~A.~%" (basic-block-name blk)))))
+               (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
 
          (process-block (blk registrant)
            ;; if this block is expecting a rewiring, we should make sure the
@@ -325,7 +325,7 @@ Returns a value list: (processed-program, of type parsed-program
                    (initial-l2p (if (typep blk 'preserved-block)
                                     (make-rewiring (chip-spec-n-qubits chip-specification))
                                     (basic-block-in-rewiring blk))))
-               (format *compiler-noise-stream* "COMPILER-HOOK: Matching rewiring from ~A (~A) to ~A (~A).~%"
+               (format-noise "COMPILER-HOOK: Matching rewiring from ~A (~A) to ~A (~A)."
                        (basic-block-name registrant)
                        final-l2p
                        (basic-block-name blk)
@@ -341,7 +341,7 @@ Returns a value list: (processed-program, of type parsed-program
              (return-from process-block))
 
            (let ((*print-pretty* nil))
-             (format *compiler-noise-stream* "COMPILER-HOOK: Visiting ~A for the first time, coming from ~A (~A).~%"
+             (format-noise "COMPILER-HOOK: Visiting ~A for the first time, coming from ~A (~A)."
                      (basic-block-name blk)
                      (and registrant (basic-block-name registrant))
                      (and registrant (basic-block-out-rewiring registrant))))

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -67,9 +67,9 @@
                             "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
                             compilation-method instruction))
                          (dolist (instr result)
-                           (write-string "    " *compiler-noise-stream*)
-                           (print-instruction instr *compiler-noise-stream*)
-                           (terpri *compiler-noise-stream*))
+                           (write-string "    " *compiler-noise*)
+                           (print-instruction instr *compiler-noise*)
+                           (terpri *compiler-noise*))
                          (return-from apply-translation-compilers result))
                      (compiler-does-not-apply () nil))
                  (try-next-compiler ()

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -64,8 +64,8 @@
                        (let ((result (funcall compilation-method instruction :context context)))
                          (let ((*print-pretty* nil))
                            (format-noise
-                                   "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
-                                   compilation-method instruction))
+                            "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
+                            compilation-method instruction))
                          (dolist (instr result)
                            (write-string "    " *compiler-noise-stream*)
                            (print-instruction instr *compiler-noise-stream*)
@@ -85,8 +85,8 @@
       (map nil #'try-compiler (chip-specification-generic-compilers chip-spec))
       ;; if those failed too, there's really nothing more to do.
       (format-noise
-              "APPLY-TRANSLATION-COMPILERS: Could not find a compiler for ~/quil:instruction-fmt/."
-              instruction)
+       "APPLY-TRANSLATION-COMPILERS: Could not find a compiler for ~/quil:instruction-fmt/."
+       instruction)
       (give-up-compilation))))
 
 
@@ -242,7 +242,7 @@ Returns a value list: (processed-program, of type parsed-program
              ;; try again, but with this new jump
              (push (list fresh-block registrant) block-stack)
              (format-noise "COMPILER-HOOK: Introduced ~A to deal with the rewiring."
-                     (basic-block-name fresh-block))))
+                           (basic-block-name fresh-block))))
 
          (touch-preserved-block (blk)
            ;; if so, then we don't have any business compiling it. treat
@@ -342,9 +342,9 @@ Returns a value list: (processed-program, of type parsed-program
 
            (let ((*print-pretty* nil))
              (format-noise "COMPILER-HOOK: Visiting ~A for the first time, coming from ~A (~A)."
-                     (basic-block-name blk)
-                     (and registrant (basic-block-name registrant))
-                     (and registrant (basic-block-out-rewiring registrant))))
+                           (basic-block-name blk)
+                           (and registrant (basic-block-name registrant))
+                           (and registrant (basic-block-out-rewiring registrant))))
            ;; set the block-initial-l2p, forced by the previous block
            (when registrant
              (setf (basic-block-in-rewiring blk)

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -66,10 +66,11 @@
                            (format-noise
                             "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
                             compilation-method instruction))
-                         (dolist (instr result)
-                           (write-string "    " *compiler-noise*)
-                           (print-instruction instr *compiler-noise*)
-                           (terpri *compiler-noise*))
+                         (when *compiler-noise*
+                           (dolist (instr result)
+                             (write-string "    " *compiler-noise*)
+                             (print-instruction instr *compiler-noise*)
+                             (terpri *compiler-noise*)))
                          (return-from apply-translation-compilers result))
                      (compiler-does-not-apply () nil))
                  (try-next-compiler ()
@@ -375,10 +376,10 @@ Returns a value list: (processed-program, of type parsed-program
 
       ;; kick off the traversal
       (exhaust-stack)
-      
+
       ;; one more pass of CFG collapse
       (simplify-cfg cfg)
-      
+
       (let ((processed-program (reconstitute-program cfg)))
         ;; Keep global PRAGMAS in the code, at the top of the file.
         (setf (parsed-program-executable-code processed-program)

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -66,11 +66,7 @@
                            (format-noise
                             "APPLY-TRANSLATION-COMPILERS: Applying ~A to ~/quil:instruction-fmt/."
                             compilation-method instruction))
-                         (when *compiler-noise*
-                           (dolist (instr result)
-                             (write-string "    " *compiler-noise*)
-                             (print-instruction instr *compiler-noise*)
-                             (terpri *compiler-noise*)))
+                         (format-noise "~{    ~/quil:instruction-fmt/~%~}" result)
                          (return-from apply-translation-compilers result))
                      (compiler-does-not-apply () nil))
                  (try-next-compiler ()

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -709,8 +709,8 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
       (dolist (circuit-crafter crafters)
         (unless (and (first candidate-pairs)
                      (double= 1d0 (car (first candidate-pairs))))
-          (format *compiler-noise-stream*
-                  "~&APPROXIMATE-2Q-COMPILER: Trying ~A on ~A...~%"
+          (format-noise
+                  "~&APPROXIMATE-2Q-COMPILER: Trying ~A on ~A..."
                   circuit-crafter
                   (with-output-to-string (s) (print-instruction instr s)))
           (handler-case
@@ -727,8 +727,8 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
                                    (mapcar #'constant-value (application-parameters can))
                                    (get-canonical-coords-from-diagonal
                                     (nth-value 1 (orthogonal-decomposition m))))))
-                  (format *compiler-noise-stream*
-                          " for infidelity ~A.~%" infidelity)
+                  (format-noise
+                          " for infidelity ~A." infidelity)
                   (push (cons (* circuit-cost (- 1 infidelity)) sandwiched-circuit)
                         candidate-pairs)))
             (compiler-does-not-apply () nil))))

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -710,9 +710,9 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
         (unless (and (first candidate-pairs)
                      (double= 1d0 (car (first candidate-pairs))))
           (format-noise
-                  "~&APPROXIMATE-2Q-COMPILER: Trying ~A on ~A..."
-                  circuit-crafter
-                  (with-output-to-string (s) (print-instruction instr s)))
+           "~&APPROXIMATE-2Q-COMPILER: Trying ~A on ~A..."
+           circuit-crafter
+           (with-output-to-string (s) (print-instruction instr s)))
           (handler-case
               (let* ((center-circuit (funcall circuit-crafter can))
                      (ls (append-instructions-to-lschedule (make-lscheduler) center-circuit))
@@ -727,8 +727,7 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
                                    (mapcar #'constant-value (application-parameters can))
                                    (get-canonical-coords-from-diagonal
                                     (nth-value 1 (orthogonal-decomposition m))))))
-                  (format-noise
-                          " for infidelity ~A." infidelity)
+                  (format-noise " for infidelity ~A." infidelity)
                   (push (cons (* circuit-cost (- 1 infidelity)) sandwiched-circuit)
                         candidate-pairs)))
             (compiler-does-not-apply () nil))))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -606,27 +606,31 @@ other's."
                                                        reduced-decompiled-instructions
                                                        context)
     
-        ;; compare their respective runtimes and return the shorter one
-        (let ((result-instructions
-                (cond
-                  ((and decompiled-instructions
-                        (not (equalp decompiled-instructions reduced-decompiled-instructions))
-                        (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
-                           (calculate-instructions-duration reduced-instructions chip-specification)))
-                   reduced-decompiled-instructions)
-                  (t
-                   reduced-instructions))))
-          (format-quil-sequence *compiler-noise-stream*
-                                result-instructions
-                                "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%")
-          result-instructions))))
+      ;; compare their respective runtimes and return the shorter one
+      (let ((result-instructions
+             (cond
+              ((and decompiled-instructions
+                    (not (equalp decompiled-instructions reduced-decompiled-instructions))
+                    (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
+                       (calculate-instructions-duration reduced-instructions chip-specification)))
+               reduced-decompiled-instructions)
+              (t
+               reduced-instructions))))
+        (when *compiler-noise*
+          (format-quil-sequence *compiler-noise*
+                              result-instructions
+                              "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
+        
+        result-instructions))))
 
 
 (defun compress-instructions-with-possibly-unknown-params (instructions chip-specification context &optional processed-instructions)
   "Dispatch routine for compressing a sequence of INSTRUCTIONS, perhaps with unknown parameter values sprinkled through, based on the routines specified by a CHIP-SPECIFICATION and the current CONTEXT."
-  (format-quil-sequence *compiler-noise-stream*
+  (when *compiler-noise*
+     (format-quil-sequence *compiler-noise*
                         instructions
-                        "COMPRESS-INSTRUCTIONS: Selected the following sequence for compression:~%")
+                        "COMPRESS-INSTRUCTIONS: Selected the following sequence for compression:~%"))
+ 
   ;;
   ;; we can't apply linear algebraic rewriting to instructions with unknown
   ;; parameters, so the plan is to carve up the incoming sequence of INSTRUCTIONS

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -281,8 +281,8 @@ other's."
                                                       (peephole-rewriter-node-prev
                                                        (first relevant-nodes-for-inspection))))))))
                        (format-noise
-                               "ALGEBRAICALLY-REDUCE-INSTRUCTIONS: Applying the rewriting rule called ~A."
-                               (compiler-name rule))
+                        "ALGEBRAICALLY-REDUCE-INSTRUCTIONS: Applying the rewriting rule called ~A."
+                        (compiler-name rule))
                        ;; if the rule was triggered, splice it in and remove
                        ;; all of the instructions that the rule touched.
                        ;;
@@ -605,32 +605,31 @@ other's."
                                                        reduced-instructions
                                                        reduced-decompiled-instructions
                                                        context)
-    
-      ;; compare their respective runtimes and return the shorter one
-      (let ((result-instructions
-             (cond
-              ((and decompiled-instructions
-                    (not (equalp decompiled-instructions reduced-decompiled-instructions))
-                    (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
-                       (calculate-instructions-duration reduced-instructions chip-specification)))
-               reduced-decompiled-instructions)
-              (t
-               reduced-instructions))))
-        (when *compiler-noise*
-          (format-quil-sequence *compiler-noise*
-                              result-instructions
-                              "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
-        
-        result-instructions))))
+
+       
+        ;; compare their respective runtimes and return the shorter one
+        (let ((result-instructions
+                (cond
+                  ((and decompiled-instructions
+                        (not (equalp decompiled-instructions reduced-decompiled-instructions))
+                        (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
+                           (calculate-instructions-duration reduced-instructions chip-specification)))
+                   reduced-decompiled-instructions)
+                  (t
+                   reduced-instructions))))
+          (when *compiler-noise*
+            (format-quil-sequence *compiler-noise-stream*
+                                  result-instructions
+                                  "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
+          result-instructions))))
 
 
 (defun compress-instructions-with-possibly-unknown-params (instructions chip-specification context &optional processed-instructions)
   "Dispatch routine for compressing a sequence of INSTRUCTIONS, perhaps with unknown parameter values sprinkled through, based on the routines specified by a CHIP-SPECIFICATION and the current CONTEXT."
   (when *compiler-noise*
-     (format-quil-sequence *compiler-noise*
-                        instructions
-                        "COMPRESS-INSTRUCTIONS: Selected the following sequence for compression:~%"))
- 
+    (format-quil-sequence *compiler-noise*
+                          instructions
+                          "COMPRESS-INSTRUCTIONS: Selected the following sequence for compression:~%"))
   ;;
   ;; we can't apply linear algebraic rewriting to instructions with unknown
   ;; parameters, so the plan is to carve up the incoming sequence of INSTRUCTIONS

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -280,8 +280,8 @@ other's."
                                      (list ':context (peephole-rewriter-node-context
                                                       (peephole-rewriter-node-prev
                                                        (first relevant-nodes-for-inspection))))))))
-                       (format *compiler-noise-stream*
-                               "ALGEBRAICALLY-REDUCE-INSTRUCTIONS: Applying the rewriting rule called ~A.~%"
+                       (format-noise
+                               "ALGEBRAICALLY-REDUCE-INSTRUCTIONS: Applying the rewriting rule called ~A."
                                (compiler-name rule))
                        ;; if the rule was triggered, splice it in and remove
                        ;; all of the instructions that the rule touched.
@@ -589,12 +589,10 @@ other's."
             reduced-decompiled-instructions)
     
         ;; now proceed to do the reductions
-        (format *compiler-noise-stream*
-                "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to original string.~%")
+        (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to original string.")
         (setf reduced-instructions
               (algebraically-reduce-instructions instructions chip-specification context))
-        (format *compiler-noise-stream*
-                "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to recompiled string.~%")
+        (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to recompiled string.")
         (when decompiled-instructions
           (setf reduced-decompiled-instructions
                 (algebraically-reduce-instructions decompiled-instructions
@@ -737,7 +735,7 @@ other's."
   "Compresses a sequence of INSTRUCTIONS based on the routines specified by a CHIP-SPECIFICATION.
 
 This specific routine is the start of a giant dispatch mechanism. Its role is to find SHORT SEQUENCES (so that producing their matrix form is not too expensive) of instructions WHOSE RESOURCES OVERLAP (so that the peephole rewriter stands a chance of finding instructions that cancel)."
-  (format *compiler-noise-stream* "COMPRESS-INSTRUCTIONS: entrance.~%")
+  (format-noise "COMPRESS-INSTRUCTIONS: entrance.")
   ;; set up the places where our state will live
   (let* ((output nil)
          (n-qubits (chip-spec-n-qubits chip-specification))
@@ -1115,8 +1113,7 @@ This specific routine is the start of a giant dispatch mechanism. Its role is to
         :downto 0
         :do (dotimes (address (length (nth order governors)))
               (transition-governor-state order address ':flushing))))
-    (format *compiler-noise-stream*
-            "COMPRESS-INSTRUCTIONS: departure.~%")
+    (format-noise "COMPRESS-INSTRUCTIONS: departure.")
     (nreverse output)))
 
 

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -604,9 +604,7 @@ other's."
                                                        decompiled-instructions
                                                        reduced-instructions
                                                        reduced-decompiled-instructions
-                                                       context)
-
-       
+                                                       context)       
         ;; compare their respective runtimes and return the shorter one
         (let ((result-instructions
                 (cond
@@ -618,7 +616,7 @@ other's."
                   (t
                    reduced-instructions))))
           (when *compiler-noise*
-            (format-quil-sequence *compiler-noise-stream*
+            (format-quil-sequence *compiler-noise*
                                   result-instructions
                                   "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
           result-instructions))))

--- a/src/define-pragma.lisp
+++ b/src/define-pragma.lisp
@@ -411,7 +411,5 @@ the display of a specialized pragma instruction.")
                                                           freeform-string)))
                (apply #'change-class instr new-class initargs)))
             (t
-             (format *compiler-noise-stream*
-                     "SPECIALIZE-PRAGMA: Unknown PRAGMA type ~A.~%"
-                     name)
+             (format-noise "SPECIALIZE-PRAGMA: Unknown PRAGMA type ~A." name)
              instr)))))

--- a/src/options.lisp
+++ b/src/options.lisp
@@ -18,10 +18,10 @@
   "The function used to handle/resolve pathnames passed to INCLUDE directives in Quil. Specifically, it should be a function designator that takes one argument (a pathname designator) and returns the absolute pathname to include, or signals an error.")
 
 (defvar *compiler-noise* nil
-  "The stream used to emit compiler debug output to. This variable can be bound to a stream that suppresses display, eg (make-broadcast-stream).")
+  "The stream on which to emit compiler debug output or NIL to suppress compiler noise.")
 
 (defmacro format-noise (str &rest args)
-  "format-noise checks to see whether *compiler-noise* has been set and, if so, formats it according to the passed format string and arguments."
+  "FORMAT-NOISE checks to see whether *COMPILER-NOISE* has been set and, if so, formats it according to the passed format string and arguments."
   `(progn
      (when *compiler-noise*
        (format *compiler-noise* ,str ,@args)

--- a/src/options.lisp
+++ b/src/options.lisp
@@ -17,8 +17,16 @@
 (defvar *resolve-include-pathname* 'identity
   "The function used to handle/resolve pathnames passed to INCLUDE directives in Quil. Specifically, it should be a function designator that takes one argument (a pathname designator) and returns the absolute pathname to include, or signals an error.")
 
-(defvar *compiler-noise-stream* (make-broadcast-stream)
-  "The stream used to emit compiler debug output to.  By default, this variable is bound to a stream that suppresses display.")
+(defvar *compiler-noise* nil
+  "The stream used to emit compiler debug output to. This variable can be bound to a stream that suppresses display, eg (make-broadcast-stream).")
+
+(defmacro format-noise (str &rest args)
+  "format-noise checks to see whether *compiler-noise* has been set and, if so, formats it according to the passed format string and arguments."
+  `(progn
+     (when *compiler-noise*
+       (format *compiler-noise* ,str ,@args)
+       (fresh-line *compiler-noise*))
+     (values)))
 
 (defvar *compress-carefully* nil
   "Flag that turns on/off a bunch of intermediate correctness checks during compression.  WARNING: this can be *very* costly, since it involves computing explicit matrix presentations.")


### PR DESCRIPTION
* replace `format *compiler-noise*` with `format-noise` which includes check to see if defined.
* `format-noise` includes fresh line.