### PR TITLE
Draft: Fix test TEST-BIG-DEFGATE stack overflow with certain compiler policy…

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -264,45 +264,53 @@ A logical line may be introduced either as the result of a :NEWLINE or a :SEMICO
     (declare (type cons pieces pieces-last))
     (labels ((doit (start last end)
                (declare (type list start last end))
-               (cond
-                 ;; Done
-                 ((null end)
-                  (unless (eq start end)
-                    (rplacd pieces-last (cons start nil))
-                    (setf pieces-last (cdr pieces-last)))
-                  pieces)
-                 ;; Split off a newline
-                 ((eq ':NEWLINE (car end))
-                  (cond
-                    ((eq start end)
-                     (let ((next (cdr start)))
-                       (doit next next next)))
-                    (t
-                     (rplacd pieces-last (cons start nil))
-                     (setf pieces-last (cdr pieces-last))
-                     (setf start (cdr end))
-                     (rplacd last nil)
-                     (doit start start start))))
-                 ;; A semicolon also results in a new line being split, but we
-                 ;; also inherit the preceding indentation.
-                 ((eq ':SEMICOLON (car end))
-                  (cond
-                    ((eq start end)
-                     (let ((next (cdr start)))
-                       (doit next next next)))
-                    (t
-                     (rplacd pieces-last (cons start nil))
-                     (setf pieces-last (cdr pieces-last))
-                     ;; Prepend appropriate indentation
-                     (setf start (if (eq ':INDENTATION (token-type (car start)))
-                                     (cons (car start)  ; Copy the indentation (line number on this token is irrelevant)
-                                           (cdr end))
-                                     (cdr end)))
-                     (rplacd last nil)
-                     (doit start start start))))
-                 ;; Keep on truckin'.
-                 (t
-                  (doit start end (cdr end))))))
+               (loop :when (null end)
+                       ;; Done
+                       :do (unless (eq start end)
+                             (rplacd pieces-last (cons start nil))
+                             (setf pieces-last (cdr pieces-last)))
+                           (return pieces)
+                     :do
+                        (cond
+                          ;; Split off a newline
+                          ((eq ':NEWLINE (car end))
+                           (cond
+                             ((eq start end)
+                              (let ((next (cdr start)))
+                                (setq start next)
+                                (setq last next)
+                                (setq end next)))
+                             (t
+                              (rplacd pieces-last (cons start nil))
+                              (setf pieces-last (cdr pieces-last))
+                              (setf start (cdr end))
+                              (rplacd last nil)
+                              (setq last start)
+                              (setq end start))))
+                          ;; A semicolon also results in a new line being split, but we
+                          ;; also inherit the preceding indentation.
+                          ((eq ':SEMICOLON (car end))
+                           (cond
+                             ((eq start end)
+                              (let ((next (cdr start)))
+                                (setq start next)
+                                (setq last next)
+                                (setq end next)))
+                             (t
+                              (rplacd pieces-last (cons start nil))
+                              (setf pieces-last (cdr pieces-last))
+                              ;; Prepend appropriate indentation
+                              (setf start (if (eq ':INDENTATION (token-type (car start)))
+                                              (cons (car start) ; Copy the indentation (line number on this token is irrelevant)
+                                                    (cdr end))
+                                              (cdr end)))
+                              (rplacd last nil)
+                              (setq last start)
+                              (setq end start))))
+                          ;; Keep on truckin'.
+                          (t
+                           (setq last end)
+                           (setq end (cdr end)))))))
       (cdr (doit tokens tokens tokens)))))
 
 (defun tokenize (string)


### PR DESCRIPTION
… on SBCL.

With a certain ultra slow ultra safe compiler policy, a stack overflow
error during one of its tests, namely cl-quil-tests::test-big-defgate.

When compiler policy is set by evaluating the following

  (sb-ext:restrict-compiler-policy 'debug 3 3)
  (sb-ext:restrict-compiler-policy 'safety 3 3)
  (sb-ext:restrict-compiler-policy 'space 0 0)
  (sb-ext:restrict-compiler-policy 'speed 0 0)

the sytem gives the following error

    Control stack exhausted (no more space for function call frames).
    This is probably due to heavily nested or infinitely recursive function
    calls, or a tail call that SBCL cannot or has not optimized away.

There follows a backtrace with an extremely large number of calls to SPLIT-LINES.

One might guess that this is simply a result of tail call optimization
not being done. The function where this is called is a candidate for
tail call elimination, due to its inner (flet) recursive function
DOIT.

However, SBCL's tail call elimination policy is rather unclear. At
least I could not find clear documentation of the compiler
optimization policy.

When the following is evaluated

  (sb-ext:restrict-compiler-policy 'debug 3 3)
  (sb-ext:restrict-compiler-policy 'safety 3 3)
  (sb-ext:restrict-compiler-policy 'space 0 0)
  (sb-ext:restrict-compiler-policy 'speed 3 3)

and then split-lines is recompiled, the error going away.

At any rate, this reimplementation of split-lines without a recursive
inner function runs without any error with both compilation settings,
and all tests pass.