### PR TITLE
Fix for magicl update and other sundries

### DIFF
--- a/cl-quil-tests.asd
+++ b/cl-quil-tests.asd
@@ -8,8 +8,8 @@
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:cl-quil
                (:version #:qvm "1.9.0")
-               #:magicl
-               #:magicl-transcendental
+               (:version #:magicl/core "0.9.0")
+               #:magicl/ext-expokit
                #:alexandria
                #:fiasco
                #:uiop

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -13,7 +13,8 @@
                #:yacc                   ; Arithmetic parsing
                #:alexandria             ; Utilities
                #:parse-float            ; Float parsing
-               (:version #:magicl "0.7.0")
+               (:version #:magicl/core "0.9.0")
+               #:magicl/ext-lapack      ; for CSD
                                         ; internal linear algebra library
                #:cl-grnm                ; nelder-mead implementation
                #:singleton-classes
@@ -137,7 +138,7 @@
 
 ;;; Contribs
 
-;; Adapted from magicl's magicl-transcendental adapted from commonqt's
+;; Adapted from magicl's MAGICL/EXT-EXPOKIT adapted from commonqt's
 ;; qt.asd.
 
 ;; NOTE: The following contrib requires a C++17 compiler, and is untested on

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1289,14 +1289,6 @@ N.B. This slot should not be accessed directly! Consider using GATE-APPLICATION-
                        :documentation "The definition of the circuit used in this application."))
   (:documentation "An instruction representing an application of a known circuit."))
 
-(defvar *print-fractional-radians* t
-  "When true, FORMAT-COMPLEX pretty-prints some common fractions of pi in a more human-readable form.
-
-N.B., The fractions of pi will be printed up to a certain precision!")
-
-(defvar *print-polar-form* nil
-  "When true, FORMAT-COMPLEX prints out complex numbers in polar form with syntax AMPLITUDE∠PHASE.")
-
 (declaim (type (vector rational) **reasonable-rationals**))
 (global-vars:define-global-var **reasonable-rationals**
     (coerce (nconc (a:iota 10 :start 1)

--- a/src/clifford/benchmarking-procedures.lisp
+++ b/src/clifford/benchmarking-procedures.lisp
@@ -206,9 +206,13 @@
 
 (defun apply-pauli-to-wavefunction (ph index q wf)
   "Apply the pauli specified by index (0 = I, 1 = X, 2 = Z, 3 = Y) to qubit Q of the wavefunction WF, with a phase PH."
+  (assert (quil::positive-power-of-two-p (length wf))
+          (wf)
+          "The provided wavefunction must have a positive power-of-two length.")
   (multiple-value-bind (b a) (floor index 2)
     (let* ((phase (expt #C(0.0d0 1.0d0) (b* a b)))
            (n (quil::ilog2 (length wf))))
+      (declare (type (integer 1) n))    ; Due to ASSERT above.
       (flet ((xz (w0 w1)
                (setf w0 (* ph phase w0))
                (setf w1 (* ph phase w1 (expt #C(-1.0d0 0.0d0) b)))

--- a/src/compressor/compressor.lisp
+++ b/src/compressor/compressor.lisp
@@ -348,15 +348,13 @@ other's."
 
     ;; strip out all the NOPs.
     (let* ((instructions (remove-if (lambda (x) (typep x 'no-operation)) instructions))
-           (head (instrs->peephole-rewriter-nodes instructions))
-           (node head))
+           (head (instrs->peephole-rewriter-nodes instructions)))
 
       ;; actually, we need to prepend a dummy head
       (setf head (make-peephole-rewriter-node :instr (build-gate "Z" () 0)
                                               :next head
                                               :context context))
       (setf (peephole-rewriter-node-prev (peephole-rewriter-node-next head)) head)
-      (setf node head)
 
       (outer-instruction-loop head)
       ;; when we make it to this point, no rewrite rules apply, so quit.

--- a/src/csd.lisp
+++ b/src/csd.lisp
@@ -154,7 +154,13 @@ See also http://www.netlib.org/lapack/explore-html/de/d0d/zuncsd_8f.html."
                     v2h
                     theta)))))))
 
-(defvar *lapack-csd* (if (magicl.foreign-libraries:foreign-symbol-available-p "zuncsd_" 'magicl.foreign-libraries:liblapack)
-                         #'magicl:lapack-csd
-                         #'csd)
+;;; We use symbols below to allow redefinition.
+;;;
+;;; TODO: Just use MAGICL:CSD as soon as we conform to its interface.
+(defvar *lapack-csd*
+  (if (magicl.foreign-libraries:foreign-symbol-available-p
+       "zuncsd_"
+       'magicl.foreign-libraries:liblapack)
+      'magicl-lapack:lapack-csd
+      'csd)
   "Implementation of the CS decomposition suitable for use in Quilc. Allows us to replace ZUNCSD on systems whose LAPACK does not provide it.")

--- a/src/options.lisp
+++ b/src/options.lisp
@@ -17,16 +17,9 @@
 (defvar *resolve-include-pathname* 'identity
   "The function used to handle/resolve pathnames passed to INCLUDE directives in Quil. Specifically, it should be a function designator that takes one argument (a pathname designator) and returns the absolute pathname to include, or signals an error.")
 
+;;; See FORMAT-NOISE for making compiler noise.
 (defvar *compiler-noise* nil
   "The stream on which to emit compiler debug output or NIL to suppress compiler noise.")
-
-(defmacro format-noise (str &rest args)
-  "FORMAT-NOISE checks to see whether *COMPILER-NOISE* has been set and, if so, formats it according to the passed format string and arguments."
-  `(progn
-     (when *compiler-noise*
-       (format *compiler-noise* ,str ,@args)
-       (fresh-line *compiler-noise*))
-     (values)))
 
 (defvar *compress-carefully* nil
   "Flag that turns on/off a bunch of intermediate correctness checks during compression.  WARNING: this can be *very* costly, since it involves computing explicit matrix presentations.")
@@ -35,3 +28,17 @@
   "When NIL, compression by replacing instructions sequences with approximate sequences is disabled.
 
 NOTE: When T, this permits the approximate compilation templates to emit inexact results, but does not actually enable any alternative code paths.  When NIL, these results are still generated, but they are discarded.")
+
+
+;;; These are more internal options for debugging (and forward
+;;; declaration).
+
+;;; See **REASONABLE-RATIONALS** for what rational numbers get
+;;; printed.
+(defvar *print-fractional-radians* t
+  "When true, FORMAT-COMPLEX pretty-prints some common fractions of pi in a more human-readable form.
+
+N.B., The fractions of pi will be printed up to a certain precision!")
+
+(defvar *print-polar-form* nil
+  "When true, FORMAT-COMPLEX prints out complex numbers in polar form with syntax AMPLITUDE∠PHASE.")

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -237,6 +237,14 @@ contains the bits of INTEGER. See http://www.cliki.net/ROTATE-BYTE"
   (dohash ((key val) hash)
     (format stream "~A -> ~A~%" key val)))
 
+(defmacro format-noise (str &rest args)
+  "FORMAT-NOISE checks to see whether *COMPILER-NOISE* has been set and, if so, formats it according to the passed format string and arguments."
+  `(progn
+     (when *compiler-noise*
+       (format *compiler-noise* ,str ,@args)
+       (fresh-line *compiler-noise*))
+     (values)))
+
 ;;; Cribbed from QVM-TESTS
 (defmacro with-output-to-quil (&body body)
   "Collect all data sent to *STANDARD-OUTPUT* and return it parsed as as a Quil program."

--- a/tests/clifford-tests.lisp
+++ b/tests/clifford-tests.lisp
@@ -106,7 +106,7 @@
             :while (< n (* num-qubits 50))
             :for p := (random-pauli num-qubits)
             :for x := (1- (random 1.0d0))
-            :for reference := (magicl-transcendental:expm
+            :for reference := (magicl:expm
                                (magicl:scale (quil:parsed-program-to-logical-matrix
                                               (pauli-to-parsed-program p))
                                              (* #c(0.0d0 -1.0d0) x)))
@@ -318,7 +318,7 @@
         (phased-bell-tab (cl-quil.clifford::make-tableau-zero-state 2)))
     ;; zero state wavefunction
     (setf (aref zero-wf 0) 1)
-    (is (cl-quil.clifford::global-phase~ 
+    (is (cl-quil.clifford::global-phase~
          zero-wf
          (cl-quil.clifford::tableau-wavefunction zero-tab)))
     ;; bell state wavefunction


### PR DESCRIPTION
This PR does two things:

1. ~Adds a forwards and backwards compatible fix for the upcoming changes to MAGICL. it'll search for the `LAPACK-CSD` function from multiple packages.~ Updates MAGICL to 0.9.0 and removes deprecated systems.
2. Fixes a few errors caught by SBCL at compile-time.