### PR TITLE
Fix UB of destructively modifying macro arguments

### DIFF
--- a/boondoggle/src/pipeline.lisp
+++ b/boondoggle/src/pipeline.lisp
@@ -7,8 +7,8 @@
 
 (defmacro pipeline (vars &rest pipes)
   ;; first, deal with all the definition bindings
-  (let* ((vars (nreverse vars))
-         (pipes (nreverse pipes))
+  (let* ((vars (reverse vars))
+         (pipes (reverse pipes))
          (result-form `,(first (first pipes))))
     (dolist (pipe pipes)
       (destructuring-bind (name lambda-list instruction) pipe


### PR DESCRIPTION
This was detected by a warning on the upcoming SBCL 2.0.7.
http://report.quicklisp.org/2020-07-24/failure-report/quilc.html#boondoggle
