### PR TITLE
Truncate fidelities to the range (0, 1)

### DIFF
--- a/src/chip/chip-reader.lisp
+++ b/src/chip/chip-reader.lisp
@@ -135,7 +135,7 @@
 
 (defun deforestify-fidelity (fidelity)
   "The fidelity values recorded in Forest DB are subject to various quirks. This \"parser\" un-quirks them."
-  (cond 
+  (cond
     ((double= fidelity +forest-error-sentinel+)
      (warn "Chip specification contains a fidelity field populated by the Forest error sentinel. Replacing it with the default ~A." +totally-awful-fidelity+)
      +totally-awful-fidelity+)
@@ -144,9 +144,11 @@
      +near-perfect-fidelity+)
     ((> fidelity +near-perfect-fidelity+)
      ;; Silent truncation.
-     +near-perfect-fidelity+)
+     (- 1d0 double-float-epsilon))
     ((minusp fidelity)
      (error "Chip specification contained negative fidelity ~A. I don't know what to do with this value." fidelity))
+    ((zerop fidelity)
+     double-float-epsilon)
     (t
      fidelity)))
 
@@ -450,6 +452,3 @@
       (when (typep blk 'preserved-block)
         (check-instructions-skip-dead-qubits (basic-block-code blk) dead-qubits
                                              :condition-class 'illegal-qubits-used-in-preserved-block-error)))))
-
-
-


### PR DESCRIPTION
i.e. the range [double-float-epsilon, 1 - double-float-epsilon]

We truncate perfect fidelities to less-than-perfect so that we have
some wiggle room when deciding what to do next. That less-than-perfect
fidelity was chosen to be 0.999, which I think (at least in theory)
could cause unexpected behaviour. Say for example you have one
instruction with a very good fidelity (say 0.999999) and another with
good fidelity (0.999). The compiler will truncate the former to 0.999,
and may then pick the second instruction for its output. The user is
then left thinking why is this instruction chosen over the superior
0.999999 instruction?

The user might then return to the compiler to inquire about the
resulting fidelity of the program, which it will report as 0.999 which
is fine if the compiler chose the less-good of the two options, but if
it chose the "better" of the two, then the user would expect to see a
fidelity of 0.999999.

This change goes some way to solving/alleviating those issues. In the
first case, 0.999999 will not be truncated and so the compiler will do
The Right Thing. In the second case, the fidelity will look reasonable
to the user. In the case where a fidelity of 1.0 is specified,
it *will* be truncated but it will still likely be larger than other
fidelities, and the fidelity calculation will still be reasonable to
the user (even if it isn't a perfect 1.0).