### PR TITLE
Do not use a default value in EYE

### DIFF
--- a/src/magicl-constructors.lisp
+++ b/src/magicl-constructors.lisp
@@ -23,7 +23,7 @@
   "CL-QUIL version of MAGICL:RAND"
   (magicl:rand shape :type type :layout layout :distribution distribution))
 
-(defun eye (shape &key (value #C(1d0 0d0)) (type +default-magicl-type+) layout)
+(defun eye (shape &key value (type +default-magicl-type+) layout)
   "CL-QUIL version of MAGICL:EYE"
   (magicl:eye shape :value value :type type :layout layout))
 


### PR DESCRIPTION
`EYE` wraps `MAGICL:EYE`, which may be provided with both a type and a value for the diagonal. Currently, `MAGICL:EYE` will `COERCE` the value to the type, if need be. However, `(complex double-float)` cannot be coerced to `double-float`, even if the imaginary part is zero. Every so often quilc tries to construct a double-float identity matrix, e.g. here https://github.com/rigetti/quilc/blob/master/src/compilers/approx.lisp#L201, and this will cause an error.