### PR TITLE
Preserve quicklisp preferences in build-app.lisp system loading

### DIFF
--- a/build-app.lisp
+++ b/build-app.lisp
@@ -54,9 +54,16 @@
              (with-open-file (stream "system-index.txt")
                (loop
                  :for system-file := (read-line stream nil)
+                 :for name := (and system-file (pathname-name system-file))
+                 :for lookup := (gethash name system-table)
                  :while system-file
-                 :do (setf (gethash (pathname-name system-file) system-table)
-                           (merge-pathnames system-file)))))
+                 ;; assuming entries are produced with QL:WRITE-ASDF-MANIFEST-FILE,
+                 ;; which sorts by descending QL-DIST:PREFERENCE
+                 :if lookup
+                   :do (warn "Duplicate system ~A detected. Preferring ~A over ~A." name lookup system-file)
+                 :else
+                   :do (setf (gethash (pathname-name system-file) system-table)
+                             (merge-pathnames system-file)))))
            (local-system-search (name)
              (values (gethash name system-table)))
            (strip-version-githash (version)


### PR DESCRIPTION
The `quilc` build currently proceeds by first generating `system-index.txt`. The entries in this are used in `build-app.lisp`, which creates an ASDF system definition search function mapping system names to their paths as specified in `system-index.txt`. However, there is the possibility of conflicts: for example, if a system is present both in quicklisp local projects as well as one of the existing quicklisp dists. Previously, `build-app.lisp` overwrote earlier entries in the system table with later entries. This is contrary to the ordering of `system-index.txt`, which is by descending quicklisp preference. This PR maintains this preference ordering, and warns the user when conflicts are detected.