### PR TITLE
 fix QS-COMPILER in certain edge cases of what it accepts

### DIFF
--- a/src/compilers/qs-compile.lisp
+++ b/src/compilers/qs-compile.lisp
@@ -12,6 +12,14 @@
   ;; QS-COMPILER only allows gates with 3 or more qubits. It doesn't
   ;; make sense (and it can't be done) to recursively decompose a 1-
   ;; or 2-qubit gate.
+  ;;
+  ;; ECP sez: In context, I think this that is a totally reasonable
+  ;; restriction. In the abstract, I'm surprised that QSD doesn't
+  ;; apply to small operators—I feel it should work for 2Q operators
+  ;; without much effort and perhaps also for 1Q operators if the
+  ;; implementer is clever. Might be worth modifying the
+  ;; implementation someday to permit these cases (even if the 2Q and
+  ;; 1Q stuff that quilc already does is superior).
   (when (< (length (application-arguments instr)) 3)
     (give-up-compilation))
 

--- a/src/compilers/qs-compile.lisp
+++ b/src/compilers/qs-compile.lisp
@@ -9,12 +9,13 @@
 
 (define-compiler qs-compiler (instr)
   "Performs Quantum Shannon Compilation, emitting a list of anonymous gates and UCR instructions that describe an equivalent circuit."
-  (unless (or (>= (length (application-arguments instr)) 3)
-              (adt:match operator-description (application-operator instr)
-                ((named-operator name) (not (find name (standard-gate-names) :test #'string=)))
-                (_ t)))
+  ;; QS-COMPILER only allows gates with 3 or more qubits. It doesn't
+  ;; make sense (and it can't be done) to recursively decompose a 1-
+  ;; or 2-qubit gate.
+  (when (< (length (application-arguments instr)) 3)
     (give-up-compilation))
-  
+
+  ;; Note that GATE-MATRIX is now going to have dim >= 2^3.
   (let ((matrix (gate-matrix instr)))
     (unless matrix
       (give-up-compilation))

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -182,6 +182,29 @@ CNOT 0 2"))
     ;; test on quality of compilation, and not on correctness.
     (is (>= 6 (length 2q-code)))))
 
+(deftest test-cswap-compiles-with-qs ()
+  "Test that CSWAP compiles with QS-COMPILER. (Don't test the output's validity.)"
+  (let ((result (quil::qs-compiler (quil::build-gate "CSWAP" () 0 1 2))))
+    ;; Just check we get compilation output.
+    (is (plusp (length result)))))
+
+(deftest test-anons-compile-with-qs ()
+  "Test that a few anonymous gates compile with QS-COMPILER. (Don't test the output's validity.)"
+  (let ((result3 (quil::qs-compiler (quil::anon-gate "ANON" (quil::random-special-unitary (expt 2 3)) 0 1 2)))
+        (result4 (quil::qs-compiler (quil::anon-gate "ANON" (quil::random-special-unitary (expt 2 4)) 0 1 2 3)))
+        (result5 (quil::qs-compiler (quil::anon-gate "ANON" (quil::random-special-unitary (expt 2 5)) 0 1 2 3 4))))
+    ;; Just check we get compilation output.
+    (is (plusp (length result3)))
+    (is (plusp (length result4)))
+    (is (plusp (length result5)))))
+
+(deftest test-qs-dont-compile-nonsense ()
+  "Test that QS-COMPILER doesn't compile an anonymous 1Q or 2Q gate."
+  (signals CL-QUIL::COMPILER-DOES-NOT-APPLY
+    (quil::qs-compiler (quil::anon-gate "ANON" (quil::random-special-unitary 2) 0)))
+  (signals CL-QUIL::COMPILER-DOES-NOT-APPLY
+    (quil::qs-compiler (quil::anon-gate "ANON" (quil::random-special-unitary 4) 0 1))))
+
 (deftest test-sohaib-fidelity-rewiring-regression ()
   (not-signals bt:timeout
     (bt:with-timeout (1)


### PR DESCRIPTION
For some reason, QS-COMPILER allowed anonymous gates of fewer than 3
qubits. Issues around this arose while trying to make custom ISA files
and having typos in gate names. The issues would manifest themselves
as faulty calls to INST* with no qubit arguments (i.e., trying to
decompose a 1-qubit gate into 0-qubit "gates").

This commit also removes the check for the nativeness of a gate. If
this check persists, then CSWAP will not be compilable. Since CSWAP,
CCNOT, and CAN are the only listed native gates, I figure it's fine if
these gates hit this compiler.