### PR TITLE
Only use "reducers" that strictly improve fidelity

### DIFF
--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -240,10 +240,10 @@ other's."
                                           context)
   "Applies peephole rewriter rules from a CHIP-SPECIFICATION to a sequence of INSTRUCTIONS, using CONTEXT to activate context-sensitive rules."
   (labels
-      ( ;; utility for calculating how many instructions a rewriting rule requests
+      (;; utility for calculating how many instructions a rewriting rule requests
        (rewriting-rule-count (compiler)
          (length (compiler-bindings compiler)))
-       
+
        ;; let the context know that we've passed inspection of NODE, so that the
        ;; effect of that instruction is visible during inspection of the next node
        (update-context (node)
@@ -303,7 +303,7 @@ other's."
        ;; successfully, we rewind by the peephole window and try again. if it
        ;; fails, we fall through, step through to the next node, and try again.
        (outer-instruction-loop (node)
-         (do ( ;; for each instruction...
+         (do (;; for each instruction...
               (node #1=(peephole-rewriter-node-next node) #1#))
              ((null node))
            (update-context node)

--- a/src/define-compiler.lisp
+++ b/src/define-compiler.lisp
@@ -874,7 +874,7 @@ Compilers matching gates which don't have parameters don't count as accepting pa
              (let* ((input-fidelity (calculate-fidelity-of-concrete-gates gates))
                     (output (apply compiler gates))
                     (output-fidelity (calculate-fidelity-of-concrete-gates output)))
-               (>= output-fidelity input-fidelity))
+               (> output-fidelity input-fidelity))
            (no-binding-match () nil)
            (compiler-does-not-apply () nil)
            (cannot-concretize-binding () nil)))
@@ -907,7 +907,7 @@ Compilers matching gates which don't have parameters don't count as accepting pa
                                                           (when (typep b 'gate-binding)
                                                             (binding-subsumes-p (copy-binding b :options nil) g)))
                                                       (setf in-fidelity (* in-fidelity gate-fidelity)))))
-                  (>= out-fidelity in-fidelity)))
+                  (> out-fidelity in-fidelity)))
            ;; if that falls through, try the exhaustive match
            (let ((matches (loop :for binding :in (compiler-bindings compiler)
                                 :for match := (gates-that-match-binding binding gateset)

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -240,13 +240,14 @@ CNOT 4 8
          (progm (parse "RX(pi/2) 0; RX(pi/2) 0"))
          (comp (compiler-hook progm chip))
          (code (%filter-halt comp)))
-    (is (m= (parsed-program-to-logical-matrix
-             (parse "RX(pi) 0"))
-            (parsed-program-to-logical-matrix comp)))
+    (is (quil::matrix-equals-dwim
+         (parsed-program-to-logical-matrix
+          (parse "RX(pi) 0"))
+         (parsed-program-to-logical-matrix comp)))
     (is (= 1 (length code)))
     (is (string= "RX" (quil::application-operator-root-name (elt code 0))))
     (is (quil::double= pi
-                       (constant-value (first (application-parameters (elt code 0))))))))
+                       (abs (constant-value (first (application-parameters (elt code 0)))))))))
 
 (defun %random-rz-rx-program (length)
   (make-instance 'parsed-program


### PR DESCRIPTION
In `compute-applicable-reducers` we hope to narrow the list of `compilers` down to those that "improve the brevity of a gate sequence" subject to the restriction "without exiting a particular `gateset`". (The word "brevity" here is maybe a hold-over from a time when program length (duration?) was the cost function, and now it means fidelity?) In reality, it would also include compilers that did *at least as good* as others. This seems to cause trouble for certain ISAs and compilers.

For example, if your ISA contains `CZ 0 1`, `CPHASE(θ) 0 1`, *and* each has the same fidelity `fid` then the compiler can get into a loop where a `CPHASE(θ) 0 1` is compiled with `half-cphase-to-cz` and then the resulting `CZ` are compiled with `cz-to-cphase`, etc. Both of these compilers are present in the list computed by `compute-applicable-reducers` where I think only one of them needs to be present. By making the `compute-applicable-reducers` comparison strict, the reducers then are only applied if they improve the fidelity, and the compiler can support ISAs whose gates may be equivalent (CZ = CPHASE(pi)) and of equal fidelity.

Am I missing something? :D