### PR TITLE
Cache chip specs between server requests

### DIFF
--- a/app/src/chip-cache.lisp
+++ b/app/src/chip-cache.lisp
@@ -1,0 +1,70 @@
+;;;; chip-cache.lisp
+;;;;
+;;;; Chip caching for faster compilation requests
+;;;;
+;;;; Author: Mark Skilbeck
+;;;;
+
+(in-package #:quilc)
+
+(defclass cached-chip ()
+  ((last-accessed
+    :initarg :last-accessed
+    :type real
+    :accessor cached-chip-last-accessed)
+   (chip
+    :initarg :chip
+    :type chip-specification
+    :accessor cached-chip-chip)
+   (addresser-state
+    :initarg :addresser-state
+    :type quil::addresser-state
+    :accessor cached-chip-addresser-state))
+  (:documentation "Represents chip and addresser state cached between server requests."))
+
+(defvar *chip-cache*
+  (cons (make-hash-table :test #'equalp)
+        (bt:make-lock "chip cache lock"))
+  "Cached chip specifications. Pair of values (hash-table . lock). Large chips have a significant construction overhead, and caching chips between requests reduces or eliminates that overhead. The hash value for a given key is a pair (last-access . chip-spec). Note: use the lock when accessing.")
+
+(defvar *chip-cache-max-size* 10
+  "The maximum number of entries in the cache.")
+
+(defun get-internal-real-time-seconds ()
+  (/ (get-internal-real-time)
+     internal-time-units-per-second))
+
+(defun chip-cache-purge ()
+  "Purge the least recently used entries in *CHIP-CACHE* according to *CHIP-CACHE-MAX-SIZE*.
+
+After calling this function, *CHIP-CACHE* has at most *CHIP-CACHE-MAX-SIZE* entries."
+  (let ((cache (car *chip-cache*)))
+    (when (>= (hash-table-count cache) *chip-cache-max-size*)
+      (let* ((n (- (hash-table-count cache) *chip-cache-max-size*))
+             (lru (subseq (sort (a:hash-table-alist cache)
+                                #'<
+                                :key (a:compose #'cached-chip-last-accessed #'cdr))
+                          0 n)))
+        (dolist (cached lru)
+          (remhash (car cached) cache))))))
+
+(defun chip-cache-or-create (qpu-hash)
+  "Look up the chip described by QPU-HASH in the chip spec cache if it exists, otherwise create and cache it.
+
+This function has the added side-effect that it will purge old chips according to *CHIP-CACHE-MAX-SIZE*"
+  (let* ((cache (car *chip-cache*))
+         (cached-chip (gethash qpu-hash cache)))
+    (cond
+      (cached-chip
+       (setf (cached-chip-last-accessed cached-chip)
+             (get-internal-real-time-seconds))
+       cached-chip)
+      (t
+       (let* ((chip (quil::qpu-hash-table-to-chip-specification qpu-hash))
+              (cached-chip (make-instance 'cached-chip
+                                          :last-accessed (get-internal-real-time-seconds)
+                                          :chip chip)))
+         (setf (gethash qpu-hash cache)
+               cached-chip)
+         (chip-cache-purge)
+         cached-chip)))))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -218,6 +218,7 @@
                           (server-mode-rpc nil)
                           (host nil)
                           (port nil)
+                          (cache-chips nil)
                           time-limit
                           (help nil)
                           (log-level nil)
@@ -326,7 +327,8 @@
        (*quil-stream* (make-broadcast-stream))
        (*protoquil* protoquil)
        (*state-aware* enable-state-prep-reductions)
-       (quil::*safe-include-directory* safe-include-directory))
+       (quil::*safe-include-directory* safe-include-directory)
+       (*chip-cache-max-size* cache-chips))
 
     (when check-sdk-version
       (asynchronously-indicate-update-availability +QUILC-VERSION+ :proxy proxy))

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -55,7 +55,9 @@
          (qpu-hash (a:plist-hash-table (list "isa" (rpcq::|TargetDevice-isa| target-device)
                                              "specs" (rpcq::|TargetDevice-specs| target-device))
                                        :test #'equal))
-         (chip-specification (cl-quil::qpu-hash-table-to-chip-specification qpu-hash))
+         (cache (bt:with-lock-held ((cdr *chip-cache*))
+                  (chip-cache-or-create qpu-hash)))
+         (chip-specification (cached-chip-chip cache))
          ;; Allow endpoint to override server's -P
          (protoquil (ecase protoquil
                       ((nil) *protoquil*)
@@ -65,6 +67,11 @@
                         ((nil) *state-aware*)
                         (:false nil)
                         (t t))))
+    (unless (slot-boundp cache 'addresser-state)
+      (setf (cached-chip-addresser-state cache)
+            (make-instance quil::*default-addresser-state-class*
+                           :chip-spec chip-specification
+                           :initial-l2p (quil::prog-initial-rewiring quil-program chip-specification))))
     (multiple-value-bind (processed-program statistics-dict)
         (process-program quil-program chip-specification
                          :protoquil protoquil

--- a/quilc.asd
+++ b/quilc.asd
@@ -36,6 +36,7 @@
                (:file "impl/sbcl")
                #+clozure
                (:file "impl/clozure")
+               (:file "chip-cache")
                (:file "rpc-server")
                (:file "printers")
                (:file "options")


### PR DESCRIPTION
This PR adds a chip cache used by the RPC endpoints, so the benefit is mostly felt by pyquil users. Produces a speedup between ~3s and ~4s based on some simple tests. You'll notice below that even a very simple compilation still takes an amount of time that scales with the size of the chip -- this is because the addresser state object is rebuilt on every compilation. Caching this also would provide a very nice win. For a future PR.

For example:
```
from pyquil import get_qc, Program
from time import time
qc = get_qc("30q-qvm", as_qvm=True)
p = Program("""CNOT 0 1""")
for i in range(4):
    t = time()
    print(qc.compile(p).program)
    print(f"iteration {i} took \t {time() - t}s")

RZ(-pi/2) 1
RX(pi/2) 1
CZ 1 0
RZ(pi) 0
RX(pi/2) 0
RX(-pi/2) 0
RX(-pi/2) 1
RZ(pi/2) 1
HALT

iteration 0 took 	 3.0537497997283936s
RZ(-pi/2) 1
RX(pi/2) 1
CZ 1 0
RZ(pi) 0
RX(pi/2) 0
RX(-pi/2) 0
RX(-pi/2) 1
RZ(pi/2) 1
HALT

iteration 1 took 	 0.9757657051086426s
RZ(-pi/2) 1
RX(pi/2) 1
CZ 1 0
RZ(pi) 0
RX(pi/2) 0
RX(-pi/2) 0
RX(-pi/2) 1
RZ(pi/2) 1
HALT

iteration 2 took 	 1.0833849906921387s
RZ(-pi/2) 1
RX(pi/2) 1
CZ 1 0
RZ(pi) 0
RX(pi/2) 0
RX(-pi/2) 0
RX(-pi/2) 1
RZ(pi/2) 1
HALT

iteration 3 took 	 0.9600250720977783s
```
and
```
qc = get_qc("Aspen-8", as_qvm=True)
p = Program("""CNOT 0 1""")
for i in range(4):
    t = time()
    print(qc.compile(p).program)
    print(f"iteration {i} took \t {time() - t}s")

RZ(pi/2) 33
RX(-pi/2) 33
CZ 33 32
RZ(pi) 32
RX(pi/2) 33
RZ(-pi/2) 33
HALT

iteration 0 took 	 0.44094109535217285s
RZ(-pi/2) 33
RX(pi/2) 33
CZ 33 32
RZ(pi) 32
RX(-pi/2) 33
RZ(pi/2) 33
HALT

iteration 1 took 	 0.11467194557189941s
RZ(-pi/2) 33
RX(pi/2) 33
CZ 33 32
RZ(pi) 32
RX(-pi/2) 33
RZ(pi/2) 33
HALT

iteration 2 took 	 0.11051273345947266s
RZ(-pi/2) 33
RX(pi/2) 33
CZ 33 32
RZ(pi) 32
RX(-pi/2) 33
RZ(pi/2) 33
HALT

iteration 3 took 	 0.11118412017822266s
```