### PR TITLE
Fix frame-hash to return same hash, portably, for two frame= frames.

### DIFF
--- a/src/quilt/ast.lisp
+++ b/src/quilt/ast.lisp
@@ -20,11 +20,16 @@
        (quil::list= (frame-qubits a) (frame-qubits b) :test #'qubit=)))
 
 (defun frame-hash (f)
+  "Return a hash for frame F. This is to frame= as sxhash is to equal, i.e., (frame= a b) implies (= (frame-hash a) (frame-hash b))."
   (check-type f frame)
-  #+sbcl
-  (sb-int:mix (sxhash (frame-name f)) (sxhash (frame-qubits f)))
-  #-sbcl
-  (logxor (sxhash (frame-name f)) (sxhash (frame-qubits f))))
+  (let* ((name (frame-name f))
+         (qubits (frame-qubits f))
+         (hash (sxhash name)))
+    (dolist (qubit qubits hash)
+      (setq hash
+            (#+sbcl sb-int:mix #-sbcl logxor
+             hash
+             (qubit-index qubit))))))
 
 (defmethod print-instruction-generic ((thing frame) (stream stream))
   (format stream "~{~/quil:instruction-fmt/ ~}\"~A\""


### PR DESCRIPTION
Note that this is not for cl-quil itself but rather for cl-quil/quilt,
a separate system that depends on cl-quil.

Previously, frame-hash would mix the list of qubits into the hash.
However, since qubits are objects and not interned per their index, in
order to have the desired effect, the hash of the index of each qubit
should be used.  By analogy with CL's sxhash, frame-hash now has the
desireable property that two frames that are frame= have the same
hash.

In older versions of SBCL, in particular in 1.4.5.debian, which is the
version used for CI on the cl-quil main repo, sxhash would return the
same result for two non-equal structures of the same type no matter
their internal values.

SBCL's behavior was not technically a bug, but it was nonoptimal, and
that was improved upon in this commit:
https://sourceforge.net/p/sbcl/sbcl/ci/0fcebff494f89fe5fa0e5855fb36ed5d913783b7

The old behavior helped to mask the bug in the particular set of tests
for this system.  Given the lack of guarantees by Common Lisp for
unique sxhash results for different input, a more reliable and
portable implementation ought to be considered.

This fixes two tests that were failing in SBCL 2.0.11:

(1) test-definition-signature in tests/quilt/parser-tests.lisp

It would fail on the test comparing the signatures for two exact same
input programs, namely

  (equalp (signature "DEFFRAME 0 \"foo\"")
          (signature "DEFFRAME 0 \"foo\""))

Note that this test *would* pass without this fix in older SBCL, but
that was due to the SBCL bug described above, since it made every
qubit structure instance have the same sxhash, which happened to make
this test pass, but would have also made other tests pass
that should not, e.g.,

  (equalp (signature "DEFFRAME 3 \"foo\"")   ; should *NOT* pass
          (signature "DEFFRAME 0 \"foo\""))

(2) test-fill-delays-fence-expansion in tests/quilt/analysis-tests.lisp

The FILL-DELAYS pass will emit explicit DELAY instructions in contexts
where they were previously implicit. It does this by tracking timing
info in a hash table keyed by frames.  Because under some
implementations FRAME-HASH could give different values for two frames
that satisfy FRAME=, the timing info in this table was was not managed
correctly.