### PR TITLE
Fixup sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN make dump-version-info install-test-deps
 # build the quilc app
 ADD . /src/quilc
 WORKDIR /src/quilc
-RUN git clean -fdx && make ${build_target} && make install && ldconfig
+RUN git clean -fdx && make ${build_target} install && ldconfig
 
 EXPOSE 5555
 EXPOSE 6000


### PR DESCRIPTION
This was an oopsie. The `make install` was being treated as a separate build, not inheriting the appropriate `${build_target}` and so it was re-built and then installed as a standard non-sdk build.