### PR TITLE
Fix error in test-logical-matrix-sanity with high type safety on SBCL.

### DIFF
--- a/src/addresser/addresser-state.lisp
+++ b/src/addresser/addresser-state.lisp
@@ -22,7 +22,7 @@
              :type list)
    (lschedule :accessor addresser-state-logical-schedule
               :documentation "The logical schedule of not-yet-processed instructions."
-              :type logical-schedule)
+              :type logical-scheduler)
    (chip-sched :accessor addresser-state-chip-schedule
                :documentation "The outgoing schedule of processed instructions."
                :type chip-schedule)


### PR DESCRIPTION
In src/addresser/addresser-state.lisp slot lschedule in class
addresser-state had wrong type declaration. It was
LOGICAL-SCHEDULE. It should be LOGICAL-SCHEDULER.

This got exposed with the system compiled in SBCL with compiler policy
safety = 3. To reproduce I recompiled after clearing binaries and
evaluating the following before compiling and running tests:

  (sb-ext:restrict-compiler-policy 'debug 3 3)
  (sb-ext:restrict-compiler-policy 'safety 3 3)
  (sb-ext:restrict-compiler-policy 'space 0 0)
  (sb-ext:restrict-compiler-policy 'speed 0 0)

Then test test-logical-matrix-sanity would fail with error message

  unknown type specifier: CL-QUIL::LOGICAL-SCHEDULE

As per SBCL doc here http://www.sbcl.org/manual/#Declarations-as-Assertions,
when

(or (>= safety 2) (>= safety speed 1))

the compiler inserts runtime type checks for declared types. So this
was not caught with the default compiler policy, which is safety = 1,
speed = 1.

Note that there seems to be confusion between 'schedule' and
'scheduler' throughout sources and doc. in fact the doc for this very
slot still refers to logical "schedule", not "scheduleR". I left it as
is, since it's just the tip of the iceberg. In the future a review and
cleanup of the two usages may be worthwhile.