### PR TITLE
Fix floating point regex in plundered-regex-gold.quil

### DIFF
--- a/tests/printer-test-files/gold-regex/plundered-regex-gold.quil
+++ b/tests/printer-test-files/gold-regex/plundered-regex-gold.quil
@@ -181,7 +181,7 @@ PRAGMA BLOCK
 CPHASE\(0\.2\) 0 1
 PRAGMA END_BLOCK
 PRAGMA BLOCK
-CPHASE\(0\.30{4,}\d*\) 0 2
+CPHASE\(0\.3\d*\) 0 2
 PRAGMA END_BLOCK
 PRAGMA BLOCK
 CPHASE\(0\.4\) 1 2
@@ -448,7 +448,7 @@ CZ 0 2
 RX(0.2) 1
 
 # Output
-RY\(0\.30{4,}\d*\) 0
+RY\(0\.3\d*\) 0
 CZ 0 2
 RX\(0\.2\) 1
 


### PR DESCRIPTION
A [recent update](https://github.com/soemraws/parse-float/commit/2d11b77647aa33efab31dbe0720b8fca9a274c81) to `PARSE-FLOAT` has changed the parsing of "0.3", which previously resulted in something like 0.30000000000000004 when printed, but now results in 0.3.

The new regex should be compatible with both old and new versions of `PARSE-FLOAT`.

Fixes #588