### PR TITLE
Framework for implementing quilc backends

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -413,7 +413,7 @@
                (unless output
                  (error "Output must be provided when compilation is enabled. Specify an output file with -o or --output."))
 
-               (let ((backend-class (quil:parse-backend backend)))
+               (let ((backend-class (quil:find-backend backend)))
                  (unless backend-class
                    (error "The backend value '~a' does not name an available backend. For a list of available backends, run 'quilc --list-backends'." backend))
 
@@ -438,7 +438,7 @@
                                      :element-type '(unsigned-byte 8)
                                      :if-exists ':supersede
                                      :if-does-not-exist ':create))
-           (let ((executable (quil:compile-executable program chip-spec backend)))
+           (let ((executable (quil:backend-compile program chip-spec backend)))
              (quil:write-executable executable stream)))
       (when stream
         (close stream)))))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -99,7 +99,9 @@
           (mapcar 'sb-alien::shared-object-pathname sb-sys:*shared-objects*))
   (unless (magicl.foreign-libraries:foreign-symbol-available-p "zuncsd_"
                                                                'magicl.foreign-libraries:liblapack)
-    (format t "The loaded version of LAPACK is missing functionality. The compiler will still work with your current LAPACK but it is advisable to install a more complete version.~%")
+    (format t "The loaded version of LAPACK is missing ~
+    functionality. The compiler will still work with your current ~
+    LAPACK but it is advisable to install a more complete version.~%")
     (uiop:quit 1))
   (format t "Library check passed.~%")
   (uiop:quit 0))
@@ -166,7 +168,8 @@
   (loop :for kw :in args :by #'cddr
         :for found := (find kw *deprecated-option-spec* :test #'string-equal :key #'caar)
         :when found :do
-          (format *error-output* "The option --~A is deprecated and will be removed. See --help for more information.~%"
+          (format *error-output* "The option --~A is deprecated and ~
+          will be removed. See --help for more information.~%"
                   (caar found))))
 
 (defun warn-ignored-options (args)
@@ -174,7 +177,9 @@
   (loop :for kw :in args :by #'cddr
         :for found := (find kw *ignored-option-spec* :test #'string-equal :key #'caar)
         :when found :do
-          (format *error-output* "The option --~A is deprecated and disabled, and will be removed. See --help for more information.~%"
+          (format *error-output* "The option --~A is deprecated and ~
+          disabled, and will be removed. See --help for more ~
+          information.~%"
                   (caar found))))
 
 (defun process-options (&rest all-args
@@ -409,14 +414,20 @@
              ;; New and improved flow
              (when compile
                (unless backend
-                 (error "Backend must be provided when compilation is enabled. For a list of available backends, run 'quilc --list-backends'."))
+                 (error "Backend must be provided when compilation is ~
+                 enabled. For a list of available backends, run 'quilc ~
+                 --list-backends'."))
 
                (unless output
-                 (error "Output must be provided when compilation is enabled. Specify an output file with -o or --output."))
+                 (error "Output must be provided when compilation is ~
+                 enabled. Specify an output file with -o or ~
+                 --output."))
 
                (let ((backend-class (quil:find-backend backend)))
                  (unless backend-class
-                   (error "The backend value '~a' does not name an available backend. For a list of available backends, run 'quilc --list-backends'." backend))
+                   (error "The backend value '~a' does not name an ~
+                   available backend. For a list of available ~
+                   backends, run 'quilc --list-backends'." backend))
 
                  ;; TODO: Compute and pass statistics to backend when
                  ;; using protoquil

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -442,17 +442,12 @@
 
 (defun backend-compile-program (program chip-spec backend output)
   "Compile the processed program PROGRAM for BACKEND, writing to OUTPUT."
-  (let ((stream))
-    (unwind-protect
-         (progn
-           (setf stream (open output :direction ':output
-                                     :element-type '(unsigned-byte 8)
-                                     :if-exists ':supersede
-                                     :if-does-not-exist ':create))
-           (let ((executable (quil:backend-compile program chip-spec backend)))
-             (quil:write-executable executable stream)))
-      (when stream
-        (close stream)))))
+  (with-open-file (stream output :direction ':output
+                                 :element-type '(unsigned-byte 8)
+                                 :if-exists ':supersede
+                                 :if-does-not-exist ':create)
+    (let ((executable (quil:backend-compile program chip-spec backend)))
+      (quil:write-executable executable stream))))
 
 (defun process-program (program chip-specification
                         &key

--- a/app/src/options.lisp
+++ b/app/src/options.lisp
@@ -43,6 +43,28 @@
      :initial-value "8Q"
      :documentation "set ISA to one of \"8Q\", \"20Q\", \"16QMUX\", \"bristlecone\", \"ibmqx5\", or path to QPU description file")
 
+    (("compile" #\c)
+     :type boolean
+     :optional t
+     :initial-value nil
+     :documentation "compile the program to an executable using the specified backend")
+
+    (("backend" #\b)
+     :type string
+     :optional t
+     :documentation "backend used to compile the program. Only has effect when --compile or -c are provided.")
+
+    (("list-backends")
+     :type boolean
+     :optional t
+     :initial-value nil
+     :documentation "list available backends for compilation")
+
+    (("output" #\o)
+     :type string
+     :optional t
+     :documentation "file to write output of compilation to. Only has effect when --compile or -c are provided.")
+
     (("enable-state-prep-reductions")
      :type boolean
      :optional t

--- a/app/src/options.lisp
+++ b/app/src/options.lisp
@@ -52,13 +52,13 @@
     (("backend" #\b)
      :type string
      :optional t
-     :documentation "backend used to compile the program. Only has effect when --compile or -c are provided.")
+     :documentation "backend used to compile the program. Only has effect when --compile or -c are provided")
 
     (("backend-option" #\B)
      :type string
      :list t
      :optional t
-     :documentation "backend option passed to initialization of backend. Only has effect when --backend or -b are provided.")
+     :documentation "backend option passed to initialization of backend. Only has effect when --backend or -b are provided. Backend options are supplied in the following format: 'option-name=val1;val2;val3...'")
 
     (("list-backends")
      :type boolean
@@ -69,7 +69,7 @@
     (("output" #\o)
      :type string
      :optional t
-     :documentation "file to write output of compilation to. Only has effect when --compile or -c are provided.")
+     :documentation "file to write output of compilation to. Only has effect when --compile or -c are provided")
 
     (("enable-state-prep-reductions")
      :type boolean

--- a/app/src/options.lisp
+++ b/app/src/options.lisp
@@ -54,6 +54,12 @@
      :optional t
      :documentation "backend used to compile the program. Only has effect when --compile or -c are provided.")
 
+    (("backend-option" #\B)
+     :type string
+     :list t
+     :optional t
+     :documentation "backend option passed to initialization of backend. Only has effect when --backend or -b are provided.")
+
     (("list-backends")
      :type boolean
      :optional t

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -27,6 +27,7 @@
                #:global-vars            ; Static globals
                #:salza2                 ; God table compression
                #:trivial-garbage        ; weak hash tables
+               #:flexi-streams          ; For executable writing
                #:cl-heap
                #:cl-permutation
                #:queues.priority-queue
@@ -106,6 +107,12 @@
                 :serial t
                 :components ((:file "chip-specification")
                              (:file "chip-reader")))
+               (:module "backends"
+                :serial t
+                :components ((:file "common")
+                             (:module "quil"
+                              :serial t
+                              :components ((:file "quil-backend")))))
                (:module "addresser"
                 :serial t
                 :components ((:file "rewiring")

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -1,0 +1,61 @@
+;;;; common.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil)
+
+;;; The BACKEND protocol
+;;;
+;;; The BACKEND class is used primarily to determine available
+;;; backends primarily by computing subclasses.
+
+(defclass backend ()
+  ()
+  (:documentation "Every backend must be represented by a subclass of this abstract base class.")
+  (:metaclass abstract-class))
+
+(defgeneric backend-name (backend-class)
+  (:documentation "The user-accessible name for BACKEND-CLASS."))
+
+(defgeneric backend-supports-chip-p (backend chip)
+  (:documentation "Does BACKEND support the chip CHIP-SPECIFICATION?"))
+
+;;; TODO: Should we add anything to the BACKEND protocol to deal with
+;;; memory allocation, the memory model (cf. classical-memory.lisp),
+;;; etc.?
+
+;;; The EXECUTABLE protocol
+;;;
+;;; An executable is an artifact which may be written to a binary
+;;; output stream. (The executable may itself represent characters, of
+;;; course, but we force implementers of this protocol to select an
+;;; encoding.)
+;;;
+;;; Multi-file executables are expected to be managed by the
+;;; implementer with e.g. tarballs.
+;;;
+
+(defgeneric write-executable (executable stream)
+  (:documentation "Write EXECUTABLE to the binary output STREAM."))
+
+
+;;; The COMPILATION protocol
+
+(defgeneric compile-executable (program chip-spec backend)
+  (:documentation "Compile the PROGRAM which comports to the CHIP-SPEC to an executable for BACKEND."))
+
+
+;;;;;;;;;;;;;;; Backend Construction Library Functions ;;;;;;;;;;;;;;;
+
+;;; The things below aren't part of the protocol, but generally useful.
+
+
+(defun list-available-backends ()
+  ;; This is simpleminded and assumes there isn't some crazy
+  ;; inheritance structure.
+  (mapcar #'class-name (c2mop:class-direct-subclasses (find-class 'backend))))
+
+(defun parse-backend (backend-name)
+  "Returns the backend class associated with the string BACKEND-NAME."
+  (find-if (lambda (x) (equal backend-name (backend-name x)))
+           (list-available-backends)))

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -15,7 +15,9 @@
   (:metaclass abstract-class))
 
 (defgeneric backend-name (backend-class)
-  (:documentation "The user-accessible name for BACKEND-CLASS."))
+  (:documentation "The user-accessible name for BACKEND-CLASS.")
+  (:method ((backend backend))
+    (backend-name (class-name (class-of backend)))))
 
 (defgeneric backend-supports-chip-p (backend chip)
   (:documentation "Does BACKEND support the chip CHIP-SPECIFICATION?"))
@@ -41,7 +43,7 @@
 
 ;;; The COMPILATION protocol
 
-(defgeneric compile-executable (program chip-spec backend)
+(defgeneric backend-compile (program chip-spec backend)
   (:documentation "Compile the PROGRAM which comports to the CHIP-SPEC to an executable for BACKEND."))
 
 
@@ -55,7 +57,6 @@
   ;; inheritance structure.
   (mapcar #'class-name (c2mop:class-direct-subclasses (find-class 'backend))))
 
-(defun parse-backend (backend-name)
+(defun find-backend (backend-name)
   "Returns the backend class associated with the string BACKEND-NAME."
-  (find-if (lambda (x) (equal backend-name (backend-name x)))
-           (list-available-backends)))
+  (find backend-name (list-available-backends) :test #'string= :key #'backend-name))

--- a/src/backends/quil/quil-backend.lisp
+++ b/src/backends/quil/quil-backend.lisp
@@ -10,7 +10,6 @@
   ((print-circuit-definitions :initarg :print-circuit-definitions
                               :initform nil
                               :reader print-circuit-definitions))
-  (:metaclass singleton-class)
   (:documentation "A backend the emits plain old Quil. In some sense, this backend does nothing."))
 
 (defmethod backend-name ((backend-class (eql 'quil-backend)))
@@ -34,7 +33,7 @@
 
 ;;; The COMPILATION protocol
 
-(defmethod compile-executable (program chip-spec (backend quil-backend))
+(defmethod backend-compile (program chip-spec (backend quil-backend))
   (declare (ignore chip-spec))
   (labels ((print-program-to-stream (stream)
              ;; If we want circuit definitons, keep them. Otherwise

--- a/src/backends/quil/quil-backend.lisp
+++ b/src/backends/quil/quil-backend.lisp
@@ -27,9 +27,7 @@
                      :reader utf8-quil-output)))
 
 (defmethod write-executable ((executable quil-executable) stream)
-  (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
-    (loop :for byte :across (utf8-quil-output executable)
-          :do (write-byte byte stream))))
+  (write-sequence (utf8-quil-output executable) stream))
 
 ;;; The COMPILATION protocol
 

--- a/src/backends/quil/quil-backend.lisp
+++ b/src/backends/quil/quil-backend.lisp
@@ -1,0 +1,54 @@
+;;;; quil-backend.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil)
+
+;;; The BACKEND protocol
+
+(defclass quil-backend (backend)
+  ((print-circuit-definitions :initarg :print-circuit-definitions
+                              :initform nil
+                              :reader print-circuit-definitions))
+  (:metaclass singleton-class)
+  (:documentation "A backend the emits plain old Quil. In some sense, this backend does nothing."))
+
+(defmethod backend-name ((backend-class (eql 'quil-backend)))
+  "quil")
+
+(defmethod backend-supports-chip-p ((backend quil-backend) chip)
+  (declare (ignore backend chip))
+  t)
+
+;;; The EXECUTABLE protocol
+
+(defclass quil-executable ()
+  ((utf8-bytes :initarg :utf8-bytes
+               :type (array (unsigned-byte 8) (*))
+               :reader utf8-bytes)))
+
+(defmethod write-executable ((executable quil-executable) stream)
+  (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
+    (loop :for byte :across (utf8-bytes executable)
+          :do (write-byte byte stream))))
+
+;;; The COMPILATION protocol
+
+(defmethod compile-executable (program chip-spec (backend quil-backend))
+  (declare (ignore chip-spec))
+  (labels ((print-program-to-stream (stream)
+             ;; If we want circuit definitons, keep them. Otherwise
+             ;; delete so they don't get printed.
+             (unless (print-circuit-definitions backend)
+               (setf (parsed-program-circuit-definitions program) nil))
+
+             ;; TODO: When statistics are added to backends, we should
+             ;; print them here.
+
+             (print-parsed-program program stream)))
+    
+    (make-instance 'quil-executable
+                   :utf8-bytes
+                   (flexi-streams:with-output-to-sequence (stream :element-type '(unsigned-byte 8))
+                     (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
+                       (print-program-to-stream stream))))))

--- a/src/backends/quil/quil-backend.lisp
+++ b/src/backends/quil/quil-backend.lisp
@@ -22,13 +22,13 @@
 ;;; The EXECUTABLE protocol
 
 (defclass quil-executable ()
-  ((utf8-bytes :initarg :utf8-bytes
-               :type (array (unsigned-byte 8) (*))
-               :reader utf8-bytes)))
+  ((utf8-quil-output :initarg :utf8-quil-output
+                     :type (array (unsigned-byte 8) (*))
+                     :reader utf8-quil-output)))
 
 (defmethod write-executable ((executable quil-executable) stream)
   (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
-    (loop :for byte :across (utf8-bytes executable)
+    (loop :for byte :across (utf8-quil-output executable)
           :do (write-byte byte stream))))
 
 ;;; The COMPILATION protocol
@@ -47,7 +47,7 @@
              (print-parsed-program program stream)))
     
     (make-instance 'quil-executable
-                   :utf8-bytes
+                   :utf8-quil-output
                    (flexi-streams:with-output-to-sequence (stream :element-type '(unsigned-byte 8))
                      (let ((stream (flexi-streams:make-flexi-stream stream :external-format ':UTF-8)))
                        (print-program-to-stream stream))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -492,9 +492,9 @@
    #:backend-name                       ; GENERIC
    #:backend-supports-chip-p            ; GENERIC
    #:write-executable                   ; GENERIC
-   #:compile-executable                 ; GENERIC
+   #:backend-compile                    ; GENERIC
    #:list-available-backends            ; FUNCTION
-   #:parse-backend                      ; FUNCTION
+   #:find-backend                       ; FUNCTION
 
    #:quil-backend                       ; CLASS
    #:quil-executable                    ; CLASS

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -486,6 +486,21 @@
    #:quil-type-error                    ; FUNCTION
    )
 
+  ;; backend/ stuff
+  (:export
+   #:backend                            ; CLASS
+   #:backend-name                       ; GENERIC
+   #:backend-supports-chip-p            ; GENERIC
+   #:write-executable                   ; GENERIC
+   #:compile-executable                 ; GENERIC
+   #:list-available-backends            ; FUNCTION
+   #:parse-backend                      ; FUNCTION
+
+   #:quil-backend                       ; CLASS
+   #:quil-executable                    ; CLASS
+   )
+
+
   ;; utilities.lisp
   (:export
    #:ilog2                              ; FUNCTION


### PR DESCRIPTION
Tell me, O compiler, of that ingenious backend who travelled far and wide after he had sacked the famous town of Aho-Ullman-Sethi-Lam. This PR introduces some protocols to formalize the notion of a "backend". QUILC so far has acted as a front-end for Quil. Included is a simple "no op" backend that just writes out Quil as UTF8 bytes.

We don't suggest that this will be the end-all be-all protocol; we have use-cases in mind and in development, and we expect that as actual backends get implemented, the shape of this code will change. As such, consider this a "germ" of sorts.

The PR includes:

- New command line options `--backend`, `--backend-options`, `--list-backends`, `--compile`, `--output`, as well as short versions.

- A new directory `backends` for implementations of backends, including the `quil-backend`, which is a re-imagining of current quilc functionality.

- A backend protocol, from `backends/common.lisp`.

The basic idea for implementing a backend:

1. Impelement a subclass of `backend`, which will be populated with requisite data needed to compile for that backend.

2. Implement the executable format.

3. Implement `backend-compile` to actually do the dirty work.

If you do this, quilc should "automatically know".

This supersedes PR #630.