### PR TITLE
Reference PARSED-QUILT-PROGRAM accessors from the appropriate package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,18 @@ test-cl-quil:
     - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
     - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
 
+test-quilt:
+  stage: test
+  tags:
+    - github
+    - dockerd
+  only:
+    - branches
+  image: docker:stable
+  script:
+    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
+    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-quilt
+    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
 
 test-quilc:
   stage: test

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ test:
 	$(QUICKLISP) \
 		--eval "(ql:quickload :cl-quil-tests)" \
 		--eval "(asdf:test-system :cl-quil)" \
+		--eval "(ql:quickload :cl-quil/quilt-tests)" \
+		--eval "(asdf:test-system :cl-quil/quilt)" \
 		--eval "(ql:quickload :quilc-tests)" \
 		--eval "(asdf:test-system :quilc)"
 
@@ -137,6 +139,11 @@ test-quilc:
 	$(QUICKLISP) \
 		--eval "(ql:quickload :quilc-tests)" \
 		--eval "(asdf:test-system :quilc)"
+
+test-quilt:
+	$(QUICKLISP) \
+		--eval "(ql:quickload :cl-quil/quilt-tests)" \
+		--eval "(asdf:test-system :cl-quil/quilt)"
 
 # You can specify a different c++17-compatible compiler via the CXX
 # variable. For example: make CXX=/usr/bin/clang++ test-tweedledum

--- a/src/quilt/package.lisp
+++ b/src/quilt/package.lisp
@@ -126,5 +126,10 @@
    #:parse-quilt-into-raw-program       ; FUNCTION
    #:parse-quilt                        ; FUNCTION
    #:read-quilt-file                    ; FUNCTION
+
+   #:parsed-quilt-program                   ; CLASS
+   #:parsed-program-waveform-definitions    ; READER
+   #:parsed-program-calibration-definitions ; READER
+   #:parsed-program-frame-definitions       ; READER
    )
   )

--- a/tests/quilt/parser-tests.lisp
+++ b/tests/quilt/parser-tests.lisp
@@ -150,9 +150,9 @@ DEFWAVEFORM wf 1.0:
                (prints-as (format nil def)
                           (concatenate 'string (format nil def) (format nil boilerplate))
                           :accessor accessor))))
-      (verify-definitions frame-defns #'quil:parsed-program-frame-definitions)
-      (verify-definitions waveform-defns #'quil:parsed-program-waveform-definitions)
-      (verify-definitions calibration-defns #'quil:parsed-program-calibration-definitions))))
+      (verify-definitions frame-defns #'parsed-program-frame-definitions)
+      (verify-definitions waveform-defns #'parsed-program-waveform-definitions)
+      (verify-definitions calibration-defns #'parsed-program-calibration-definitions))))
 
 (deftest test-definition-signature ()
   (flet ((signature (raw-quil &rest args)


### PR DESCRIPTION
Export the following symbols from the CL-QUIL.QUILT package:

   - `PARSED-QUILT-PROGRAM                   ; CLASS`
   - `PARSED-PROGRAM-WAVEFORM-DEFINITIONS    ; READER`
   - `PARSED-PROGRAM-CALIBRATION-DEFINITIONS ; READER`
   - `PARSED-PROGRAM-FRAME-DEFINITIONS       ; READER`

The last three were previously exported from CL-QUIL, even though they no longer live there, and were removed from CL-QUIL exported symbols in #583.

`PARSED-QUILT-PROGRAM` was previously not exported anywhere, but seems reasonable to export as well.

Additionally, add a `test-quilt` Makefile target, and run it when running `make test`.