### PR TITLE
If quilc is latest version, don't print the SDK version check log message

### DIFF
--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -80,9 +80,6 @@ version. Second value returned indicates the latest version."
          ((null latest)
           ;; There was some kind of issue getting the version and a warning was already emitted.
           )
-         ((not available?)
-          (cl-syslog:rfc-log (*logger* :info "This is the latest version of the SDK.")
-            (:msgid "LOG0001")))
          (available?
           (cl-syslog:rfc-log (*logger* :notice "An update is available to the SDK. You have version ~A. ~
 Version ~A is available from https://downloads.rigetti.com/~%"

--- a/app/src/versions.lisp
+++ b/app/src/versions.lisp
@@ -82,7 +82,7 @@ version. Second value returned indicates the latest version."
           )
          (available?
           (cl-syslog:rfc-log (*logger* :notice "An update is available to the SDK. You have version ~A. ~
-Version ~A is available from https://downloads.rigetti.com/~%"
+Version ~A is available from https://qcs.rigetti.com/sdk-downloads~%"
                                        +QUILC-VERSION+ latest)
             (:msgid "LOG0001"))))))
    :name "Version Check"))


### PR DESCRIPTION
What's the use?