### PR TITLE
Add .travis.yml build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+env:
+  - TARGET=cl-quil
+  - TARGET=quilt
+  - TARGET=quilec
+  - TARGET=quilc
+
+services:
+  - docker
+
+script:
+  - echo ${TARGET}
+  - docker build -t rigetti/quilc:${TRAVIS_COMMIT} .
+  - docker run --rm --entrypoint=make rigetti/quilc:${TRAVIS_COMMIT} test-${TARGET}
+  - docker rmi rigetti/quilc:${TRAVIS_COMMIT}


### PR DESCRIPTION
This enables builds on travis, thus allowing PRs from external branches to trigger the testing pipelines.