### PR TITLE
Fix quilt test TEST-FILL-DELAYS-FENCE-EXPANSION

### DIFF
--- a/src/quilt/analysis/fill-delays.lisp
+++ b/src/quilt/analysis/fill-delays.lisp
@@ -174,9 +174,7 @@ If WF-OR-WF-DEFN is a waveform definition, SAMPLE-RATE (Hz) must be non-null. "
     (a:when-let ((frame (pulse-operation-frame instr)))
       (let* ((start-time (local-time clocks frame))
              (end-time (+ start-time (quilt-instruction-duration instr))))
-        
         (setf (local-time clocks frame) end-time)
-
         (if (nonblocking-p instr)
             nil
             (loop :for f :in (remove-if-not (lambda (f)

--- a/src/quilt/analysis/fill-delays.lisp
+++ b/src/quilt/analysis/fill-delays.lisp
@@ -174,7 +174,7 @@ If WF-OR-WF-DEFN is a waveform definition, SAMPLE-RATE (Hz) must be non-null. "
     (a:when-let ((frame (pulse-operation-frame instr)))
       (let* ((start-time (local-time clocks frame))
              (end-time (+ start-time (quilt-instruction-duration instr))))
-
+        
         (setf (local-time clocks frame) end-time)
 
         (if (nonblocking-p instr)
@@ -184,7 +184,8 @@ If WF-OR-WF-DEFN is a waveform definition, SAMPLE-RATE (Hz) must be non-null. "
                                             (tracked-frames clocks))
                   :for lag := (- end-time (local-time clocks f))
                   ;; handle implicit delays
-                  :when (plusp lag)
+                  :when (and (not (frame= frame f))
+                             (plusp lag))
                     :do (incf (local-time clocks f) lag)
                     :and :collect (make-instance 'delay-on-frames
                                                  :frames (list f)

--- a/tests/quilt/analysis-tests.lisp
+++ b/tests/quilt/analysis-tests.lisp
@@ -187,17 +187,17 @@ CAPTURE 1 \"xy\" flat(duration: 1, iq: 1) iq
            (is (not (typep instr 'fence))))
          (parsed-program-executable-code pp))
     (let ((instr (quil::nth-instr 1 pp)))
-      (is (and (typep instr 'delay)
-               (= 1.0 (constant-value  (delay-duration instr)))
-               ;; we can't say which kind of delay is inserted,
-               ;; so we just check either
-               (typecase instr
-                 (delay-on-frames
-                  (every (lambda (f)
-                           (frame= f
-                                   (frame (list (qubit 1)) "xy")))
-                         (delay-frames instr)))
-                 (delay-on-qubits
-                  (every (lambda (q)
-                           (= 1 (qubit-index q)))
-                         (delay-qubits instr)))))))))
+      (is (typep instr 'delay))
+      (is (= 1.0 (constant-value  (delay-duration instr))))
+      (is (typecase instr
+            ;; there are two possible delays which could be emitted
+            ;; we check both
+            (delay-on-frames
+             (every (lambda (f)
+                      (frame= f
+                              (frame (list (qubit 1)) "xy")))
+                    (delay-frames instr)))
+            (delay-on-qubits
+             (every (lambda (q)
+                      (= 1 (qubit-index q)))
+                    (delay-qubits instr))))))))


### PR DESCRIPTION
It was observed that one of the `cl-quil/quilt` tests was failing. I'm not sure how this got through the original PR process (perhaps I goofed something in a rebase??), but here's an easy fix. It's worth noting two things:

- As far as I know, `cl-quil/quilt` is not currently used by anyone.
- The change here reflects the minor work needed to get the test to pass, and it is at least consistent with the stated intent of the analysis pass (previously it was inserting a spurious `DELAY`). But I'm not otherwise verifying the correctness of `cl-quil/quilt` with respect to the proposed Quilt standard or the Rigetti pidgin implementation.


There's another Quilt test, `test-definition-signature`, that fails under some circumstances due to how the hash method for frames is currently implemented. That may be addressed in a separate PR.