### PR TITLE
Allow building xy chips

### DIFF
--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -300,11 +300,12 @@ used to specify CHIP-SPEC."
                                   (hardware-object-gate-information obj))
                          (make-gate-record :duration 150
                                            :fidelity fidelity)))))
-      (dolist (data `((:cz     "CZ"     ()  (_ _) 0.89d0)
+      (dolist (data `((:cz     "CZ"     ()  (_ _) 0.95d0)
                       (:iswap  "ISWAP"  ()  (_ _) 0.91d0)
-                      (:cphase "CPHASE" (_) (_ _) 0.80d0)
-                      (:piswap "PISWAP" (_) (_ _) 0.80d0)
-                      (:cnot   "CNOT"   ()  (,qubit0 ,qubit1) 0.90d0)))
+                      (:cphase "CPHASE" (_) (_ _) 0.98d0)
+                      (:piswap "PISWAP" (_) (_ _) 0.98d0)
+                      (:xy     "XY"     (_) (_ _) 0.98d0)
+                      (:cnot   "CNOT"   ()  (,qubit0 ,qubit1) 0.95d0)))
         (destructuring-bind (atom gate-name parameters arguments fidelity) data
           (stash-gate-record atom gate-name parameters arguments fidelity))))
     (when (member ':cnot type)

--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -286,11 +286,11 @@ used to specify CHIP-SPEC."
                                      (t
                                       600)))
                         (hardware-object-permutation-gates obj))
-    
+
     ;; this is the new model for setting up gate data
     (when gate-information
       (setf (hardware-object-gate-information obj) gate-information))
-    
+
     ;; this is the legacy model for setting up gate data
     (flet ((stash-gate-record (atom gate-name parameters arguments fidelity)
              (when (member atom type) #+ignore (optimal-2q-target-meets-requirements type atom)
@@ -301,11 +301,11 @@ used to specify CHIP-SPEC."
                          (make-gate-record :duration 150
                                            :fidelity fidelity)))))
       (dolist (data `((:cz     "CZ"     ()  (_ _) 0.95d0)
-                      (:iswap  "ISWAP"  ()  (_ _) 0.91d0)
-                      (:cphase "CPHASE" (_) (_ _) 0.98d0)
-                      (:piswap "PISWAP" (_) (_ _) 0.98d0)
-                      (:xy     "XY"     (_) (_ _) 0.98d0)
-                      (:cnot   "CNOT"   ()  (,qubit0 ,qubit1) 0.95d0)))
+                      (:iswap  "ISWAP"  ()  (_ _) 0.97d0)
+                      (:cphase "CPHASE" (_) (_ _) 0.93d0)
+                      (:piswap "PISWAP" (_) (_ _) 0.97d0)
+                      (:xy     "XY"     (_) (_ _) 0.97d0)
+                      (:cnot   "CNOT"   ()  (,qubit0 ,qubit1) 0.90d0)))
         (destructuring-bind (atom gate-name parameters arguments fidelity) data
           (stash-gate-record atom gate-name parameters arguments fidelity))))
     (when (member ':cnot type)

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -419,7 +419,7 @@ Both CENTER-CIRCUIT and the return value are lists of GATE-APPLICATIONs; A, D, a
       (match-matrix-to-an-e-basis-diagonalization
        (make-matrix-from-quil center-circuit :relabeling (standard-qubit-relabeler `(,q1 ,q0)))
        a d b)
-    
+
     (multiple-value-bind (b1 b0) (convert-su4-to-su2x2 ub)
       (multiple-value-bind (a1 a0) (convert-su4-to-su2x2 ua)
         (values
@@ -470,7 +470,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
                                    :class approximate-compiler
                                    :permit-binding-mismatches-when *enable-approximate-compilation*)
              ,docstring
-	     ,@decls
+             ,@decls
              (let ((,circuit (with-inst () ,@body))
                    (,coord (mapcar #'constant-value (application-parameters ,instr-name)))
                    (,q1 (qubit-index (first (application-arguments ,instr-name))))
@@ -485,7 +485,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 
 (defmacro define-searching-approximate-template (name (coord q1 q0 parameter-array)
                                                  (&key predicate
-                                                       parameter-count)
+                                                    parameter-count)
                                                  &body parametric-circuit)
   "Defines an approximate template that uses an inexact (and possibly imperfect) search algorithm (e.g., a Nelder-Mead solver).  In addition to the documentation of DEFINE-CANONICAL-CIRCUIT-APPROXIMATION, this macro takes the extra value PARAMETER-COUNT which controls how many variables the searcher will optimize over."
   (a:with-gensyms (instr a d b in goodness template-values)
@@ -496,7 +496,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
                     ;; this is here to throw the compiler hunter off the scent
                     :where t))
          ,@(when docstring (list docstring))
-	 ,@decls
+         ,@decls
          (labels
              ((circuit-template (,parameter-array ,q1 ,q0)
                 (with-inst ()
@@ -554,7 +554,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
     ((instr ("CAN" (alpha 0 0) q1 q0)))
   (inst "CPHASE" (list (* 2 alpha)) q1 q0))
 
-(define-canonical-circuit-approximation nearest-ISWAP-circuit-of-depth-2 
+(define-canonical-circuit-approximation nearest-ISWAP-circuit-of-depth-2
     ((instr ("CAN" (alpha beta 0) q1 q0)))
   (inst "ISWAP" ()           q1 q0)
   (inst "RY"    (list alpha) q1)
@@ -648,7 +648,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
   (inst "PISWAP" (list (aref array 3))     q1 q0))
 
 (define-canonical-circuit-approximation nearest-CZ-circuit-of-depth-2
-    ((instr ("CAN" (alpha beta 0d0) q1 q0)))    
+    ((instr ("CAN" (alpha beta 0d0) q1 q0)))
   (inst "CZ" () q1 q0)
   (inst "RY" (list alpha) q1)
   (inst "RY" (list beta) q0)
@@ -696,7 +696,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMATE-COMPILER* is NIL."
   (check-type instr gate-application)
   (check-type context compilation-context)
-  
+
   (unless (= 2 (length (application-arguments instr)))
     (give-up-compilation))
 
@@ -706,7 +706,7 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
           (q0 (qubit-index (second (application-arguments instr))))
           (candidate-pairs nil)
           (chip-spec (compilation-context-chip-specification context)))
-      
+
       ;; now we manufacture a bunch of candidate circuits
       (dolist (circuit-crafter crafters)
         (unless (and (first candidate-pairs)
@@ -733,7 +733,7 @@ NOTE: This routine degenerates to an optimal 2Q compiler when *ENABLE-APPROXIMAT
                   (push (cons (* circuit-cost (- 1 infidelity)) sandwiched-circuit)
                         candidate-pairs)))
             (compiler-does-not-apply () nil))))
-      
+
       ;; now vomit the results
       (when (endp candidate-pairs)
         (give-up-compilation))

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -41,7 +41,7 @@
 ;;       routines immediately following this definition.
 (deftype optimal-2q-target-atom ()
   "An enumerative type describing the two-qubit operators required by a particular two-qubit decomposition template."
-  '(member :cz :iswap :piswap :cphase :cnot))
+  '(member :cz :iswap :piswap :xy :cphase :cnot))
 
 (defun sequence-of-optimal-2q-target-atoms-p (seq)
   (and (typep seq 'sequence)
@@ -60,6 +60,7 @@
         (requirementsl (a:ensure-list requirements)))
     (when (member ':cphase targetl) (push ':cz targetl))
     (when (member ':piswap targetl) (push ':iswap targetl))
+    (when (member ':xy targetl) (push ':iswap targetl))
     (when (member ':cnot targetl) (push ':cz targetl))
     (subsetp requirementsl targetl)))
 
@@ -73,6 +74,7 @@
                     (:cz       (string= name "CZ"))
                     (:iswap    (string= name "ISWAP"))
                     (:piswap   (string= name "PISWAP"))
+                    (:xy       (string= name "XY"))
                     (:cphase   (string= name "CPHASE"))
                     (otherwise nil))))
            (some #'good requirements)))))


### PR DESCRIPTION
Allow providing `:xy` as `:architecture` to the various chip builders. Also brings the default fidelities to something more recent / less guess-y, at least for xy/piswap/cz.

Closes #582 