### PR TITLE
introduce cl-quil.si package, eliminate :: refs in Quilt

### DIFF
--- a/src/quilt/analysis/expand-calibrations.lisp
+++ b/src/quilt/analysis/expand-calibrations.lisp
@@ -118,7 +118,7 @@
   "Instantiate FRAME with respect to the argument values represented by ARG-VALUE, constructing a new frame if needed."
   (let* ((remake nil)
          (qubits (mapcar (quil.si:flag-on-update remake
-                                               (lambda (q) (ensure-instantiated q :arg-value arg-value)))
+                                                 (lambda (q) (ensure-instantiated q :arg-value arg-value)))
                          (frame-qubits frame))))
     (if remake
         (let ((instantiated (frame qubits (frame-name frame))))
@@ -236,7 +236,7 @@
          (duration (ensure-instantiated (delay-duration instr)
                                         :param-value param-value))
          (frames (mapcar (quil.si:flag-on-update remake
-                                               (lambda (f) (instantiate-frame f arg-value)))
+                                                 (lambda (f) (instantiate-frame f arg-value)))
                          (delay-frames instr))))
     (if (and (eq duration (delay-duration instr))
              (not remake))
@@ -248,7 +248,7 @@
 (defmethod instantiate-instruction ((instr fence) param-value arg-value)
   (let* ((remake nil)
          (qubits (mapcar (quil.si:flag-on-update remake
-                                               (lambda (q) (ensure-instantiated q :arg-value arg-value)))
+                                                 (lambda (q) (ensure-instantiated q :arg-value arg-value)))
                          (fence-qubits instr))))
     (if remake
         (make-instance 'fence :qubits qubits)
@@ -257,28 +257,28 @@
 ;;; Calibrations instantiate to their bodies, with parameters and formals substituted
 (defmethod instantiate-instruction ((instr gate-calibration-definition) param-value arg-value)
   (quil.si:instantiate-definition-body instr
-                                     (calibration-definition-body instr)
-                                     (calibration-definition-parameters instr)
-                                     param-value
-                                     (calibration-definition-arguments instr)
-                                     arg-value))
+                                       (calibration-definition-body instr)
+                                       (calibration-definition-parameters instr)
+                                       param-value
+                                       (calibration-definition-arguments instr)
+                                       arg-value))
 
 (defmethod instantiate-instruction ((instr measure-calibration-definition) param-value arg-value)
   (quil.si:instantiate-definition-body instr
-                                     (calibration-definition-body instr)
-                                     nil
-                                     param-value
-                                     (list (measurement-calibration-qubit instr)
-                                           (measure-calibration-address instr))
-                                     arg-value))
+                                       (calibration-definition-body instr)
+                                       nil
+                                       param-value
+                                       (list (measurement-calibration-qubit instr)
+                                             (measure-calibration-address instr))
+                                       arg-value))
 
 (defmethod instantiate-instruction ((instr measure-discard-calibration-definition) param-value arg-value)
   (quil.si:instantiate-definition-body instr
-                                     (calibration-definition-body instr)
-                                     nil
-                                     param-value
-                                     (list (measurement-calibration-qubit instr))
-                                     arg-value))
+                                       (calibration-definition-body instr)
+                                       nil
+                                       param-value
+                                       (list (measurement-calibration-qubit instr))
+                                       arg-value))
 
 (defgeneric instantiate-applicable-calibration (instr gate-cals measure-cals measure-discard-cals)
   (:documentation "If INSTR has an associated calibration, return a list of instructions instantiated from the body of the calibration definition. Otherwise, return NIL.")
@@ -292,8 +292,8 @@
       (a:if-let ((defn (find-if (lambda (defn) (calibration-matches-p defn instr))
                                 (gethash op gate-cals))))
         (quil.si:instantiate-instruction defn
-                                       (application-parameters instr)
-                                       (application-arguments instr))
+                                         (application-parameters instr)
+                                         (application-arguments instr))
         nil)))
 
   (:method ((instr measure) gate-cals measure-cals measure-discard-cals)
@@ -301,9 +301,9 @@
     (a:if-let ((defn (find-if (lambda (defn) (calibration-matches-p defn instr))
                               measure-cals)))
       (quil.si:instantiate-instruction defn
-                                     nil
-                                     (list (measurement-qubit instr)
-                                           (measure-address instr)))
+                                       nil
+                                       (list (measurement-qubit instr)
+                                             (measure-address instr)))
       nil))
 
   (:method ((instr measure-discard) gate-cals measure-cals measure-discard-cals)
@@ -311,8 +311,8 @@
     (a:if-let ((defn (find-if (lambda (defn) (calibration-matches-p defn instr))
                               measure-discard-cals)))
       (quil.si:instantiate-instruction defn
-                                     nil
-                                     (list (measurement-qubit instr)))
+                                       nil
+                                       (list (measurement-qubit instr)))
       nil))
 
   (:method (instr gate-cals measure-cals measure-discard-cals)

--- a/src/quilt/analysis/fill-delays.lisp
+++ b/src/quilt/analysis/fill-delays.lisp
@@ -96,8 +96,8 @@ If WF-OR-WF-DEFN is a waveform definition, SAMPLE-RATE (Hz) must be non-null. "
 (defun frame-on-p (frame qubits)
   "Does FRAME involve exactly the specified QUBITS in the specified order?"
   (quil.si:list= (frame-qubits frame)
-               qubits
-               :test #'qubit=))
+                 qubits
+                 :test #'qubit=))
 
 ;;; Frame Clocks
 ;;;

--- a/src/quilt/analysis/fill-delays.lisp
+++ b/src/quilt/analysis/fill-delays.lisp
@@ -7,7 +7,7 @@
 (define-transform fill-delays (fill-delays)
   "This transform fills empty time on Quilt frames with explicit DELAY instructions in a greedy fashion."
   expand-calibrations
-  quil::resolve-objects)
+  quil.si:resolve-objects)
 
 ;;; Syntactic conveniences
 
@@ -95,7 +95,7 @@ If WF-OR-WF-DEFN is a waveform definition, SAMPLE-RATE (Hz) must be non-null. "
 
 (defun frame-on-p (frame qubits)
   "Does FRAME involve exactly the specified QUBITS in the specified order?"
-  (quil::list= (frame-qubits frame)
+  (quil.si:list= (frame-qubits frame)
                qubits
                :test #'qubit=))
 

--- a/src/quilt/analysis/resolve-objects.lisp
+++ b/src/quilt/analysis/resolve-objects.lisp
@@ -64,7 +64,7 @@
   ;; they do not involve formal arguments). The motivation for this is twofold:
   ;; i) it's sometimes convenient to parse calibrations separately from frame definitions
   ;; ii) we prefer to handle this resolution uniformly at expansion time
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (a:if-let ((formal-qubit (find-if #'is-formal (frame-qubits frame))))
       ;; time to get rowdy...
       (quil-parse-error "Unable to resolve formal ~A outside of definition body." formal-qubit)
@@ -72,7 +72,7 @@
                              :key #'frame-definition-frame
                              :test #'frame=)))
         (setf (frame-name-resolution frame) defn)
-        (quil-parse-error "No frame definition found for referenced frame ~/quil::instruction-fmt/."
+        (quil-parse-error "No frame definition found for referenced frame ~/quil.si:instruction-fmt/."
                           frame))))
   frame)
 
@@ -83,7 +83,7 @@
   instr)
 
 (defmethod resolve-instruction ((instr swap-phase) parsed-program)
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (let ((defns (parsed-program-frame-definitions parsed-program)))
       (resolve-frame (swap-phase-left-frame instr) defns)
       (resolve-frame (swap-phase-right-frame instr) defns)))
@@ -94,13 +94,13 @@
   instr)
 
 (defmethod resolve-instruction ((instr delay-on-frames) parsed-program)
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (dolist (frame (delay-frames instr))
       (resolve-frame frame (parsed-program-frame-definitions parsed-program))))
   instr)
 
 (defmethod resolve-instruction ((instr pulse) parsed-program)
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (resolve-frame (pulse-frame instr)
                    (parsed-program-frame-definitions parsed-program)))
   (resolve-waveform-reference (pulse-waveform instr)
@@ -108,7 +108,7 @@
   instr)
 
 (defmethod resolve-instruction ((instr capture) parsed-program)
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (resolve-frame (capture-frame instr)
                    (parsed-program-frame-definitions parsed-program)))
   (resolve-waveform-reference (capture-waveform instr)
@@ -116,7 +116,7 @@
   instr)
 
 (defmethod resolve-instruction ((instr raw-capture) parsed-program)
-  (unless quil::*in-definition-body*
+  (unless quil.si:*in-definition-body*
     (resolve-frame (raw-capture-frame instr)
                    (parsed-program-frame-definitions parsed-program)))
   instr)
@@ -134,7 +134,7 @@
                 seq)))
     ;; resolve calibration definitions
     (map nil (lambda (cd)
-               (let ((quil::*in-definition-body* t))
+               (let ((quil.si:*in-definition-body* t))
                  (resolve-instruction-sequence
                   (calibration-definition-body cd))))
          (parsed-program-calibration-definitions unresolved-program))

--- a/src/quilt/analysis/type-safety.lisp
+++ b/src/quilt/analysis/type-safety.lisp
@@ -17,11 +17,11 @@
 ;; CAPTURE must target a REAL[2]
 (defmethod type-check-instr ((instr capture) memory-regions)
   (let* ((mref (capture-memory-ref instr))
-         (mdesc (quil::find-descriptor-for-mref mref memory-regions)))
-    (quil::enforce-mref-bounds mref mdesc)
+         (mdesc (quil.si:find-descriptor-for-mref mref memory-regions)))
+    (quil.si:enforce-mref-bounds mref mdesc)
     (adt:match quil-type (memory-descriptor-type mdesc)
       (quil-real
-       (if (> 2 (quil::memory-segment-length mdesc :offset mref))
+       (if (> 2 (quil.si:memory-segment-length mdesc :offset mref))
            (quil-type-error "CAPTURE instruction target ~/quil:instruction-fmt/ must be a REAL ~
                             vector of length no less than 2."
                             mref)
@@ -30,19 +30,19 @@
        (quil-type-error "CAPTURE instruction target must be of type ~
                         REAL, but got ~/quil:instruction-fmt/ of type ~A."
                         mref
-                        (quil::quil-type-string (memory-descriptor-type mdesc)))))))
+                        (quil.si:quil-type-string (memory-descriptor-type mdesc)))))))
 
 ;; RAW-CAPTURE must target a REAL[n] where n is 2*(the number of iq values)
 (defmethod type-check-instr ((instr raw-capture) memory-regions)
   (let* ((mref (raw-capture-memory-ref instr))
-         (mdesc (quil::find-descriptor-for-mref mref memory-regions))
+         (mdesc (quil.si:find-descriptor-for-mref mref memory-regions))
          (frame-defn (frame-name-resolution
                       (raw-capture-frame instr))))
-    (quil::enforce-mref-bounds mref mdesc)
+    (quil.si:enforce-mref-bounds mref mdesc)
     (adt:match quil-type (memory-descriptor-type mdesc)
       (quil-real
        (a:if-let ((samples (raw-capture-num-real-samples instr)))
-         (if (> samples (quil::memory-segment-length mdesc :offset mref))
+         (if (> samples (quil.si:memory-segment-length mdesc :offset mref))
              (quil-type-error "RAW-CAPTURE instruction target ~/quil:instruction-fmt/ must be a REAL ~
                               vector of length no less than ~A."
                               mref
@@ -53,4 +53,4 @@
        (quil-type-error "RAW-CAPTURE instruction target must be of type ~
                         REAL, but got ~/quil:instruction-fmt/ of type ~A."
                         mref
-                        (quil::quil-type-string (memory-descriptor-type mdesc)))))))
+                        (quil.si:quil-type-string (memory-descriptor-type mdesc)))))))

--- a/src/quilt/ast.lisp
+++ b/src/quilt/ast.lisp
@@ -431,8 +431,8 @@
             (calibration-definition-arguments defn)))
   (format stream ":~%")
   (quil.si:print-instruction-sequence (calibration-definition-body defn)
-                                    :stream stream
-                                    :prefix "    "))
+                                      :stream stream
+                                      :prefix "    "))
 
 (defclass measurement-calibration-definition (calibration-definition)
   ((qubit :initarg :qubit
@@ -460,8 +460,8 @@
               (measure-calibration-address defn)
               nil))
   (quil.si:print-instruction-sequence (calibration-definition-body defn)
-                                    :stream stream
-                                    :prefix "    "))
+                                      :stream stream
+                                      :prefix "    "))
 
 ;;;;;;;;;;;;;;;;;;;;;; Program Representations ;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/quilt/ast.lisp
+++ b/src/quilt/ast.lisp
@@ -17,7 +17,7 @@
   (check-type a frame)
   (check-type b frame)
   (and (string= (frame-name a) (frame-name b))
-       (quil::list= (frame-qubits a) (frame-qubits b) :test #'qubit=)))
+       (quil.si:list= (frame-qubits a) (frame-qubits b) :test #'qubit=)))
 
 (defun frame-hash (f)
   "Return a hash for frame F. This is to frame= as sxhash is to equal, i.e., (frame= a b) implies (= (frame-hash a) (frame-hash b))."
@@ -361,7 +361,7 @@
 
 (defun make-waveform-definition (name parameters entries sample-rate &key context)
   (check-type name string)
-  (check-type parameters quil::symbol-list)
+  (check-type parameters quil.si:symbol-list)
   (if (not (endp parameters))
       (make-instance 'parameterized-waveform-definition
                      :name name
@@ -387,9 +387,9 @@
                     (with-output-to-string (s)
                       (etypecase z
                         (number
-                         (quil::format-complex z s))
+                         (quil.si:format-complex z s))
                         ((or list symbol)
-                         (print-instruction (quil::make-delayed-expression nil nil z) s)))))
+                         (print-instruction (quil.si:make-delayed-expression nil nil z) s)))))
                   (waveform-definition-entries defn)))
   (terpri stream))
 
@@ -430,7 +430,7 @@
     (format stream "~{ ~/quil:instruction-fmt/~}"
             (calibration-definition-arguments defn)))
   (format stream ":~%")
-  (quil::print-instruction-sequence (calibration-definition-body defn)
+  (quil.si:print-instruction-sequence (calibration-definition-body defn)
                                     :stream stream
                                     :prefix "    "))
 
@@ -459,7 +459,7 @@
           (if (typep defn 'measure-calibration-definition)
               (measure-calibration-address defn)
               nil))
-  (quil::print-instruction-sequence (calibration-definition-body defn)
+  (quil.si:print-instruction-sequence (calibration-definition-body defn)
                                     :stream stream
                                     :prefix "    "))
 
@@ -499,4 +499,4 @@
     (print-definitions (parsed-program-gate-definitions pp))
     (print-definitions (parsed-program-circuit-definitions pp))
 
-    (quil::print-instruction-sequence (parsed-program-executable-code pp) :stream stream)))
+    (quil.si:print-instruction-sequence (parsed-program-executable-code pp) :stream stream)))

--- a/src/quilt/cl-quilt.lisp
+++ b/src/quilt/cl-quilt.lisp
@@ -22,7 +22,7 @@
 
 (defmethod definition-signature ((instr gate-calibration-definition))
   (list 'gate-calibration-definition
-        (intern (quil::operator-description-string
+        (intern (quil.si:operator-description-string
                  (calibration-definition-operator instr))
                 :keyword)
         (mapcar #'canonicalize-params-args (calibration-definition-arguments instr))
@@ -54,14 +54,14 @@ This also signals ambiguous definitions, which may be handled as needed."
     (flet ((bin (instr)
              (a:when-let ((signature (definition-signature instr)))
                (let ((originating-file (typecase (lexical-context instr)
-                                         (quil::token
-                                          (quil::token-pathname (lexical-context instr)))
+                                         (quil.si:token
+                                          (quil.si:token-pathname (lexical-context instr)))
                                          (t
                                           (quil-parse-error "Unable to resolve definition context ~/quil:instruction-fmt/" instr)))))
                  ;; check for conflicts
                  (a:when-let ((entries (gethash signature all-seen-defns)))
                    (cerror "Continue with ambiguous definition."
-                           (make-instance 'quil::ambiguous-definition-condition
+                           (make-instance 'quil.si:ambiguous-definition-condition
                                           :instruction instr
                                           :file originating-file
                                           :conflicts entries)))
@@ -87,7 +87,7 @@ This also signals ambiguous definitions, which may be handled as needed."
                                               'simple-vector)))))
 
 (defvar *standard-quilt-transforms*
-  '(quil::expand-circuits expand-calibrations quil::type-check)
+  '(quil.si:expand-circuits expand-calibrations quil.si:type-check)
   "The standard transforms for using PARSE-QUIL with Quilt code.")
 
 
@@ -98,7 +98,7 @@ This also signals ambiguous definitions, which may be handled as needed."
 
 In the presence of multiple definitions with a common signature, a signal is raised, with the default handler specified by AMBIGUOUS-DEFINITION-HANDLER.
 "
-  (quil::%parse-quil string
+  (quil.si:%parse-quil string
                      #'raw-quilt-to-unresolved-program
                      :originating-file originating-file
                      :transforms transforms

--- a/src/quilt/cl-quilt.lisp
+++ b/src/quilt/cl-quilt.lisp
@@ -92,19 +92,19 @@ This also signals ambiguous definitions, which may be handled as needed."
 
 
 (defun parse-quilt (string &key originating-file
-                             (transforms *standard-quilt-transforms*)
-                             (ambiguous-definition-handler #'continue))
+                                (transforms *standard-quilt-transforms*)
+                                (ambiguous-definition-handler #'continue))
   "Parse and process the Quilt string STRING, which originated from the file ORIGINATING-FILE. Transforms in TRANSFORMS are applied in-order to the processed Quil string.
 
 In the presence of multiple definitions with a common signature, a signal is raised, with the default handler specified by AMBIGUOUS-DEFINITION-HANDLER.
 "
   (quil.si:%parse-quil string
-                     #'raw-quilt-to-unresolved-program
-                     :originating-file originating-file
-                     :transforms transforms
-                     :ambiguous-definition-handler ambiguous-definition-handler
-                     :parser-extensions (list #'parse-quilt-program-lines)
-                     :lexer-extensions (list #'quilt-keyword-lexer)))
+                       #'raw-quilt-to-unresolved-program
+                       :originating-file originating-file
+                       :transforms transforms
+                       :ambiguous-definition-handler ambiguous-definition-handler
+                       :parser-extensions (list #'parse-quilt-program-lines)
+                       :lexer-extensions (list #'quilt-keyword-lexer)))
 
 (defun read-quilt-file (filespec)
   "Read the Quilt file designated by FILESPEC, and parse it as if by PARSE-QUIL."

--- a/src/quilt/parser.lisp
+++ b/src/quilt/parser.lisp
@@ -46,7 +46,7 @@
   "Parse a frame from the list of tokens TOKS. Returns the frame and the remaining tokens."
   (multiple-value-bind (qubit-toks rest-toks)
       (quil.si:take-until (lambda (tok) (eq ':STRING (quil:token-type tok)))
-                        toks)
+                          toks)
     (let ((qubits (mapcar #'quil.si:parse-qubit qubit-toks)))
       (when (endp rest-toks)
         (quil-parse-error "Expected a frame name in ~A, but none were found. Did you forget quotes?"
@@ -75,9 +75,9 @@
 (defun parse-waveform-parameter-and-value (toks)
   "Parse a <param>:<value> pair, consuming TOKS."
   (quil.si:match-line ((name :NAME) (colon :COLON) &rest value-expr) (list toks)
-      (cons
-       (param (quil:token-payload name))
-       (quil.si:parse-parameter-or-expression value-expr))))
+    (cons
+     (param (quil:token-payload name))
+     (quil.si:parse-parameter-or-expression value-expr))))
 
 (defun parse-waveform-parameter-alist (params-args)
   "Parse waveform parameters and their assigned values from the list of tokens PARAMS-ARGS. Returns an association list and the remaining tokens."
@@ -90,7 +90,7 @@
   ;; Parse out the parameters enclosed.
   (multiple-value-bind (found-params rest-line)
       (quil.si:take-while-from-end (lambda (x) (eq ':RIGHT-PAREN (quil:token-type x)))
-                                 params-args)
+                                   params-args)
 
     ;; Error if we didn't find a right parenthesis.
     (when (endp rest-line)
@@ -132,8 +132,8 @@
 
       (multiple-value-bind (qubit-toks remaining)
           (quil.si:take-until (lambda (tok)
-                              (not (member (quil:token-type tok) '(:NAME :INTEGER))))
-                            rest-toks)
+                                (not (member (quil:token-type tok) '(:NAME :INTEGER))))
+                              rest-toks)
         (when (endp qubit-toks)
           (quil-parse-error "Expected one or more qubits specified in DELAY instruction."))
         (setf qubits (mapcar #'quil.si:parse-qubit qubit-toks))
@@ -141,8 +141,8 @@
 
       (multiple-value-bind (frame-name-toks duration-toks)
           (quil.si:take-until (lambda (tok)
-                              (not (eq ':STRING (quil:token-type tok))))
-                            rest-toks)
+                                (not (eq ':STRING (quil:token-type tok))))
+                              rest-toks)
         (when (endp duration-toks)
           (quil-parse-error "Expected a duration in DELAY instruction."))
         (setf frame-names (mapcar #'quil:token-payload frame-name-toks))
@@ -181,7 +181,7 @@
         (unless (endp (rest rest-toks))
           (quil-parse-error "Unexpected token ~A in CAPTURE" (cadr rest-toks)))
         (let ((address-obj (quil.si:parse-memory-or-formal-token (first rest-toks)
-                                                               :ensure-valid t)))
+                                                                 :ensure-valid t)))
           (make-instance 'capture
                          :frame frame
                          :waveform waveform-ref
@@ -223,7 +223,7 @@
 
     (multiple-value-bind (op-instr rest-lines)
         (quil.si:parse-program-lines (cons (rest line)
-                                         (rest tok-lines)))
+                                           (rest tok-lines)))
       (setf (nonblocking-p op-instr) t)
       (values op-instr
               rest-lines))))


### PR DESCRIPTION
Eliminate use of package names with double colons (::) in Quilt, by
two methods: (1) exporting many semi-internal symbols to a new
package, cl-quil.si, and referring to them in that package; and (2) by
referring to symbols already exported (from CL-Quil) with a single
colon.

The new package, cl-quil.si (or quil.si, for short) is intended to
export system internal (SI) symbols, that is, some symbols not
generally intended to be used by the wider public, but more intended
for "friends" -- packages or facilities that are prepared to go a bit
below the surface level API.

References to most such symbols in Quilt, which previously referred to
quil::<symbol>, are changed in this commit to instead refer to
quil.si:<symbol>. (Quil.si is a nickname for cl-quil.si.)

In addition, the following symbols were already being exported from
the cl-quil package, so they were simply changed to be referred to
with single colon.

  TOK
  TOKEN-PAYLOAD
  TOKEN-TYPE
  IS-CONSTANT
  APPLICATION-ARGUMENTS
  APPLICATION-OPERATOR
  GATE-DEFINITION
  PARSED-PROGRAM-EXECUTABLE-CODE
  QUBIT-INDEX
  INSTRUCTION-FMT
  PARSE-QUIL
  GATE-DEFINITION-TO-GATE
  PERMUTATION-GATE
  PERMUTATION-GATE-PERMUTATION