### PR TITLE
Allow freely parameterized RX gates

### DIFF
--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -705,8 +705,7 @@ other's."
       (let ((new-context context))
         (dolist (instr first-block)
           (setf new-context
-                (update-compilation-context new-context instr
-                                            :destructive? nil)))
+                (update-compilation-context new-context instr :destructive? nil)))
         (return-from compress-instructions-with-possibly-unknown-params
           (compress-instructions-with-possibly-unknown-params
            (nconc second-block instr-rest)

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -403,8 +403,8 @@ other's."
          ;; as the matrix representation of INSTRUCTIONS
          (decompile-instructions-into-full-unitary ()
            (a:when-let ((matrix (make-matrix-from-quil
-                                          instructions
-                                          :relabeling (standard-qubit-relabeler qubits-on-obj))))
+                                 instructions
+                                 :relabeling (standard-qubit-relabeler qubits-on-obj))))
              (expand-to-native-instructions
               (list (make-instance 'gate-application
                                    :operator #.(named-operator "WHOLEPROGRAM")
@@ -589,45 +589,44 @@ other's."
                             ;; here. We just want to indicate to the
                             ;; user that an error happened down here.
                             ))))
-      ;; start by making a decision about how we're going to do linear algebraic compression
-      (let ((decompiled-instructions (decompile-instructions-in-context instructions
-                                                                        chip-specification
-                                                                        context))
-            reduced-instructions
-            reduced-decompiled-instructions)
-    
-        ;; now proceed to do the reductions
-        (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to original string.")
-        (setf reduced-instructions
-              (algebraically-reduce-instructions instructions chip-specification context))
-        (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to recompiled string.")
-        (when decompiled-instructions
-          (setf reduced-decompiled-instructions
-                (algebraically-reduce-instructions decompiled-instructions
-                                                   chip-specification
-                                                   context)))
-    
-        ;; check that the quil that came out was the same as the quil that went in
-        (check-contextual-compression-was-well-behaved instructions
-                                                       decompiled-instructions
-                                                       reduced-instructions
-                                                       reduced-decompiled-instructions
-                                                       context)       
-        ;; compare their respective runtimes and return the shorter one
-        (let ((result-instructions
-                (cond
-                  ((and decompiled-instructions
-                        (not (equalp decompiled-instructions reduced-decompiled-instructions))
-                        (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
-                           (calculate-instructions-duration reduced-instructions chip-specification)))
-                   reduced-decompiled-instructions)
-                  (t
-                   reduced-instructions))))
-          (when *compiler-noise*
-            (format-quil-sequence *compiler-noise*
-                                  result-instructions
-                                  "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
-          result-instructions))))
+    ;; start by making a decision about how we're going to do linear algebraic compression
+    (let ((decompiled-instructions (decompile-instructions-in-context instructions
+                                                                      chip-specification
+                                                                      context))
+          reduced-instructions
+          reduced-decompiled-instructions)
+
+      ;; now proceed to do the reductions
+      (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to original string.")
+      (setf reduced-instructions
+            (algebraically-reduce-instructions instructions chip-specification context))
+      (format-noise "COMPRESS-INSTRUCTIONS: Applying algebraic rewrites to recompiled string.")
+      (when decompiled-instructions
+        (setf reduced-decompiled-instructions
+              (algebraically-reduce-instructions decompiled-instructions
+                                                 chip-specification
+                                                 context)))
+
+      ;; check that the quil that came out was the same as the quil that went in
+      (check-contextual-compression-was-well-behaved instructions
+                                                     decompiled-instructions
+                                                     reduced-instructions
+                                                     reduced-decompiled-instructions
+                                                     context)
+      ;; compare their respective runtimes and return the shorter one
+      (let ((result-instructions
+              (cond
+                ((and decompiled-instructions
+                      (< (calculate-instructions-duration reduced-decompiled-instructions chip-specification)
+                         (calculate-instructions-duration reduced-instructions chip-specification)))
+                 reduced-decompiled-instructions)
+                (t
+                 reduced-instructions))))
+        (when *compiler-noise*
+          (format-quil-sequence *compiler-noise*
+                                result-instructions
+                                "COMPRESS-INSTRUCTIONS: Replacing the above sequence with the following:~%"))
+        result-instructions))))
 
 
 (defun compress-instructions-with-possibly-unknown-params (instructions chip-specification context &optional processed-instructions)
@@ -707,7 +706,7 @@ other's."
         (dolist (instr first-block)
           (setf new-context
                 (update-compilation-context new-context instr
-                                           :destructive? nil)))
+                                            :destructive? nil)))
         (return-from compress-instructions-with-possibly-unknown-params
           (compress-instructions-with-possibly-unknown-params
            (nconc second-block instr-rest)

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -707,15 +707,15 @@ N.B.: The word \"shortest\" here is a bit fuzzy.  In practice it typically means
         
         ;; these are basically all the compilers we care to use; now we need to
         ;; sort them into preference order.
-        (let* ((sorted-compilers
-                 (stable-sort (remove-duplicates
-                               (append (loop :for compiler :being :the :hash-keys :of compiler-hash
-                                             :collect compiler)
-                                       (loop :for compiler :in generic-path
-                                             :when (typep compiler 'compiler)
-                                               :collect compiler)))
-                              #'>
-                              :key (lambda (x) (gethash x compiler-hash))))
+        (let* ((unique-compilers
+                 (remove-duplicates
+                  (append (loop :for compiler :being :the :hash-keys :of compiler-hash
+                                :collect compiler)
+                          (loop :for compiler :in generic-path
+                                :when (typep compiler 'compiler)
+                                  :collect compiler))))
+               (sorted-compilers
+                 (stable-sort unique-compilers #'> :key (lambda (x) (gethash x compiler-hash))))
                ;; additionally, we install a couple extra compilers as hax to make
                ;; the whole machine work. each such hak comes with an explanation,
                ;; and it would be preferable to work to make each hak unnecessary.

--- a/tests/qpu-test-files/1q-free-rx.qpu
+++ b/tests/qpu-test-files/1q-free-rx.qpu
@@ -1,0 +1,83 @@
+{
+    "isa": {
+        "1Q": {
+            "0": {
+                "gates": [
+                    {
+                        "operator": "I",
+                        "parameters": [],
+                        "arguments": [
+                            "_"
+                        ],
+                        "fidelity": null,
+                        "duration": null
+                    },
+                    {
+                        "operator": "RX",
+                        "parameters": [
+                           "theta"
+                        ],
+                        "arguments": [
+                            "_"
+                        ],
+                        "fidelity": null,
+                        "duration": null
+                    },
+                    {
+                        "operator": "RZ",
+                        "parameters": [
+                            "theta"
+                        ],
+                        "arguments": [
+                            "_"
+                        ],
+                        "fidelity": null,
+                        "duration": null
+                    },
+                    {
+                        "operator": "MEASURE",
+                        "qubit": "_",
+                        "target": "_",
+                        "duration": null,
+                        "fidelity": null
+                    },
+                    {
+                        "operator": "MEASURE",
+                        "qubit": "_",
+                        "target": null,
+                        "duration": null,
+                        "fidelity": null
+                    }
+                ]
+            }
+        },
+        "2Q": {
+            
+        }
+    },
+    "specs": {
+        "1Q": {
+            "0": {
+                "f1QRB": 0.909,
+                "f1QRB_std_err": 0.01,
+                "f1Q_simultaneous_RB": 0.909,
+                "f1Q_simultaneous_RB_std_err": 0.02,
+                "fRO": 0.9,
+                "T1": 3e-05,
+                "T2": 3e-05,
+                "fActiveReset": 0.909
+            },
+            "1": {
+                "f1QRB": 0.909,
+                "f1QRB_std_err": 0.01,
+                "f1Q_simultaneous_RB": 0.909,
+                "f1Q_simultaneous_RB_std_err": 0.02,
+                "fRO": 0.9,
+                "T1": 3e-05,
+                "T2": 3e-05,
+                "fActiveReset": 0.909
+            }
+        },
+        "2Q": null
+    }
+}


### PR DESCRIPTION
Closes #610. In an ISA, under the "gates" key one can specify a parameter value for which the gate is native. For example, on Aspen chips `RX` is native only for parameter values of `0`, `pi/2`, `pi`, `-pi/2`, and `-pi`. This restriction is occasionally baked-into the compiler, rather than just in the ISA. I remove that restriction, allowing freely parameterized RXs as the output of compilation:
```
;; produce a 1Q program on qubit 0, with 10 interleaved RX or RZ gates
(print-parsed-program (compiler-hook (random-1q-program 0 10) chip))

RX(0.8883713366102477) 0                # Entering rewiring: #(0)
RZ(-1.8883138383394045) 0
RX(2.8851948642306953) 0
```
where chip is given by this ISA:
```
{
    "isa": {
        "1Q": {
            "0": {
                "gates": [
                    {
                        "operator": "I",
                        "parameters": [],
                        "arguments": [
                            "_"
                        ],
                        "fidelity": null,
                        "duration": null
                    },
                    {
                        "operator": "RX",
                        "parameters": [
                           "theta"
                        ],
                        "arguments": [
                            "_"
                        ],
                        "fidelity": null,
                        "duration": null
                    },
                    {
                        "operator": "RZ",
                        "parameters": [
                            "theta"
                        ],
                        "arguments": [
                            "_"
                        ],
                        "fidelity": null,
                        "duration": null
                    },
                    {
                        "operator": "MEASURE",
                        "qubit": "_",
                        "target": "_",
                        "duration": null,
                        "fidelity": null
                    },
                    {
                        "operator": "MEASURE",
                        "qubit": "_",
                        "target": null,
                        "duration": null,
                        "fidelity": null
                    }
                ]
            }
        },
        "2Q": {
            
        }
    },
    "specs": {
        "1Q": {
            "0": {
                "f1QRB": 0.909,
                "f1QRB_std_err": 0.01,
                "f1Q_simultaneous_RB": 0.909,
                "f1Q_simultaneous_RB_std_err": 0.02,
                "fRO": 0.9,
                "T1": 3e-05,
                "T2": 3e-05,
                "fActiveReset": 0.909
            },
            "1": {
                "f1QRB": 0.909,
                "f1QRB_std_err": 0.01,
                "f1Q_simultaneous_RB": 0.909,
                "f1Q_simultaneous_RB_std_err": 0.02,
                "fRO": 0.9,
                "T1": 3e-05,
                "T2": 3e-05,
                "fActiveReset": 0.909
            }
        },
        "2Q": null
    }
}
```

This decouples part of the compiler from a particular architecture choice (in this case the particular parameterization of `RX` for Rigetti hardware) and makes the ISA more flexible (and retargetable, as we claim to be).

TODO
- [ ] Test