### PR TITLE
Bugfix: use layout when placing tikz operations for nq gates

### DIFF
--- a/tests/tools/circuit-diagram-tests.lisp
+++ b/tests/tools/circuit-diagram-tests.lisp
@@ -48,3 +48,30 @@
                  (cl-quil.tools:plot-circuit pp
                                              :backend :latex
                                              :right-align-measurements t)))))
+
+(deftest test-plot-circuit-nq-gate-layout ()
+  (let ((pp (quil:parse-quil "
+DEFGATE FOO p q r AS PAULI-SUM:
+    X(pi) p
+    Y(pi) q
+    Z(pi) r
+
+FOO 3 2 1"))
+        (expected
+          "\\documentclass[convert={density=300,outext=.png}]{standalone}
+\\usepackage[margin=1in]{geometry}
+\\usepackage{tikz}
+\\usepackage{quantikz}
+
+\\begin{document}
+\\begin{tikzcd}
+ \\lstick{\\ket{q_1}} &  \\gate[wires=3]{FOO} &  \\qw \\\\
+ \\lstick{\\ket{q_2}} &  \\qw &  \\qw \\\\
+ \\lstick{\\ket{q_3}} &  \\qw &  \\qw \\\\
+\\end{tikzcd}
+\\end{document}
+"))
+    (is (string= expected
+                 (cl-quil.tools:plot-circuit pp
+                                             :backend :latex
+                                             :layout-strategy ':increasing)))))


### PR DESCRIPTION
This fixes an issue with placing of non-controlled nq (n > 1) gates in the circuit rendering algorithm. The basic problem was that something like "FOO p q r" would have the Tikz operator `\gate[wires=3]{FOO}` placed on the qubit line for `p`, even if that line happened to be below the lines for either `q` or `r` in the diagram. This is not valid as far as quantikz is concerned. Now we should have the operator placed on whatever qubit line happens to be first, with respect to our layout. Note that this happened to sneak under the radar because the only n > 1 qubit gates I had tested with happened to have special handling (e.g. `CNOT`).