### PR TITLE
Account for number of gates of unknown fidelity in EVAL-OCC-TABLE

### DIFF
--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -540,7 +540,11 @@ Optionally constrains the output to include only those bindings of a particular 
                  occurrence-table-metric-fidelity
                  occurrence-table-metric-unknowns))
 (defstruct (occurrence-table-metric (:constructor %make-occurrence-table-metric (fidelity unknowns)))
-  "Abstract assessment of an occurrence table, which can be sorted by the function OCCURRENCE-TABLE-METRIC-WORSEP."
+  "Abstract assessment of an occurrence table, which can be sorted by the function OCCURRENCE-TABLE-METRIC-WORSEP.
+
+FIDELITY is a real number between 0 and 1 which estimates the accuracy of executing gates in the evaluated occurrence table.
+
+UNKNOWNS is the number of gates with unknown fidelity in the evaluated occurrence table. Gates with unknown fidelity are not native and are presumed to be expensive. See OCCURRENCE-TABLE-METRIC-WORSEP."
   (fidelity nil :type (double-float 0d0 1d0))
   (unknowns nil :type (integer 0)))
 #+sbcl (declaim (sb-ext:freeze-type occurrence-table-metric))
@@ -575,7 +579,7 @@ Optionally constrains the output to include only those bindings of a particular 
                    (* (expt (gate-record-fidelity cost-val) val)
                       (occurrence-table-metric-fidelity ret)))
              (go :SKIP)))
-         (incf (occurrence-table-metric-unknowns ret))
+         (incf (occurrence-table-metric-unknowns ret) val)
          :SKIP))))
 
 (defun occurrence-table-in-gateset-p (occurrence-table gateset)

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -250,7 +250,7 @@ CNOT 4 8
                      (%read-test-chipspec "Aspen-6-2Q-A.qpu")
                      (%read-test-chipspec "Aspen-7-28Q-A.qpu"))))
     (dolist (chip chips)
-      (%test-reduction-with-chip 7 chip))))
+      (%test-reduction-with-chip 5 chip))))
 
 ;; (deftest test-free-rx-rz-strings-reduce ()
 ;;   (%test-reduction-with-chip 3 (%read-test-chipspec "1q-free-rx.qpu")))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -252,5 +252,5 @@ CNOT 4 8
     (dolist (chip chips)
       (%test-reduction-with-chip 5 chip))))
 
-;; (deftest test-free-rx-rz-strings-reduce ()
-;;   (%test-reduction-with-chip 3 (%read-test-chipspec "1q-free-rx.qpu")))
+(deftest test-free-rx-rz-strings-reduce ()
+  (%test-reduction-with-chip 3 (%read-test-chipspec "1q-free-rx.qpu")))


### PR DESCRIPTION
Previously, a gate with unknown fidelity and n occurrences was
recorded in the metric as having one unknown. This means an occurrence
table of `{RX: 1, RY: 50}` with `RX` known and `RY` unknown would have a
better metric than `{RX: 2, RY: 1}` since the `RY` in both cases is recorded
as 1 unknown. This causes issues in determining short compiler paths.

This change now records the former table with 50 unknowns
and the latter with 1 unknown. This change also adds additional
documentation to the `OCCURRENCE-TABLE` structure to make this clear.

`TEST-RX-RZ-STRINGS-REDUCE` has been returned to its initial expectation
of five gates.