### PR TITLE
initial proposal for quilc backends

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -30,6 +30,8 @@
                #:cl-heap
                #:cl-permutation
                #:queues.priority-queue
+               #:ironclad               ; Signing executables
+               #:flexi-streams          ; For executable writing
                #+sbcl #:sb-rotate-byte
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil-tests)))
@@ -106,6 +108,12 @@
                 :serial t
                 :components ((:file "chip-specification")
                              (:file "chip-reader")))
+               (:module "backends"
+                :serial t
+                :components ((:file "common")
+                             (:module "quil"
+                              :serial t
+                              :components ((:file "quil-backend")))))
                (:module "addresser"
                 :serial t
                 :components ((:file "rewiring")

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -78,5 +78,5 @@
 
 (defconstant +rsa-recommended-size-bits+ 3072)
 
-(defun generate-key-pair ()
+(defun generate-rsa-key-pair (&optional (num-bits +rsa-recommended-size-bits+))
   (ironclad:generate-key-pair ':rsa :num-bits +rsa-recommended-size-bits+))

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -7,7 +7,7 @@
 ;;; The BACKEND protocol
 ;;;
 ;;; The BACKEND class is used primarily to determine available
-;;; baackends primarily by computing subclasses.
+;;; backends primarily by computing subclasses.
 
 (defclass backend ()
   ()

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -62,7 +62,7 @@
 (defgeneric compile-to-backend (program chip-spec backend)
   (:documentation "Compile the PROGRAM which comports to the CHIP-SPEC to an executable for BACKEND."))
 
-;;;;;;;;;;;;;;; Backend Construction Library Functiona ;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;; Backend Construction Library Functions ;;;;;;;;;;;;;;;
 
 ;;; The things below aren't part of the protocol, but generally useful.
 

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -52,7 +52,7 @@
   (:documentation "Set the signature of the executbale."))
 
 (defgeneric sign-executable (executable private-key)
-  (:documentation "Sign the EXECUTABLE with PRIVATE-KEY. This should set the signature with SIGNATURE."))
+  (:documentation "Sign the EXECUTABLE with PRIVATE-KEY. This should set the signature with (SETF SIGNATURE)."))
 
 (defgeneric verify-signature (executable public-key)
   (:documentation "Verify the EXECUTABLE was signed by the owner of PUBLIC-KEY."))

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -1,0 +1,82 @@
+;;;; common.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil)
+
+;;; The BACKEND protocol
+;;;
+;;; The BACKEND class is used primarily to determine available
+;;; baackends primarily by computing subclasses.
+
+(defclass backend ()
+  ()
+  (:documentation "Every backend must be represented by a subclass of this abstract base class.")
+  (:metaclass abstract-class))
+
+(defgeneric backend-supports-chip-p (backend chip)
+  (:documentation "Does BACKEND support the chip CHIP-SPECIFICATION?"))
+
+(define-condition incompatible-memory-model-error (error)
+  ((backend :initarg :backend
+            :reader incompatible-memory-model-error-backend)
+   (descriptors :initarg :descriptors
+                :reader incompatible-memory-model-error-descriptors))
+  (:documentation "A condition signaled if a set of descriptors is incompatible with a backend."))
+
+;;; TODO: Should we add anything to the BACKEND protocol to deal with
+;;; memory allocation, the memory model (cf. classical-memory.lisp),
+;;; etc.?
+
+;;; The EXECUTABLE protocol
+;;;
+;;; An executable is an artifact which may be written to a binary
+;;; output stream. (The executable may itself represent characters, of
+;;; course, but we force implementers of this protocol to select an
+;;; encoding.)
+;;;
+;;; Multi-file executables are expected to be managed by the
+;;; implementer with e.g. tarballs.
+;;;
+;;; Many of the functioms below deal with signing the executable,
+;;; which verifies the identity of the creator of the executable.
+;;;
+
+(defgeneric write-executable (executable stream)
+  (:documentation "Write EXECUTABLE to the binary output STREAM."))
+
+(defgeneric signature (executable)
+  (:documentation "The signature of the executable, or NIL of not present."))
+
+(defgeneric (setf signature) (executable new-signature)
+  (:documentation "Set the signature of the executbale."))
+
+(defgeneric sign-executable (executable private-key)
+  (:documentation "Sign the EXECUTABLE with PRIVATE-KEY. This should set the signature with SIGNATURE."))
+
+(defgeneric verify-signature (executable public-key)
+  (:documentation "Verify the EXECUTABLE was signed by the owner of PUBLIC-KEY."))
+
+;;; The COMPILATION protocol
+
+(defgeneric compile-to-backend (program chip-spec backend)
+  (:documentation "Compile the PROGRAM which comports to the CHIP-SPEC to an executable for BACKEND."))
+
+;;;;;;;;;;;;;;; Backend Construction Library Functiona ;;;;;;;;;;;;;;;
+
+;;; The things below aren't part of the protocol, but generally useful.
+
+(defun list-available-backends ()
+  ;; This is simpleminded and assumes there isn't some crazy
+  ;; inheritance structure.
+  (mapcar #'class-name (c2mop:class-direct-subclasses (find-class 'backend))))
+
+(defconstant +binary-hash-size+ 64)
+
+(defun binary-hash (binary)
+  (ironclad:digest-sequence ':sha3 binary))
+
+(defconstant +rsa-recommended-size-bits+ 3072)
+
+(defun generate-key-pair ()
+  (ironclad:generate-key-pair ':rsa :num-bits +rsa-recommended-size-bits+))

--- a/src/backends/instructions.md
+++ b/src/backends/instructions.md
@@ -1,0 +1,33 @@
+# QUILC BACKENDS
+
+## What is a backend?
+
+A backend is a mechanism to emit device-specific code, usually but not necessarily a binary. The code that a backend receives is guaranteed to comport to a particular CHIP-SPECIFICATION.
+
+## This directory
+
+The `backends/` folder contains the implementations of the backends, as well as common code useful for constructing a backend. Every backend should have its own folder in this directory.
+
+## How to add a new backend
+
+The `quil` backend is a minimal, dummy backend that emits Quil, and can be used to model a new, more complicated backend. The basic steps are this:
+
+1. Make a new directory for your backend.
+
+1. Implement the `BACKEND`, `EXECUTABLE`, and `COMPILATION` protocols in `common.lisp`.
+
+## Example usage
+
+```
+(let* ((chip (build-nq-fully-connected-chip 5))
+       (orig (parse-quil "CONTROLLED CONTROLLED H 0 1 2") )
+       (comp (compiler-hook orig chip))
+       (back (make-instance 'quil-backend))
+       (exec (compile-to-backend comp chip back)))
+  ;; optionally SIGN-EXECUTABLE here with keys generated with GENERATE-KEY-PAIR.
+  (with-open-file (stream "~/Scratch/test.quil" :direction ':output
+                                                :if-does-not-exist ':create
+                                                :if-exists ':supersede
+                                                :element-type '(unsigned-byte 8))
+    (write-executable exec stream)))
+```

--- a/src/backends/instructions.md
+++ b/src/backends/instructions.md
@@ -14,7 +14,7 @@ The `quil` backend is a minimal, dummy backend that emits Quil, and can be used 
 
 1. Make a new directory for your backend.
 
-1. Implement the `BACKEND`, `EXECUTABLE`, and `COMPILATION` protocols in `common.lisp`.
+2. Implement the `BACKEND`, `EXECUTABLE`, and `COMPILATION` protocols in `common.lisp`.
 
 ## Example usage
 

--- a/src/backends/quil/quil-backend.lisp
+++ b/src/backends/quil/quil-backend.lisp
@@ -1,0 +1,55 @@
+;;;; quil-backend.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil)
+
+;;; The BACKEND protocol
+
+(defclass quil-backend (backend)
+  ()
+  (:metaclass singleton-class)
+  (:documentation "A backend the emits plain old Quil. In some sense, this backend does nothing."))
+
+(defmethod backend-supports-chip-p ((backend quil-backend) chip)
+  (declare (ignore backend chip))
+  t)
+
+;;; The EXECUTABLE protocol
+
+(defclass quil-executable ()
+  ((utf8-bytes :initarg :utf8-bytes
+               :type (array (unsigned-byte 8) (*))
+               :reader utf8-bytes)
+   (signature :accessor signature ; This implements SIGNATURE
+              :initform nil)))    ; and (SETF SIGNATURE).
+
+
+(defmethod write-executable ((executable quil-executable) stream)
+  (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
+    ;; Write the signature as a comment.
+    (alexandria:when-let ((sig (signature executable)))
+      (write-string "# Signature: " stream)
+      (loop :for byte :across sig :do (format stream "~2,'0X " byte))
+      (terpri stream))
+    (loop :for byte :across (utf8-bytes executable)
+          :do (write-byte byte stream))))
+
+(defmethod sign-executable ((executable quil-executable) (private-key ironclad::rsa-private-key))
+  (setf (signature executable)
+        (ironclad:sign-message private-key (binary-hash (utf8-bytes executable)))))
+
+(defmethod verify-signature ((executable quil-executable) (public-key ironclad::rsa-public-key))
+  (ironclad:verify-signature public-key
+                             (binary-hash (utf8-bytes executable))
+                             (signature executable)))
+
+;;; The COMPILATION protocol
+
+(defmethod compile-to-backend (program chip-spec (backend quil-backend))
+  (declare (ignore chip-spec))
+  (make-instance 'quil-executable
+                 :utf8-bytes
+                 (flexi-streams:with-output-to-sequence (stream :element-type '(unsigned-byte 8))
+                   (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
+                     (print-parsed-program program stream)))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -486,6 +486,25 @@
    #:quil-type-error                    ; FUNCTION
    )
 
+  ;; backend/ stuff
+  (:export
+   #:backend                            ; CLASS
+   #:backend-supports-chip-p            ; GENERIC
+   #:incompatible-memory-model-error    ; CONDITION
+   #:incompatible-memory-model-error-backend
+                                        ; READER
+   #:incompatible-memory-model-error-descriptors
+                                        ; READER
+   #:write-executable                   ; GENERIC
+   #:signature                          ; GENERIC
+   #:sign-executable                    ; GENERIC
+   #:verify-signature                   ; GENERIC
+   #:compile-to-backend                 ; GENERIC
+
+   #:quil-backend                       ; CLASS
+   #:quil-executable                    ; CLASS
+   )
+
   ;; utilities.lisp
   (:export
    #:ilog2                              ; FUNCTION


### PR DESCRIPTION
(This PR is intended to be a proposal/discussion rather than a "let's merge ASAP" sort of thing.)
(Nomenclature: I'm using the words "frontend" and "backend" for less typing and fewer -'s.)

Quilc is a compiler that only has a frontend. It produces Quil code that adheres to a particular chip specification. It currently has no means to generate code for a particular computer or control system.

The way it's done at Rigetti right now is that this "native Quil" is handed off to proprietary services internally which compile this code for Rigetti's variety of control systems. These services comprise a compiler "backend" and are currently opaque to users of quilc.

This PR aims to extend quilc to allow backends to be implemented in quilc itself. This PR does not implement any non-trivial backends. The reasons we ought to do this is:

 

-    It follows traditional compiler design. (It's very odd—though justified for private reasons—that a compiler is splayed across several services.)
-    Quilt moves the user just a few hairs away from the low-level code gen. The more adoption Quilt has, the more quilc ought to know about towards what it's compiling programs.
-   Having backend code generation allows additional optimizations to happen, which are easier to write and more performant in Lisp.
-   With a frontend and backend comes "middle-ends" [sic], where lower-level IRs can be introduced (like Quilt) which permit finer-grained, non-quantum optimizations.
-   Code generation can be costly and quilc is a good platform to optimize such.

The design I present is very simple and accomplishes the following goals:

-   It provides an ontology for backends. They are subclasses of BACKEND. I chose this over bare protocol functions since we can use the class structure to deduce available backends.
-   It provides a protocol for executables. At the end of the day, an executable is something that is writable to a binary stream, and cryptographically signable. There is no assumption as to whether an executable "is" a file or a bundle thereof. There is an assumption that an executable can be expressed as a file (e.g., a tarball).
-   It provides a UI for specifying the backend at the command line, as well as a file to write to.

The entry point to the backend (within cl-quil) is compile-to-backend. It's the line-and-sinker to our beloved compiler-hook. (Yes, I did contemplate putting compiler-line-and-sinker to be quirky in the codebase, and in this very rare occasion, I decided against it. I can be convinced otherwise by @appleby and @notmgsk only.)

Implemented in this PR is a "dummy" backend called quil, where an "executable" is a UTF8-encoded file of Quil code. This is an example of using the new user-facing features.
```
$ echo 'CONTROLLED CONTROLLED H 0 1 2' | ./quilc --backend 'quil' -o 'q.out'
<134>1 2020-04-04T21:24:42Z cobbler.local quilc 9596 - - Generating native Quil.
<134>1 2020-04-04T21:24:43Z cobbler.local quilc 9596 - - Generating backend code.
<134>1 2020-04-04T21:24:43Z cobbler.local quilc 9596 - - Wrote executable.

$ cat q.out 
RZ(0.9485576243433194) 4                # Entering rewiring: #(6 4 5 0 1 2 3 7)
RX(pi/2) 4
RZ(-3*pi/4) 5
RX(pi/2) 5
RZ(0.5299027897489266) 5
RX(-pi/2) 5
RZ(1.0149377841503018) 5
CZ 4 5
RX(pi/2) 4
RZ(0.8588857587292011) 4
RX(-pi/2) 4
CZ 4 5
RZ(2.9676117939887945) 5
RX(pi/2) 5
RZ(2.100629020021203) 5
RX(-pi/2) 5
RZ(1.5617345686152926) 5
RZ(pi/2) 6
RX(pi/2) 6
RZ(-2.383295449271497) 6
RX(-pi/2) 6
CZ 5 6
RZ(pi) 5
RX(pi/2) 5
RZ(pi) 6
RX(pi/2) 6
CZ 5 6
RX(pi/2) 4
RZ(-2.1987649493772086) 5
RX(pi/2) 5
RZ(2.078609539841221) 5
RX(-pi/2) 5
CZ 4 5
RZ(2.16095302738569) 5
RX(pi/2) 5
RZ(3*pi/4) 5
RX(-pi/2) 5
RX(pi/2) 6
CZ 5 6
RZ(-0.6455362053461816) 4
RX(-pi/2) 4
RZ(-2.208413464564872) 5
RX(pi/2) 5
RZ(1.0338528234701385) 5
RX(-pi/2) 5
RZ(0.9665135945991623) 5
CZ 5 4
RZ(pi) 4
RX(pi/2) 4
RZ(pi) 5
RX(pi/2) 5
CZ 5 4
RX(pi/2) 5
RZ(-2.332896987297744) 5
RX(pi/2) 5
RZ(-2.3407240608221773) 6
RX(pi/2) 6
CZ 5 6
RX(pi/2) 5
RZ(pi/8) 5
RX(-pi/2) 5
CZ 5 6
RX(pi/2) 4
RZ(0.808695666292048) 4
RX(-pi/2) 4
RZ(-pi/4) 4
RZ(pi) 5
RX(-pi/2) 5
RZ(7*pi/8) 6
RX(pi/2) 6
HALT                                    # Exiting rewiring: #(4 5 6 0 1 2 3 7)
```

Some big TODO items:

-   Parse out RSA keys for signage.
-   Understand a bit better how a backend might be specified. The quil backend isn't very sophisticated and I suspect more complicated backends cannot be identified with just a "string".
-   Explore what's missing in terms of protocol functions. I think there must be something missing WRT memory models, but maybe not.
-   Should any other standard conditions be specified?
-   Allow backends to be listed. The backend classes can be listed with cl-quil::list-available-backends, but there's no correspondence between "friendly names" and these classes. Right now it's hacked up in quilc::parse-backend.

I would appreciate comments, questions, and discussion!