### PR TITLE
Add POST_LOAD_ASDF_SYSTEMS option to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
 	--eval '(push (truename ".") asdf:*central-registry*)' \
 	--eval "(push (truename \"$(RIGETTI_LISP_LIBRARY_HOME)\") ql:*local-project-directories*)"
 QUICKLISP_BOOTSTRAP_URL=https://beta.quicklisp.org/quicklisp.lisp
+
+
+# Extra ASDF systems to load after quilc as part of the executable.
+export ASDF_SYSTEMS_TO_LOAD=quilc $(POST_LOAD_ASDF_SYSTEMS)
+SYSTEM_LOAD_STRING=$(foreach system,$(ASDF_SYSTEMS_TO_LOAD),--eval '(ql:quickload "$(system)")')
+
 UNAME_S=$(shell uname -s)
 PREFIX ?= /usr/local
 
@@ -28,7 +34,7 @@ $(QUICKLISP_SETUP):
 system-index.txt: $(QUICKLISP_SETUP)
 	$(QUICKLISP) \
 		$(FOREST_SDK_FEATURE) \
-		--eval '(ql:quickload "quilc")' \
+		$(SYSTEM_LOAD_STRING) \
 		--eval '(ql:write-asdf-manifest-file "system-index.txt")'
 
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ To install system-wide issue the command
 $ make install
 ```
 
+#### Build flags
+
+`quilc` can be built with additional options provided to `make` as described below:
+
+| Flag                     | Description                                                                                                                                                     |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `POST_LOAD_ASDF_SYSTEMS` | Specify additional ASDF systems to load _after_ `quilc` as part of the executable. This can be used to build `quilc` with additional out-of-tree functionality. |
+
 ### Using the Quil Compiler
 
 The Quil Compiler provides two modes of interaction: (1) communicating

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -44,11 +44,11 @@
     ;; Load systems defined by environment variable $ASDF_SYSTEMS_TO_LOAD,
     ;; or if that does not exist just load quilc
     (let ((systems (uiop:getenv "ASDF_SYSTEMS_TO_LOAD")))
-      (mapcar (lambda (sys)
-                (unless (uiop:emptyp sys)
-                  (asdf:load-system sys)))
-              (uiop:split-string (or systems "quilc")
-                                 :separator " ")))
+      (map nil (lambda (sys)
+                 (unless (uiop:emptyp sys)
+                   (asdf:load-system sys)))
+           (uiop:split-string (or systems "quilc")
+                              :separator " ")))
     ;; TODO Fix tweedledum
     ;; #-win32
     ;; (asdf:load-system "cl-quil/tweedledum")

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -44,11 +44,9 @@
     ;; Load systems defined by environment variable $ASDF_SYSTEMS_TO_LOAD,
     ;; or if that does not exist just load quilc
     (let ((systems (uiop:getenv "ASDF_SYSTEMS_TO_LOAD")))
-      (map nil (lambda (sys)
-                 (unless (uiop:emptyp sys)
-                   (asdf:load-system sys)))
-           (uiop:split-string (or systems "quilc")
-                              :separator " ")))
+      (dolist (sys (uiop:split-string (or systems "quilc") :separator " "))
+        (unless (uiop:emptyp sys)
+          (asdf:load-system sys))))
     ;; TODO Fix tweedledum
     ;; #-win32
     ;; (asdf:load-system "cl-quil/tweedledum")

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -40,7 +40,15 @@
            (subseq version 0 (position #\- version :test #'eql))))
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
-    (asdf:load-system "quilc")
+
+    ;; Load systems defined by environment variable $ASDF_SYSTEMS_TO_LOAD,
+    ;; or if that does not exist just load quilc
+    (let ((systems (uiop:getenv "ASDF_SYSTEMS_TO_LOAD")))
+      (mapcar (lambda (sys)
+                (unless (uiop:emptyp sys)
+                  (asdf:load-system sys)))
+              (uiop:split-string (or systems "quilc")
+                                 :separator " ")))
     ;; TODO Fix tweedledum
     ;; #-win32
     ;; (asdf:load-system "cl-quil/tweedledum")


### PR DESCRIPTION
Add POST_LOAD_ASDF_SYSTEMS which adds systems to be built and loaded in
the executable file. This allows for external sysytems to extend quilc
and be built into the executable without being part of the quilc system.