### PR TITLE
Better errors and coercing for param values

### DIFF
--- a/src/build-gate.lisp
+++ b/src/build-gate.lisp
@@ -25,6 +25,10 @@
   (typecase param
     (double-float
      (constant param))
+    (real
+     (constant (coerce param 'double-float)))
+    (complex
+     (error "Complex-valued gate parameter ~S not permitted" param))
     (memory-ref
      (make-delayed-expression nil nil param))
     (otherwise


### PR DESCRIPTION
- Coerce non-double reals to doubles

- Signal an explicit error for complexes

Fixes #434.